### PR TITLE
chore: add shared TypeScript config package (@sovereignfs/tsconfig)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,7 +261,10 @@ One owned npm scope for everything: **`@sovereignfs/*`**. The `fs` denotes
 - `packages/db` → `@sovereignfs/db` — internal, `"private": true`.
 - `packages/manifest` → `@sovereignfs/manifest` — internal, `"private": true`.
 - `packages/mailer` → `@sovereignfs/mailer` — internal, `"private": true`.
-- `packages/tsconfig` is consumed by path, not by package name.
+- `packages/tsconfig` → `@sovereignfs/tsconfig`. Not published and not imported
+  in code; consumed only via TypeScript `extends`
+  (`@sovereignfs/tsconfig/base.json` etc.), declared as a `workspace:*`
+  devDependency by each consumer.
 
 The "do not publish" signal is `"private": true` in the package's
 `package.json` — **not** the scope. A single scope we own avoids the
@@ -310,8 +313,9 @@ pnpm install:plugins    # clone declared sovereign/community plugins (stub until
 ## Status
 
 - ✅ Task 0.3.01 — Monorepo scaffold (merged to `main`).
-- ▶️ Next: Task 0.3.02 — Shared TypeScript config (`packages/tsconfig`).
-- ⏳ Then: Task 0.3.03 — Code quality tooling (ESLint + Prettier + hooks).
+- ✅ Docs — Build, dev DX, deployment, and npm publishing strategy (merged to `main`).
+- ▶️ In review: Task 0.3.02 — Shared TypeScript config (`packages/tsconfig`).
+- ⏳ Next: Task 0.3.03 — Code quality tooling (ESLint + Prettier + hooks).
 
 Keep this file current: update the Status section as tasks complete, and add any
 new load-bearing convention that future sessions must not violate.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "install:plugins": "tsx scripts/install-plugins.ts"
   },
   "devDependencies": {
+    "@sovereignfs/tsconfig": "workspace:*",
     "@types/node": "^22.10.2",
     "tsx": "^4.19.2",
     "turbo": "^2.3.3",

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Base",
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "moduleDetection": "force",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  }
+}

--- a/packages/tsconfig/library.json
+++ b/packages/tsconfig/library.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Library",
+  "extends": "./base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "rootDir": "src",
+    "outDir": "dist"
+  }
+}

--- a/packages/tsconfig/nextjs.json
+++ b/packages/tsconfig/nextjs.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Next.js",
+  "extends": "./base.json",
+  "compilerOptions": {
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "jsx": "preserve",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowJs": true,
+    "noEmit": true,
+    "incremental": true,
+    "plugins": [{ "name": "next" }]
+  }
+}

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@sovereignfs/tsconfig",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Shared TypeScript configurations for the Sovereign monorepo.",
+  "license": "AGPL-3.0",
+  "files": ["base.json", "nextjs.json", "library.json"],
+  "exports": {
+    "./base.json": "./base.json",
+    "./nextjs.json": "./nextjs.json",
+    "./library.json": "./library.json"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@sovereignfs/tsconfig':
+        specifier: workspace:*
+        version: link:packages/tsconfig
       '@types/node':
         specifier: ^22.10.2
         version: 22.19.20
@@ -20,6 +23,8 @@ importers:
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
+
+  packages/tsconfig: {}
 
 packages:
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@sovereignfs/tsconfig/base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["scripts/**/*.ts"]
+}


### PR DESCRIPTION
## What and why

Adds `@sovereignfs/tsconfig` — the centralised TypeScript configuration every
package and app in the monorepo extends. This is a foundational dependency
(CLAUDE.md hard rule; SRS §2.2): nothing else can be built with consistent
strictness until it exists.

## Changes

Three configs, consumed via TypeScript `extends` **by package name**
(`@sovereignfs/tsconfig/base.json` etc.) — robust across the repo's mixed
directory depths, the Turborepo-standard approach:

- **`base.json`** — strict baseline. `target: ES2022`, `module: ESNext`,
  `moduleResolution: Bundler`. Full strict family: `strict`,
  `noUncheckedIndexedAccess`, `noImplicitOverride`, `noUnusedLocals`,
  `noUnusedParameters`, `noFallthroughCasesInSwitch`. Plus `isolatedModules`
  and `verbatimModuleSyntax` to match the ESM-only build decision.
- **`nextjs.json`** — extends base; DOM libs, `jsx: preserve`, `noEmit`,
  the `next` plugin.
- **`library.json`** — extends base; `rootDir`/`outDir` for tsup-built packages.

`package.json` declares all three in `exports` (and `files`). The package is
`private` — never published, never imported in code, only referenced via
`extends`. Concrete path aliases are left to consumers (location-relative);
base only enables the resolution mode.

Also:
- Root `tsconfig.json` (extends base, `noEmit`, includes `scripts/**/*.ts`) so
  the existing scripts get editor support + typecheck under the shared config.
- `@sovereignfs/tsconfig` wired as a root workspace devDependency.
- CLAUDE.md: reconciled the package-scope note (tsconfig is consumed via
  extends-by-name as a `workspace:*` devDependency, not a relative path) and
  updated the Status section.

## Type of change
- [x] `chore` — tooling / scaffolding (no version bump)

## SRS reference
SRS §2.2 Tech Stack. Extends-by-name + ESM-only (`verbatimModuleSyntax`) align
with the build-strategy decision log.

## Verification
- [x] `pnpm install` links `@sovereignfs/tsconfig` into `node_modules/@sovereignfs/`
- [x] `tsc --showConfig` confirms `strict: true` and `noUncheckedIndexedAccess: true` are inherited through extends-by-name (both review-checklist items)
- [x] `tsc --noEmit -p tsconfig.json` passes — proves extends-by-name resolves and `scripts/` typechecks under the shared config
- [x] All three presets resolve their extends chain and layer settings correctly

## Notes for reviewer
- Branch is `chore/` (tooling scaffolding → no version bump); CLAUDE.md's example
  slug happens to show `feat/shared-tsconfig` — flagging the deliberate choice.
- Root `tsconfig.json` extends `base.json` rather than `library.json`, because
  the library preset's `rootDir: "src"` conflicts with including `scripts/`.
- `verbatimModuleSyntax: true` in base enforces `import type` everywhere; it
  typechecks clean today, flagged since it's a strict default future packages inherit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)