### PR TITLE
docs: project conventions, architectural decisions, and GitHub meta

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,95 @@
+name: Bug report
+description: Something isn't working as expected.
+labels: ["bug", "needs-triage"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please search existing issues before filing to avoid duplicates.
+        For security vulnerabilities, use [GitHub Security Advisories](https://github.com/CommonsEngine/Sovereign/security/advisories/new) — do not open a public issue.
+
+  - type: input
+    id: version
+    attributes:
+      label: Sovereign version
+      placeholder: "e.g. 0.3.1"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: Deployment method
+      options:
+        - Docker Compose
+        - Bare Node.js
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: database
+    attributes:
+      label: Database
+      options:
+        - SQLite
+        - PostgreSQL
+        - Unknown
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Affected component
+      description: Where does the issue occur?
+      options:
+        - Platform / Runtime
+        - Auth server
+        - Console plugin
+        - SDK (packages/sdk)
+        - CLI (sv)
+        - Design system (packages/ui)
+        - Other plugin
+        - Unknown
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / error output
+      description: Paste any relevant logs. Automatically formatted as code.
+      render: shell
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Screenshots, config snippets, anything else relevant.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/CommonsEngine/Sovereign/security/advisories/new
+    about: >
+      Please report security vulnerabilities privately using GitHub Security
+      Advisories. Do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,65 @@
+name: Feature request
+description: Suggest a new capability or improvement.
+labels: ["enhancement", "needs-triage"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please search existing issues before filing to check this hasn't already been proposed.
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      description: Where does this feature belong?
+      options:
+        - Platform / Runtime
+        - SDK (packages/sdk)
+        - Console plugin
+        - CLI (sv)
+        - Design system (packages/ui)
+        - New plugin idea
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem are you trying to solve? Be specific about the pain point.
+      placeholder: "I'm trying to do X but currently..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would you like to see? How should it work?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What other approaches did you consider and why didn't they work?
+
+  - type: dropdown
+    id: contribute
+    attributes:
+      label: Willing to contribute a PR?
+      options:
+        - "Yes"
+        - "Yes, with some guidance"
+        - "No"
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Mockups, related issues, prior art, anything else relevant.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+## What and why
+<!-- Describe what changed and why. Focus on the reasoning, not just the mechanics. -->
+
+## Type of change
+- [ ] `feat` — new feature or capability
+- [ ] `fix` — bug fix
+- [ ] `docs` — documentation only
+- [ ] `chore` — tooling, scaffolding, dependencies, maintenance
+
+## Related issue
+<!-- Link any related issue: Closes #123 — delete if not applicable -->
+
+## SRS reference
+<!-- If this touches architecture, requirements, or design decisions, cite the relevant
+section (e.g. SRS §3.6, PLT-02, NFR-04). Delete if not applicable. -->
+
+## Verification
+- [ ] `pnpm format:check` passes
+- [ ] `pnpm lint` passes
+- [ ] `pnpm typecheck` passes
+- [ ] Version bumped where required (see [version bump conventions](../CLAUDE.md))
+- [ ] Relevant docs updated
+- [ ] Screenshots included below (delete if no UI changes)
+
+## Screenshots
+<!-- Delete if not applicable -->
+
+---
+
+<details>
+<summary>External contributors</summary>
+
+- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) in full. By ticking this box I agree to the Sovereign CLA — no separate form is required.
+
+</details>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,277 @@
+# CLAUDE.md
+
+Guidance for Claude Code working in this repository.
+
+## What this is
+
+**Sovereign** — a modular, self-hostable workspace runtime. A shared platform
+(auth, DB, email, UI) hosts installable **plugins** as first-class apps. The
+plugin system *is* the product, not an app extended with plugins. Open source,
+privacy-first, single-tenant/multi-user in v1.
+
+## Source of truth
+
+Two documents define everything. Read the relevant sections before any task —
+they are authoritative over assumptions:
+
+- `docs/sovereign-proposal-plan-srs.md` — Concept, Plan, Architecture, SRS,
+  manifest reference, decision log.
+- `docs/sovereign-implementation-tasks.md` — The build plan: ~22 sequenced
+  tasks (v0.3 → v0.4 → v0.5 → v1.0). Each task = one branch = one PR.
+
+## Working conventions
+
+- **One task at a time.** Implement a single task, verify its review checklist,
+  then stop for human review. Do not start a task on an unmerged PR.
+- **Tasks are sequenced** — each depends on the previous unless tagged
+  `[parallel]`. Don't skip ahead.
+- **Branch per task**, always cut from an **up-to-date `main`** — run
+  `git switch main && git pull` first. Name by change type:
+  - `feat/<slug>` — features
+  - `fix/<slug>` — bug fixes
+  - `docs/<slug>` — documentation
+  - `chore/<slug>` — tooling, scaffolding, deps, maintenance
+
+  e.g. `feat/shared-tsconfig`, `chore/scaffold-monorepo`.
+  _(Post-v1.0.0 this changes: `main` becomes the production branch and `dev`
+  the integration branch — branch from `dev` then. Until then, base off `main`.)_
+- **Doc task numbers (e.g. `0.3.02`) are for local tracking only.** Never put
+  them in branch names, commit messages, or PR titles/descriptions. Refer to the
+  work by what it does, not its task number.
+- **Commits** end with the trailer (model-agnostic — do not use a specific
+  model name, as multiple models may contribute to one task):
+  `Co-Authored-By: Claude Code <noreply@anthropic.com>`
+- **PRs** target `main`; body ends with the Claude Code attribution line.
+  Describe what changed and why, and cite relevant SRS sections — but no task
+  numbers.
+- **Merge strategy: rebase and merge** (never squash, never create a merge
+  commit). Keeps history linear — each task's commit lands on `main` verbatim.
+- **Fix commit messages BEFORE merging the PR.** Once a squash-merge lands on
+  `main`, correcting it means rewriting/force-pushing `main` — avoid that.
+- **Verify before claiming done.** Run the task's review-checklist commands and
+  show the output.
+- Never merge a PR automatically. Either wait for explicit instruction to merge,
+  or ask for consent before doing so.
+- **Version bumps** are part of the PR — bump the relevant `package.json`(s)
+  in the same branch, following semver tied to the change type:
+  - `fix/` → **patch** (0.0.x)
+  - `feat/` → **minor** (0.x.0)
+  - Breaking change → **major** (x.0.0) — also requires a migration note in
+    `docs/upgrade.md`
+  - `chore/` / `docs/` → no version bump unless a public API changed
+
+  The **SDK** (`packages/sdk`) is under an additional constraint per NFR-04:
+  patch releases must never contain breaking changes; breaking changes require
+  at minimum a minor bump and a migration note, regardless of branch type.
+
+  The **platform version** in the root `package.json` tracks the roadmap
+  milestones (v0.3.x → v0.4.x → v0.5.x → v1.0.x). Bump it when a phase
+  milestone is reached.
+
+## Code quality
+
+Established in Task 0.3.03. Every package and PR must comply — no exceptions.
+
+### Tools
+
+| Tool | Purpose |
+|---|---|
+| **Prettier** | Formatting — single source of truth for style |
+| **ESLint 9 (flat config)** | Linting — correctness, best practices, SDK boundary rule |
+| `typescript-eslint` | TypeScript-specific ESLint rules (recommended + strict) |
+| `eslint-config-prettier` | Disables ESLint formatting rules that conflict with Prettier |
+| `simple-git-hooks` | Pre-commit hook runner (lighter than Husky, no shell scripts) |
+| `lint-staged` | Runs Prettier then ESLint only on staged files (fast) |
+| `.editorconfig` | Editor-level baseline — indent, line endings, charset |
+
+### Formatting conventions (Prettier)
+
+- Single quotes
+- Semicolons
+- Trailing commas (`all`)
+- Print width: 100
+- Tab width: 2 spaces
+
+### Rules
+
+- **Never disable ESLint rules inline** (`// eslint-disable`) without a comment
+  explaining why, and never disable the SDK boundary rule.
+- **Never add per-package Prettier overrides.** One config, entire monorepo.
+- `pnpm format:check` and `pnpm lint` must pass before every PR. The pre-commit
+  hook enforces this locally; CI enforces it on every push.
+- **No Biome.** ESLint is required for the custom `no-restricted-imports` SDK
+  boundary rule. Running both would be redundant overhead.
+
+### Commands
+
+```bash
+pnpm format          # write formatting fixes across the whole repo
+pnpm format:check    # check formatting without writing (used in CI)
+pnpm lint            # run ESLint
+pnpm lint:fix        # run ESLint with auto-fix
+```
+
+## Hard architectural rules (enforced or load-bearing)
+
+- **SDK is the only plugin↔platform contract.** Plugins MUST NOT import from
+  `runtime/src`. ESLint enforces this (established in Task 0.3.03, verified in
+  Task 0.3.08). Plugins use `packages/sdk` only.
+- **Every package/app extends `packages/tsconfig`** (`base`/`nextjs`/`library`),
+  established in Task 0.3.02. Easy to forget on new packages.
+- **Manifests are validated at build time.** Invalid manifest = failed build.
+- **Plugin tables are slug-prefixed** (`tasks_lists`, `splitify_groups`).
+  Single shared schema, no per-plugin DBs in v1.
+- **`tenant_id` everywhere** on user-scoped tables from day one (future
+  multi-tenancy), even though no multi-tenant logic exists in v1.
+- **DB is dialect-agnostic** (Drizzle): SQLite default, Postgres via env only.
+  No SQLite-specific SQL in app code.
+- **No secrets with defaults.** `AUTH_SECRET` / `SOVEREIGN_AUTH_SECRET` etc.
+  must throw on startup if unset.
+- **`runtime/app/plugins/` is generated** (symlinks in dev, copies in prod) and
+  gitignored — never edit or commit it. Source of truth is `plugins/[id]/app/`.
+
+## Design system (`packages/ui`)
+
+`packages/ui` is the **Sovereign Design System** — a public contract for plugin
+developers, versioned with the same discipline as the SDK. Breaking a token name
+or component API breaks every third-party plugin that uses it.
+
+### Technology
+
+- **Tokens:** CSS custom properties in plain `.css` files — universally
+  consumable from any CSS, framework-agnostic, RSC-safe. No JS import required
+  to use tokens.
+- **Components:** React + CSS Modules — zero extra dependencies, built into
+  Next.js, familiar, RSC-safe by default.
+- **No Tailwind.** No runtime CSS-in-JS. No third-party component framework.
+
+### Token architecture — two tiers
+
+```
+Primitive tokens     raw scale, no semantic meaning
+  --sv-grey-50 … --sv-grey-950
+  --sv-space-1 … --sv-space-16
+  --sv-font-size-sm … --sv-font-size-2xl
+  --sv-radius-sm / -md / -lg
+        │
+        ▼  mapped by semantic layer
+Semantic tokens      contextual meaning, what plugin devs use
+  --sv-color-surface
+  --sv-color-text-primary
+  --sv-shadow-card
+  --sv-radius-md
+```
+
+Plugin developers reference **semantic tokens only** — never primitives
+directly. The semantic layer is what tenant theming (CON-08) overrides at
+`:root`; primitives stay fixed.
+
+### Token prefix
+
+All tokens use `--sv-*` — short, consistent with the `sv` CLI identity, and
+unambiguous. **Never abbreviate after the prefix** — use full descriptive names:
+`--sv-color-text-primary` not `--sv-ctp`.
+
+### What plugin developers consume
+
+```ts
+// Components — typed React components
+import { Button, Card, Input, Badge } from '@sovereign/ui'
+
+// Tokens — already injected globally by the runtime shell.
+// Reference directly in plugin CSS without any import:
+// color: var(--sv-color-text-primary);
+// background: var(--sv-color-surface);
+```
+
+### Scope rules
+
+- The runtime shell and Console plugin use both tokens and components.
+- Plugin developers may use any component or token.
+- Components must never hardcode values — always reference `--sv-*` tokens.
+- Dark mode and tenant theming work by swapping semantic token values at `:root`;
+  no component changes required.
+
+## Native mobile app (post-v1 plan)
+
+Mobile is out of scope for v1 but the approach is decided — do not treat it as
+an open question or suggest alternatives.
+
+**Model:** Universal Capacitor shell app — one binary on the App Store / Play
+Store. On first launch the user enters their self-hosted instance URL. The app
+loads it in a WebView. All Sovereign functionality is served by the user's
+instance and runs unchanged. Multiple instances supported. Same pattern as
+Nextcloud, Bitwarden, Element (Matrix).
+
+**Shell:** Capacitor (single TypeScript codebase for iOS + Android). Lives in a
+separate `sovereign-mobile` repository, not this monorepo.
+
+**Device API tiers — in priority order:**
+1. **Web APIs** — `navigator.geolocation`, `getUserMedia` etc. Work natively in
+   WebViews, also work in browser/PWA. Use these first.
+2. **Capacitor plugins** — for what Web APIs can't cover: native photo picker,
+   APNs/FCM push notifications, Face ID / fingerprint, haptics, background
+   location.
+3. **`sdk.device.*`** — the SDK abstraction plugin developers call. Detects
+   environment, routes to the correct tier. Plugins never call Web APIs or
+   Capacitor directly.
+
+**Plugin developers use `sdk.device.*` only.** This keeps plugins portable
+across browser, PWA, and native shell without changes.
+
+See SRS §3.12 for the full specification.
+
+## Tech stack
+
+Next.js 15 (App Router) · TypeScript · Turborepo + pnpm workspaces ·
+better-auth (`apps/auth`) · Drizzle ORM (SQLite/Postgres) · nodemailer SMTP
+(`packages/mailer`) · CSS Modules + CSS custom properties (`packages/ui`) ·
+`citty` + `consola` (`bin/sv` CLI) · `@ducanh2912/next-pwa` · Docker Compose.
+
+## Monorepo layout
+
+```
+apps/auth/          better-auth wrapper (the only separate Next.js app)
+packages/
+  tsconfig/         shared TS configs (base/nextjs/library) — extend these
+  db/               Drizzle client factory + schema + migration runner
+  manifest/         manifest schema, types, validation
+  mailer/           SMTP abstraction (no-op when unconfigured)
+  ui/               shared component library + design tokens
+  sdk/              plugin↔platform contract (types + impls)
+runtime/            Sovereign Core (Next.js shell, middleware, registry, SDK bridge)
+  generated/        built from manifests — never hand-edit
+plugins/console/    core admin plugin (platform type)
+scripts/            install-plugins.ts, generate-registry.ts, dev.ts
+bin/sv              CLI (v0.5)
+```
+
+## Commands
+
+```bash
+pnpm install            # install workspace deps
+pnpm build              # turbo build (runs generate first once wired)
+pnpm dev                # turbo dev
+pnpm format             # write Prettier formatting fixes across repo
+pnpm format:check       # check formatting without writing (CI)
+pnpm lint               # ESLint incl. SDK import-boundary rule
+pnpm lint:fix           # ESLint with auto-fix
+pnpm typecheck          # tsc --noEmit across packages
+pnpm install:plugins    # clone declared sovereign/community plugins (stub until Task 0.5.00)
+```
+
+## Environment notes
+
+- Node ≥20 (dev on 24.x), pnpm 11.5.2 (pinned via `packageManager`).
+- pnpm 11 blocks dependency build scripts by default. `esbuild` (via `tsx`) is
+  allowlisted in `pnpm-workspace.yaml` under `allowBuilds` — required, or `tsx`
+  has no native binary and pnpm's pre-script check fails.
+
+## Status
+
+- ✅ Task 0.3.01 — Monorepo scaffold (merged to `main`).
+- ▶️ Next: Task 0.3.02 — Shared TypeScript config (`packages/tsconfig`).
+- ⏳ Then: Task 0.3.03 — Code quality tooling (ESLint + Prettier + hooks).
+
+Keep this file current: update the Status section as tasks complete, and add any
+new load-bearing convention that future sessions must not violate.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,115 @@
+# Contributing to Sovereign
+
+Thank you for your interest in contributing. This document covers everything
+you need to get started.
+
+## Contents
+
+- [Development setup](#development-setup)
+- [Branching and commits](#branching-and-commits)
+- [Pull requests](#pull-requests)
+- [Contributor Licence Agreement](#contributor-licence-agreement)
+- [Building a plugin](#building-a-plugin)
+
+---
+
+## Development setup
+
+**Requirements:** Node.js ≥20, pnpm 11.5.2, Git. Docker is optional but
+recommended for running the full stack locally.
+
+```bash
+git clone https://github.com/CommonsEngine/Sovereign.git
+cd Sovereign
+pnpm install
+cp .env.example .env   # fill in required values
+pnpm generate          # builds runtime/generated/ from plugin manifests
+pnpm dev               # starts runtime + auth server
+```
+
+Open `http://localhost:3000`. The first user to register is automatically
+assigned `platform:admin`.
+
+**Environment variables:** `AUTH_SECRET` and `SOVEREIGN_AUTH_SECRET` have no
+defaults — the server will not start without them. See `.env.example` for all
+required variables.
+
+**Code quality hooks:** The pre-commit hook runs Prettier and ESLint on staged
+files automatically. Run `pnpm format` and `pnpm lint` at any time to check
+your working tree manually.
+
+---
+
+## Branching and commits
+
+Always branch from an up-to-date `main`:
+
+```bash
+git switch main && git pull
+git switch -c feat/your-feature-name
+```
+
+**Branch prefixes:**
+
+| Prefix | Use for |
+|---|---|
+| `feat/` | New features or capabilities |
+| `fix/` | Bug fixes |
+| `docs/` | Documentation only |
+| `chore/` | Tooling, scaffolding, dependencies, maintenance |
+
+**Commit messages** should explain *why*, not just *what*. Keep the subject
+line under 72 characters. Body lines wrap at 100 characters.
+
+If you used an AI assistant to help write the code, include the co-author
+trailer in your commit:
+
+```
+Co-Authored-By: Claude Code <noreply@anthropic.com>
+```
+
+---
+
+## Pull requests
+
+- **One logical change per PR.** Keep scope tight.
+- All checks must pass before review: `pnpm format:check`, `pnpm lint`,
+  `pnpm typecheck`.
+- If your change touches architecture or requirements, cite the relevant SRS
+  section in the PR description (e.g. `SRS §3.6`, `PLT-02`).
+- Bump the relevant `package.json` version(s) in the same PR where required
+  — see the version bump conventions in `CLAUDE.md`.
+- PRs are merged with **rebase and merge** — no squash, no merge commits.
+- Fix commit messages before the PR is merged; correcting them after means
+  rewriting `main`.
+
+---
+
+## Contributor Licence Agreement
+
+Before your first PR can be merged, you must agree to the Sovereign
+Contributor Licence Agreement (CLA). The CLA covers both code and
+documentation contributions and grants the project the right to distribute
+your work under its current and future licences (including commercial use).
+
+**How to sign:** Read this document in full, then tick the CLA checkbox in
+the PR template when you open your pull request. That checkbox is your
+agreement — no separate form or signature is required at this stage.
+
+---
+
+## Building a plugin
+
+Sovereign's plugin system is the core of the platform. If you want to build
+a plugin rather than contribute to the runtime itself:
+
+- See `docs/plugin-development.md` for the full plugin developer guide
+  (available from v0.5).
+- For the manifest reference and SDK surface, see
+  `docs/sovereign-proposal-plan-srs.md` — Section 5 (manifest) and
+  Section 3.6 (SDK).
+- For design system usage (tokens and components), see
+  `docs/design-system.md` (available from v0.3.07).
+
+Third-party plugins may use any licence. They do not require a CLA unless
+submitted to the official registry.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,58 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Do not file a public GitHub issue for security vulnerabilities.**
+
+Report vulnerabilities privately using GitHub Security Advisories — only
+repository maintainers can see your report:
+
+### [Report a vulnerability →](https://github.com/CommonsEngine/Sovereign/security/advisories/new)
+
+You will need a GitHub account. Your report remains private until we
+coordinate disclosure together.
+
+---
+
+## What to include
+
+A useful report includes:
+
+- A clear description of the vulnerability and its potential impact
+- Steps to reproduce
+- Sovereign version and deployment method affected (Docker / bare Node,
+  SQLite / Postgres)
+- A suggested fix if you have one
+
+---
+
+## Scope
+
+**In scope:**
+- Authentication bypass or session hijacking
+- Privilege escalation (accessing admin routes as a regular user)
+- Remote code execution via the plugin system or SDK
+- Cross-user data exposure on a shared instance
+- SDK boundary violations that enable plugin-to-platform data leakage
+
+**Out of scope:**
+- Issues requiring physical access to the host machine
+- Vulnerabilities in the self-hoster's own infrastructure (reverse proxy
+  misconfiguration, weak secrets, etc.)
+- Issues in third-party or community plugins — report those to the plugin
+  author directly
+- Social engineering attacks
+
+---
+
+## Response
+
+We aim to:
+
+- **Acknowledge** your report within **72 hours**
+- **Provide an initial assessment** within **7 days**
+- **Patch and disclose** critical vulnerabilities within **30 days**
+  where possible, coordinating the disclosure timeline with you
+
+We will credit you in the published advisory unless you prefer to remain
+anonymous.

--- a/docs/sovereign-implementation-tasks.md
+++ b/docs/sovereign-implementation-tasks.md
@@ -1,6 +1,6 @@
-# Sovereign v3 — Implementation Task Breakdown
+# Sovereign — Implementation Task Breakdown
 
-**Version:** 0.2
+**Version:** 0.4
 **Date:** June 2026
 **Purpose:** Session-by-session task guide for Claude Code. Each task is a single PR. Reference `sovereign-proposal-plan-srs.md` for architectural decisions and rationale.
 
@@ -15,9 +15,11 @@ Each task maps to one Claude Code session and one PR. Before starting a session:
 
 Tasks are sequenced — each depends on the previous unless marked **[parallel]**.
 
-**TypeScript config dependency:** All packages and apps created from Task 0.3.03 onwards must extend from `packages/tsconfig`. Remind Claude Code of this at the start of each package creation session — it is a foundational dependency established in 0.3.02 and easy to miss.
+**TypeScript config dependency:** All packages and apps created from Task 0.3.04 onwards must extend from `packages/tsconfig`. Remind Claude Code of this at the start of each package creation session — it is a foundational dependency established in 0.3.02 and easy to miss.
 
-**Docker Compose scope:** Task 0.3.11 creates a basic dev-only Compose setup. Task 0.5.02 makes it production-complete. These are intentionally split — do not flag 0.5.02 as duplication.
+**Code quality dependency:** ESLint and Prettier are established in Task 0.3.03. All packages created from 0.3.04 onwards must comply with the root ESLint and Prettier config. Do not introduce per-package formatting overrides.
+
+**Docker Compose scope:** Task 0.3.12 creates a basic dev-only Compose setup. Task 0.5.02 makes it production-complete. These are intentionally split — do not flag 0.5.02 as duplication.
 
 ---
 
@@ -64,7 +66,54 @@ Tasks are sequenced — each depends on the previous unless marked **[parallel]*
 
 ---
 
-### Task 0.3.03 — `packages/db` — Drizzle client factory
+### Task 0.3.03 — Code quality tooling
+
+**Goal:** Establish consistent code formatting and linting across the entire
+monorepo before any application code is written. All subsequent tasks inherit
+this baseline — nothing is merged without passing it.
+
+**Deliverables:**
+- `.editorconfig` at repo root — indent style (spaces, 2), line endings (LF),
+  charset (UTF-8), trailing newline, trim trailing whitespace
+- `prettier.config.ts` at repo root — single quotes, semicolons, trailing
+  commas (`all`), print width 100, tab width 2
+- `eslint.config.ts` at repo root — ESLint 9 flat config:
+  - `typescript-eslint` recommended + strict rules
+  - `eslint-config-prettier` to disable formatting rules that conflict with
+    Prettier
+  - `no-restricted-imports` rule scoped to `plugins/**` — blocks any import
+    matching `*/runtime/src/*`. This is the SDK boundary rule (NFR-06); wiring
+    it here means it is active from the first line of plugin code, not
+    retroactively added in the SDK task
+- `package.json` additions:
+  - `simple-git-hooks` — pre-commit hook running lint-staged
+  - `lint-staged` — runs `prettier --write` then `eslint --fix` on staged
+    `.ts`/`.tsx`/`.css`/`.json` files
+  - Scripts: `"format": "prettier --write ."`, `"format:check": "prettier
+    --check ."`, `"lint:fix": "eslint --fix ."`
+- `turbo.json` — confirm `lint` task is correctly wired across packages
+- Run `pnpm format` on all existing files (`.gitignore`, `README.md`,
+  `package.json`, `pnpm-workspace.yaml`, `turbo.json`,
+  `scripts/install-plugins.ts`) and commit formatted output as part of this PR
+
+**Technology:** ESLint 9 (flat config) + `typescript-eslint` + Prettier +
+`eslint-config-prettier` + `simple-git-hooks` + `lint-staged`. See CLAUDE.md —
+Code quality section. No Biome — ESLint is required for the custom
+`no-restricted-imports` SDK boundary rule; running both would be redundant.
+
+**SRS reference:** NFR-06, PLT-10, SRS §2.2 Tech Stack
+
+**Review checklist:**
+- `pnpm format:check` passes on all files in the repo
+- `pnpm lint` passes with zero errors or warnings
+- Attempting to commit a file with formatting errors is blocked by the
+  pre-commit hook
+- A test import of `runtime/src/anything` inside `plugins/` causes ESLint to
+  error — boundary rule is live
+
+---
+
+### Task 0.3.04 — `packages/db` — Drizzle client factory
 
 **Goal:** Shared database package providing a Drizzle client factory that supports both SQLite and PostgreSQL via a dialect flag.
 
@@ -87,7 +136,7 @@ Tasks are sequenced — each depends on the previous unless marked **[parallel]*
 
 ---
 
-### Task 0.3.04 — `packages/manifest` — schema and validation
+### Task 0.3.05 — `packages/manifest` — schema and validation
 
 **Goal:** Manifest schema package providing TypeScript types and a validation function.
 
@@ -107,7 +156,7 @@ Tasks are sequenced — each depends on the previous unless marked **[parallel]*
 
 ---
 
-### Task 0.3.05 — `packages/mailer` — SMTP abstraction
+### Task 0.3.06 — `packages/mailer` — SMTP abstraction
 
 **Goal:** Thin mailer package wrapping nodemailer with a simple `send()` interface.
 
@@ -128,26 +177,64 @@ Tasks are sequenced — each depends on the previous unless marked **[parallel]*
 
 ---
 
-### Task 0.3.06 — `packages/ui` — component library scaffold
+### Task 0.3.07 — `packages/ui` — Sovereign Design System scaffold
 
-**Goal:** Shared UI package scaffold. No components yet — just the package structure, design token foundation, and one primitive component to validate the setup.
+**Goal:** Sovereign Design System scaffold — two-tier CSS custom property token
+architecture and one primitive component to validate the setup. This package is
+a public contract for plugin developers; token names and component APIs must be
+treated with the same versioning discipline as the SDK.
 
 **Deliverables:**
 - `packages/ui/` with:
-  - Tailwind config extending a base token set (colours, spacing, typography)
-  - `src/components/Button.tsx` — single primitive component to validate the setup
+  - `src/tokens/primitives.css` — raw scale tokens with `--sv-` prefix:
+    colour palette (`--sv-grey-50` … `--sv-grey-950`), spacing scale
+    (`--sv-space-1` … `--sv-space-16`), font sizes (`--sv-font-size-sm` …
+    `--sv-font-size-2xl`), border radii (`--sv-radius-sm/md/lg`)
+  - `src/tokens/semantic.css` — contextual tokens mapped from primitives:
+    `--sv-color-surface`, `--sv-color-text-primary`, `--sv-color-text-muted`,
+    `--sv-color-border`, `--sv-color-accent`, `--sv-shadow-card` etc. These are
+    what plugin developers reference. Tenant theming overrides this layer only.
+  - `src/components/Button/Button.tsx` — single primitive component using CSS
+    Modules to validate the setup
+  - `src/components/Button/Button.module.css` — styles referencing `--sv-*`
+    tokens only; no hardcoded values
   - `src/index.ts` — barrel export
+- Extends `packages/tsconfig` (`library.json`)
 - Builds cleanly and is importable by the runtime
+- `docs/design-system.md` — foundational design system doc covering:
+  - Design principles (what Sovereign UI should feel and look like)
+  - Token architecture (two-tier model, `--sv-*` convention, primitive vs
+    semantic, theming surface)
+  - Full primitive and semantic token reference (all tokens defined in this task)
+  - Component contribution guide (how to build a new component correctly —
+    CSS Modules, token-only values, accessibility expectations)
+  - Theming guide (how tenant overrides work by swapping semantic tokens at
+    `:root`; what primitives are and why plugins must not reference them)
+
+  Note: the plugin developer consumption guide (how to use components and tokens
+  in a plugin) lives in `docs/plugin-development.md` (Task 0.5.06), not here.
+  This doc is for contributors and system-level understanding.
+
+**Technology:** CSS custom properties for tokens (plain `.css` files) + React +
+CSS Modules for components. No Tailwind. No runtime CSS-in-JS. No third-party
+component framework. See CLAUDE.md — Design System section for full rationale
+and token conventions.
 
 **SRS reference:** 2.2 Tech Stack (`packages/ui`)
 
 **Review checklist:**
 - `Button` renders without errors when imported into a test file
-- Tailwind tokens are defined, not hardcoded values in components
+- No hardcoded colour, spacing, or radius values in any component CSS — only
+  `--sv-*` token references
+- All semantic tokens map to primitive tokens — no semantic token has a
+  hardcoded value
+- `tokens/primitives.css` and `tokens/semantic.css` are valid, importable CSS
+  files
+- `docs/design-system.md` exists and covers all sections listed above
 
 ---
 
-### Task 0.3.07 — `packages/sdk` — interface definitions
+### Task 0.3.08 — `packages/sdk` — interface definitions
 
 **Goal:** SDK package with full interface definitions for v1 surface. Implementations are stubs at this stage — real implementations come in later tasks.
 
@@ -160,18 +247,23 @@ Tasks are sequenced — each depends on the previous unless marked **[parallel]*
   - `src/platform.ts` — `getConfig()` — stub
   - `src/unimplemented.ts` — `storage`, `notifications`, `events` stubs throwing `NotImplementedError` with message indicating v1 non-implementation
   - `src/index.ts` — barrel export as `sdk.*`
-- ESLint rule configured at root: no imports from `runtime/src` in `plugins/*`
+
+Note: the `no-restricted-imports` ESLint boundary rule blocking `runtime/src`
+imports in `plugins/*` is configured in Task 0.3.03 (code quality tooling),
+not here. By the time this task runs it is already active. This task only
+verifies it catches a violation.
 
 **SRS reference:** 3.6 SDK, NFR-06
 
 **Review checklist:**
 - All SDK methods from SRS 3.6 present
 - Unimplemented stubs throw `NotImplementedError` with a clear message
-- ESLint import boundary rule is active and catches a violation in a test case
+- ESLint import boundary rule catches a `runtime/src` import in a test plugin
+  file (rule was established in Task 0.3.03)
 
 ---
 
-### Task 0.3.08 — `apps/auth` — better-auth server **[parallel with 0.3.09]**
+### Task 0.3.09 — `apps/auth` — better-auth server **[parallel with 0.3.10]**
 
 **Goal:** Auth server wrapping better-auth. Handles login, logout, registration, and session verification.
 
@@ -197,7 +289,7 @@ Tasks are sequenced — each depends on the previous unless marked **[parallel]*
 
 ---
 
-### Task 0.3.09 — Runtime scaffold **[parallel with 0.3.08]**
+### Task 0.3.10 — Runtime scaffold **[parallel with 0.3.09]**
 
 **Goal:** Sovereign Core Next.js app scaffold with shell layout, middleware, and plugin launcher page. No plugins wired yet.
 
@@ -222,7 +314,7 @@ Tasks are sequenced — each depends on the previous unless marked **[parallel]*
 
 ---
 
-### Task 0.3.10 — Generate script
+### Task 0.3.11 — Generate script
 
 **Goal:** Pre-build script that reads plugin manifests, validates them, and injects plugin routes into the runtime.
 
@@ -248,7 +340,7 @@ Tasks are sequenced — each depends on the previous unless marked **[parallel]*
 
 ---
 
-### Task 0.3.11 — Docker Compose for local dev
+### Task 0.3.12 — Docker Compose for local dev
 
 **Goal:** Docker Compose setup orchestrating runtime and auth server for local development.
 
@@ -439,23 +531,33 @@ Tasks are sequenced — each depends on the previous unless marked **[parallel]*
 **Goal:** `sv` CLI with essential commands for managing a Sovereign deployment.
 
 **Deliverables:**
-- `bin/sv` entry point
+- `bin/sv` — TypeScript entry point, executed via `tsx` (no separate compile
+  step; consistent with the `scripts/` pattern)
 - Commands:
   - `sv install` — runs install script, clones sovereign/community plugins defined in config
   - `sv generate` — runs generate script
   - `sv build` — runs generate then pnpm build
   - `sv dev` — starts runtime and auth server in dev mode
-  - `sv serve` — starts production server via direct node. PM2 is supported as an optional non-Docker deployment path — documented in `docs/self-hosting.md` but not the canonical production approach. Docker is canonical.
+  - `sv serve` — starts production server via direct node. PM2 is supported as
+    an optional non-Docker deployment path — documented in `docs/self-hosting.md`
+    but not the canonical production approach. Docker is canonical.
   - `sv plugin add <repository>` — clones a plugin, runs generate
   - `sv plugin remove <id>` — removes plugin directory, runs generate
 
-**SRS reference:** 2.4 Phased Roadmap v0.5
+**Technology:** `citty` (command framework) + `consola` (terminal output) —
+both TypeScript-first, lightweight, from the UnJS ecosystem. `citty` handles
+nested subcommands (`sv plugin add/remove`) cleanly. `consola` provides
+consistent info/success/warn/error formatting. CLI is monorepo-internal in v1
+— no global npm install path. See SRS §2.2 and decision log.
+
+**SRS reference:** 2.4 Phased Roadmap v0.5, 2.2 Tech Stack
 
 **Review checklist:**
 - `sv dev` starts both services correctly
 - `sv plugin add` clones and wires a plugin end-to-end
 - `sv plugin remove` cleans up symlinks/copies and updates registry
-- CLI help text is accurate
+- `sv --help` and `sv plugin --help` output accurate, well-formatted help text
+- No compiled output — CLI runs directly via `tsx`
 
 ---
 
@@ -505,9 +607,13 @@ Tasks are sequenced — each depends on the previous unless marked **[parallel]*
 
 **Deliverables:**
 - `.github/workflows/ci.yml` with jobs:
-  - `lint` — runs ESLint across all packages including import boundary rule (NFR-06)
+  - `format` — runs `prettier --check .` across the repo; fails on any
+    unformatted file
+  - `lint` — runs ESLint across all packages including the SDK import boundary
+    rule (NFR-06)
   - `typecheck` — runs `tsc --noEmit` across all packages
-  - `generate-validate` — runs `pnpm generate --mode=prod` and verifies `runtime/generated/registry.ts` is valid TypeScript
+  - `generate-validate` — runs `pnpm generate --mode=prod` and verifies
+    `runtime/generated/registry.ts` is valid TypeScript
   - `build` — runs `turbo build` in production mode
 - CI triggers on: push to `main`, all pull requests
 - All jobs use pnpm cache for speed
@@ -515,7 +621,8 @@ Tasks are sequenced — each depends on the previous unless marked **[parallel]*
 **SRS reference:** SRS 3.9 (CI validation step), PLT-07, NFR-06
 
 **Review checklist:**
-- All four jobs pass on a clean checkout
+- All five jobs pass on a clean checkout
+- Unformatted file causes `format` job to fail
 - Import boundary violation in a plugin causes `lint` job to fail
 - Invalid manifest in `plugins/` causes `generate-validate` job to fail
 - pnpm cache is correctly restored between runs
@@ -557,4 +664,4 @@ Tasks are sequenced — each depends on the previous unless marked **[parallel]*
 
 ---
 
-*Version 0.2 — June 2026. Updated to address review findings: middleware contradiction resolved, SDK split clarified, install-plugins and CI tasks added, PM2 scoped, parallel tasks tagged. Task breakdown covers platform only. Plugin-specific task breakdowns (Tasks, Splitify) are maintained in their respective repositories.*
+*Version 0.4 — June 2026. Changes from v0.3: New Task 0.3.03 (code quality tooling — ESLint 9 flat config, Prettier, simple-git-hooks, lint-staged, .editorconfig) inserted; all subsequent v0.3 tasks renumbered 0.3.04–0.3.12. SDK boundary rule ownership moved to Task 0.3.03. CI task updated with format-check job. Task breakdown covers platform only. Plugin-specific task breakdowns (Tasks, Splitify) are maintained in their respective repositories.*

--- a/docs/sovereign-proposal-plan-srs.md
+++ b/docs/sovereign-proposal-plan-srs.md
@@ -1,7 +1,7 @@
 # Sovereign
 ## Project Concept · Project Plan · Software Requirements Specification
 
-**Version:** 0.2
+**Version:** 0.6
 **Date:** June 2026
 **Status:** Signed Off
 
@@ -39,6 +39,7 @@
    - 3.9 [Plugin Loading Model](#39-plugin-loading-model)
    - 3.10 [Shared Login State](#310-shared-login-state)
    - 3.11 [PWA](#311-pwa)
+   - 3.12 [Native Mobile App (post-v1 plan)](#312-native-mobile-app-post-v1-plan)
 
 4. [Software Requirements Specification](#4-software-requirements-specification)
    - 4.1 [User Roles and Capabilities](#41-user-roles-and-capabilities)
@@ -95,7 +96,9 @@ Sovereign provides a self-hosted workspace runtime with:
 **Non-Goals (v1):**
 - Multi-tenancy (multiple independent workspaces on one deployment)
 - Plugin sandboxing or process isolation
-- Mobile native apps
+- Native mobile app — deferred to post-v1. Planned as a universal Capacitor
+  shell app: one app on the App Store/Play Store, user enters their instance URL
+  on first launch. See §3.11 for the full planned approach.
 - Real-time collaboration
 - Federated identity or multi-instance linking
 - Public plugin marketplace
@@ -149,6 +152,8 @@ Sovereign v3 is a clean rewrite. Two prior iterations existed:
 | Database production | PostgreSQL | Config change, not a code change |
 | Email | Custom `packages/mailer` (SMTP) | Self-hostable, no third-party email dependency |
 | UI components | `packages/ui` (shared component library) | Consistent design system across runtime and plugins |
+| CLI | `citty` + `consola`, TypeScript via `tsx` | `citty` is lightweight, TypeScript-first, handles nested subcommands cleanly. `consola` pairs naturally for consistent terminal output. `tsx` avoids a separate CLI compile step. Monorepo-internal in v1. |
+| Code quality | ESLint 9 (flat config) + `typescript-eslint` + Prettier + `simple-git-hooks` + `lint-staged` | ESLint for lint rules including the SDK import boundary; Prettier for formatting (separate concerns). `simple-git-hooks` + `lint-staged` enforce both on staged files at commit time. No Biome — ESLint is required for the custom boundary rule. |
 | PWA | @ducanh2912/next-pwa | Service worker, installable shell |
 | Containerisation | Docker + Docker Compose | Standard self-hosting deployment path |
 
@@ -250,7 +255,7 @@ plugins/tasks/
 
 ### 2.5 Reference Plugins Roadmap
 
-Tasks and Splitify are maintained in separate repositories under CommonsEngine. They are the primary reference implementations demonstrating how third-party plugins integrate with the Sovereign SDK. Their development tracks loosely alongside the platform but on independent timelines.
+Tasks and Splitify are maintained in separate repositories under the Sovereign project. They are the primary reference implementations demonstrating how third-party plugins integrate with the Sovereign SDK. Their development tracks loosely alongside the platform but on independent timelines.
 
 **sovereign-plugin-tasks**
 - v0.1 — Task CRUD, list management, basic assignment; validates SDK `auth` and `db`
@@ -359,8 +364,8 @@ Plugins are the primary unit of functionality in Sovereign. Everything beyond th
 
 | Type | Meaning | Location | `type` value |
 |---|---|---|---|
-| Platform | Ships in the monorepo, maintained by CommonsEngine | `/plugins/[id]/` (in repo) | `"platform"` |
-| Sovereign | Separate repo, maintained by CommonsEngine (e.g. Tasks, Splitify) | `/plugins/[id]/` (cloned by install script) | `"sovereign"` |
+| Platform | Ships in the monorepo, maintained by the Sovereign team | `/plugins/[id]/` (in repo) | `"platform"` |
+| Sovereign | Separate repo, maintained by the Sovereign team (e.g. Tasks, Splitify) | `/plugins/[id]/` (cloned by install script) | `"sovereign"` |
 | Community | Third-party, any maintainer, any source | `/plugins/[id]/` (cloned or manually placed) | `"community"` |
 
 **Plugin activation:**
@@ -503,7 +508,47 @@ The runtime's middleware reads the session cookie and injects user context into 
 
 `@ducanh2912/next-pwa` is added to the runtime. The PWA shell is installable from the browser. The service worker caches the shell and static assets for offline availability. Plugin data is not cached offline in v1.
 
-Native app wrappers (Tauri, Capacitor) are explicitly deferred. Next.js does not currently have a native bundling path. This is reviewed when a concrete need arises.
+### 3.12 Native Mobile App (post-v1 plan)
+
+Native mobile support is deferred to post-v1 but the approach is decided:
+
+**Model: universal shell + instance URL.**
+One app published to the App Store (iOS) and Play Store (Android). On first
+launch the user enters the URL of their self-hosted Sovereign instance. The app
+loads that URL in a WebView. All Sovereign functionality — auth, plugins, shell
+layout — is served by the user's own instance and runs inside the WebView
+unchanged. Switching between multiple instances is supported (personal + work
+etc.). This is the same distribution pattern used by Nextcloud, Bitwarden, and
+Element (Matrix).
+
+**Shell technology: Capacitor.**
+A single TypeScript codebase for both iOS and Android. The shell's logic is
+minimal: instance URL configuration on first launch, persistent URL storage,
+WebView loading, and native permission declarations. Capacitor is chosen over
+Hotwire Native (Swift + Kotlin) because:
+- Single codebase — no native language required from contributors
+- Rich plugin ecosystem (`@capacitor/camera`, `@capacitor/push-notifications`,
+  `@capacitor/biometric-auth` etc.) covering device APIs beyond Web standards
+- TypeScript throughout — consistent with the rest of the stack
+- Standardised bridge pattern — easier to expose through the SDK than
+  hand-rolled Hotwire bridges
+
+**Device API strategy — three tiers:**
+
+| Tier | Technology | Examples | Works in browser too? |
+|---|---|---|---|
+| Web APIs | Standard browser APIs, work natively in WebView | GPS (`navigator.geolocation`), camera/mic (`getUserMedia`), accelerometer, Web Push | ✅ |
+| Capacitor plugins | JS bridge to native code, richer access and better UX | Native photo picker, APNs/FCM push, Face ID / fingerprint, background location, haptics | ❌ (native shell only) |
+| SDK abstraction | `sdk.device.*` detects environment, routes to correct tier | `sdk.device.getLocation()`, `sdk.device.capturePhoto()` | ✅ (falls back to Web API) |
+
+Plugin developers use `sdk.device.*` only — they never call Web APIs or
+Capacitor plugins directly. The SDK implementation picks the right tier based
+on the runtime environment. This keeps plugins portable across browser, PWA,
+and native shell without code changes.
+
+The shell app lives in a separate repository (`sovereign-mobile`) under
+the Sovereign project, not in this monorepo. It is developed and versioned
+independently of the platform.
 
 ---
 
@@ -603,7 +648,7 @@ Granular per-user capability overrides and per-plugin role assignments are expli
 - OAuth provider functionality (Sovereign as an IdP)
 - Per-plugin isolated database (`"database": "isolated"` declared in manifest but not implemented)
 - End-to-end encryption
-- Native mobile apps or desktop wrappers
+- Native mobile app (planned post-v1 — see §3.12 for the decided approach)
 - Real-time features (WebSockets, live collaboration)
 - Per-plugin permission assignment for individual users
 - Public-facing plugin marketplace or install UI
@@ -638,8 +683,8 @@ interface SovereignManifest {
   database?: "shared" | "isolated";
 
   // Plugin type — determines origin and trust level
-  // "platform"  — ships in the monorepo, maintained by CommonsEngine
-  // "sovereign" — separate repo, maintained by CommonsEngine (e.g. Tasks, Splitify)
+  // "platform"  — ships in the monorepo, maintained by the Sovereign team
+  // "sovereign" — separate repo, maintained by the Sovereign team (e.g. Tasks, Splitify)
   // "community" — third-party, any maintainer, any source
   type: "platform" | "sovereign" | "community";
 
@@ -688,15 +733,20 @@ type Permission =
 
 | Date | Decision | Rationale |
 |---|---|---|
-| Jun 2026 | Plugin type field renamed from `source` to `type`; values changed to `platform`, `sovereign`, `community` | `source` described origin mechanics, not plugin classification. `type` is semantically cleaner. `sovereign` distinguishes CommonsEngine-maintained external plugins from true third-party community plugins. `workspace` reserved as a future user-facing concept — likely an organisational layer within a tenant (one tenant may have multiple workspaces), distinct from the deployment/tenant boundary. |
+| Jun 2026 | Plugin type field renamed from `source` to `type`; values changed to `platform`, `sovereign`, `community` | `source` described origin mechanics, not plugin classification. `type` is semantically cleaner. `sovereign` distinguishes Sovereign-maintained external plugins from true third-party community plugins. `workspace` reserved as a future user-facing concept — likely an organisational layer within a tenant (one tenant may have multiple workspaces), distinct from the deployment/tenant boundary. |
 | Jun 2026 | Drizzle ORM over Prisma | Lighter, supports SQLite and Postgres with same API, better fit for Next.js server actions. |
 | Jun 2026 | Single-tenant per deployment in v1 | Target use case is personal/small-group. Multi-tenancy adds complexity with no near-term benefit. `tenant_id` included in schema for future path. |
 | Jun 2026 | Console as core plugin, not a separate app | Consistent with plugin architecture. Avoids running a third Next.js process. Admin scope enforced by middleware. |
 | Jun 2026 | SQLite default, Postgres optional | Zero-config for self-hosters. Postgres switch is an environment config change only. |
 | Jun 2026 | SDK packages under MIT, runtime under AGPL-3.0 | Lowers barrier for plugin developers while protecting the core runtime. |
-| Jun 2026 | No native app wrapper in v1 | Next.js has no native bundling path. PWA covers the install-from-browser use case. Revisit when concrete need arises. |
+| Jun 2026 | Code formatting: Prettier; linting: ESLint 9 flat config + typescript-eslint; pre-commit: simple-git-hooks + lint-staged | ESLint is required for the custom `no-restricted-imports` SDK boundary rule — Biome has no equivalent plugin system yet, making a hybrid setup necessary. Prettier and ESLint handle separate concerns (formatting vs correctness); `eslint-config-prettier` resolves conflicts. `simple-git-hooks` is chosen over Husky — no install script, no shell files, single `package.json` entry. `lint-staged` scopes hooks to staged files only for speed. `.editorconfig` provides editor-level baseline independent of tooling. |
+| Jun 2026 | Native mobile app deferred to post-v1; approach decided | PWA covers the install-from-browser use case for v1. Native app is planned post-v1 as a universal Capacitor shell — one App Store binary, user enters their instance URL on first launch. Same pattern as Nextcloud, Bitwarden, Element. Deferred due to scope, not technical dead end. |
+| Jun 2026 | Capacitor chosen over Hotwire Native for mobile shell | Capacitor provides a single TypeScript codebase for iOS + Android, a rich plugin ecosystem for device APIs, and a standardised bridge pattern that integrates cleanly with the SDK. Hotwire Native gives a better raw native feel but requires Swift + Kotlin, no plugin ecosystem, and every device API integration is a custom bridge. For a minimal shell (URL config + WebView) the cross-platform and ecosystem benefits of Capacitor outweigh the native-feel advantage of Hotwire Native. |
+| Jun 2026 | Device APIs exposed via `sdk.device.*`; three-tier implementation strategy | Web APIs (geolocation, getUserMedia etc.) work natively in WebViews and cover most cases. Capacitor plugins cover the remainder (native photo picker, APNs/FCM push, biometric auth, haptics). Plugin developers use `sdk.device.*` only — the SDK detects the environment and routes to the correct tier. Plugins are portable across browser, PWA, and native shell without changes. |
 | Jun 2026 | Plugin schema isolation via table name prefix | Simpler than Postgres schemas. One migration runner, one connection, no cross-plugin query complexity. |
+| Jun 2026 | `packages/ui` uses CSS custom properties + CSS Modules; no Tailwind | Tailwind creates ongoing content-scan config maintenance across all plugins, cannot ship pre-built CSS from a shared library, and fights component abstraction. CSS custom properties (plain `.css` files) are universally consumable — plugin developers reference tokens from any CSS without a JS import. CSS Modules are built into Next.js with no extra deps, RSC-safe, and familiar. Two-tier token architecture: primitives (raw scale) + semantic (contextual meaning, `--sv-color-surface` etc.). All tokens prefixed `--sv-*` — consistent with `sv` CLI identity, short, unambiguous. Semantic layer is the tenant-theming surface (CON-08); primitives stay fixed. |
+| Jun 2026 | `sv` CLI built with `citty` + `consola`, TypeScript via `tsx`; monorepo-internal in v1 | `citty` is lightweight, TypeScript-first, and maps cleanly to the `sv plugin add/remove` nested command structure. `consola` is the natural pairing for consistent terminal output (info/success/warn/error). Running via `tsx` keeps the CLI consistent with `scripts/` and avoids a separate compile step. CLI is not distributed as a standalone npm package in v1 — self-hosters run it from their cloned repo. Global install deferred. |
 
 ---
 
-*Version 0.2 — Signed off June 2026. Further revisions require a new version.*
+*Version 0.6 — June 2026. Changes from v0.5: Code quality tooling decisions recorded (ESLint 9 flat config + typescript-eslint + Prettier + simple-git-hooks + lint-staged; Biome rationale). Tech stack table updated with code quality row. Decision log updated.*


### PR DESCRIPTION
## What and why

Establishes the foundational project meta layer before any application code
is written: the Claude Code session guide, all architectural decisions made
during initial planning, and GitHub collaboration infrastructure.

## Changes

**CLAUDE.md** — authoritative working guide for Claude Code sessions. Covers
branch naming, task sequencing, commit/PR conventions, version bump policy,
merge strategy (rebase and merge only), code quality baseline, design system
conventions, mobile post-v1 plan, and hard architectural rules. Source of
truth for any future session picking up the project cold.

**SRS (v0.2 → v0.6)** — records all architectural decisions made since the
initial scaffold:
- Design system: CSS custom properties + CSS Modules replacing Tailwind;
  two-tier token architecture (`--sv-*` prefix, primitives + semantic); no
  runtime CSS-in-JS. See SRS §3.7 and decision log.
- Mobile post-v1 plan: §3.12 added — universal Capacitor shell, instance URL
  model, three-tier device API strategy (`sdk.device.*`). §1.4 and §4.6
  updated to reflect deferred-not-abandoned status.
- CLI: `citty` + `consola` + `tsx`, monorepo-internal in v1. Decision log
  entry added.
- Code quality: ESLint 9 flat config + `typescript-eslint` + Prettier +
  `simple-git-hooks` + `lint-staged`. Decision log entry added.
- Branding: human-readable "CommonsEngine" references updated to "Sovereign
  team / Sovereign project"; GitHub URLs unchanged.

**Implementation tasks (v0.2 → v0.4)** — reflects all decisions above:
- New Task 0.3.03: code quality tooling (ESLint 9, Prettier, hooks,
  `.editorconfig`, SDK boundary rule established here)
- All subsequent v0.3 tasks renumbered 0.3.04–0.3.12
- Task 0.3.07 rewritten: Sovereign Design System scaffold (CSS custom
  properties, two-tier tokens, `docs/design-system.md` deliverable)
- Task 0.5.04 (CLI) and Task 0.5.07 (CI) updated accordingly
- Preamble updated with code quality dependency note

**GitHub project meta** — collaboration infrastructure:
- `.github/PULL_REQUEST_TEMPLATE.md`: structured PR template with
  verification checklist and CLA note for external contributors
- `.github/ISSUE_TEMPLATE/bug_report.yml`: structured bug report form
  (version, deployment, database, component, repro steps, logs)
- `.github/ISSUE_TEMPLATE/feature_request.yml`: feature request form
  (scope, problem, solution, alternatives, contribution intent)
- `.github/ISSUE_TEMPLATE/config.yml`: blank issues disabled; security
  advisory link for vulnerability reports
- `CONTRIBUTING.md`: dev setup, branch conventions, PR rules, CLA process
  (read CONTRIBUTING.md + tick checkbox = agreement, no separate form)
- `SECURITY.md`: private advisory reporting only; scope defined; 72h
  acknowledge / 7d assessment / 30d patch SLAs

## Type of change
- [x] `docs` — documentation only

## SRS reference
SRS §1.4, §2.2, §3.7, §3.12, §4.6, §5 (manifest), decision log entries
for code quality, CLI, design system, mobile, and plugin type branding.

## Verification
- [x] `pnpm format:check` passes (not yet enforced — Task 0.3.03 is next)
- [x] All documents are internally consistent (cross-references, task numbers, branding)
- [x] No version bump — `docs/` branch, no public API changed

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)