### PR TITLE
chore: add code quality tooling (ESLint 9, Prettier, git hooks)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: Something isn't working as expected.
-labels: ["bug", "needs-triage"]
+labels: ['bug', 'needs-triage']
 
 body:
   - type: markdown
@@ -13,7 +13,7 @@ body:
     id: version
     attributes:
       label: Sovereign version
-      placeholder: "e.g. 0.3.1"
+      placeholder: 'e.g. 0.3.1'
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Suggest a new capability or improvement.
-labels: ["enhancement", "needs-triage"]
+labels: ['enhancement', 'needs-triage']
 
 body:
   - type: markdown
@@ -52,9 +52,9 @@ body:
     attributes:
       label: Willing to contribute a PR?
       options:
-        - "Yes"
-        - "Yes, with some guidance"
-        - "No"
+        - 'Yes'
+        - 'Yes, with some guidance'
+        - 'No'
     validations:
       required: true
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,20 +1,25 @@
 ## What and why
+
 <!-- Describe what changed and why. Focus on the reasoning, not just the mechanics. -->
 
 ## Type of change
+
 - [ ] `feat` — new feature or capability
 - [ ] `fix` — bug fix
 - [ ] `docs` — documentation only
 - [ ] `chore` — tooling, scaffolding, dependencies, maintenance
 
 ## Related issue
+
 <!-- Link any related issue: Closes #123 — delete if not applicable -->
 
 ## SRS reference
+
 <!-- If this touches architecture, requirements, or design decisions, cite the relevant
 section (e.g. SRS §3.6, PLT-02, NFR-04). Delete if not applicable. -->
 
 ## Verification
+
 - [ ] `pnpm format:check` passes
 - [ ] `pnpm lint` passes
 - [ ] `pnpm typecheck` passes
@@ -23,6 +28,7 @@ section (e.g. SRS §3.6, PLT-02, NFR-04). Delete if not applicable. -->
 - [ ] Screenshots included below (delete if no UI changes)
 
 ## Screenshots
+
 <!-- Delete if not applicable -->
 
 ---

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,7 @@
+node_modules
+**/dist
+**/.next
+**/.turbo
+pnpm-lock.yaml
+runtime/app/plugins
+runtime/generated

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Guidance for Claude Code working in this repository.
 
 **Sovereign** — a modular, self-hostable workspace runtime. A shared platform
 (auth, DB, email, UI) hosts installable **plugins** as first-class apps. The
-plugin system *is* the product, not an app extended with plugins. Open source,
+plugin system _is_ the product, not an app extended with plugins. Open source,
 privacy-first, single-tenant/multi-user in v1.
 
 ## Source of truth
@@ -35,6 +35,7 @@ they are authoritative over assumptions:
   e.g. `feat/shared-tsconfig`, `chore/scaffold-monorepo`.
   _(Post-v1.0.0 this changes: `main` becomes the production branch and `dev`
   the integration branch — branch from `dev` then. Until then, base off `main`.)_
+
 - **Doc task numbers (e.g. `0.3.02`) are for local tracking only.** Never put
   them in branch names, commit messages, or PR titles/descriptions. Refer to the
   work by what it does, not its task number.
@@ -77,15 +78,15 @@ Established in Task 0.3.03. Every package and PR must comply — no exceptions.
 
 ### Tools
 
-| Tool | Purpose |
-|---|---|
-| **Prettier** | Formatting — single source of truth for style |
-| **ESLint 9 (flat config)** | Linting — correctness, best practices, SDK boundary rule |
-| `typescript-eslint` | TypeScript-specific ESLint rules (recommended + strict) |
-| `eslint-config-prettier` | Disables ESLint formatting rules that conflict with Prettier |
-| `simple-git-hooks` | Pre-commit hook runner (lighter than Husky, no shell scripts) |
-| `lint-staged` | Runs Prettier then ESLint only on staged files (fast) |
-| `.editorconfig` | Editor-level baseline — indent, line endings, charset |
+| Tool                       | Purpose                                                       |
+| -------------------------- | ------------------------------------------------------------- |
+| **Prettier**               | Formatting — single source of truth for style                 |
+| **ESLint 9 (flat config)** | Linting — correctness, best practices, SDK boundary rule      |
+| `typescript-eslint`        | TypeScript-specific ESLint rules (recommended + strict)       |
+| `eslint-config-prettier`   | Disables ESLint formatting rules that conflict with Prettier  |
+| `simple-git-hooks`         | Pre-commit hook runner (lighter than Husky, no shell scripts) |
+| `lint-staged`              | Runs Prettier then ESLint only on staged files (fast)         |
+| `.editorconfig`            | Editor-level baseline — indent, line endings, charset         |
 
 ### Formatting conventions (Prettier)
 
@@ -179,7 +180,7 @@ unambiguous. **Never abbreviate after the prefix** — use full descriptive name
 
 ```ts
 // Components — typed React components
-import { Button, Card, Input, Badge } from '@sovereignfs/ui'
+import { Button, Card, Input, Badge } from '@sovereignfs/ui';
 
 // Tokens — already injected globally by the runtime shell.
 // Reference directly in plugin CSS without any import:
@@ -210,6 +211,7 @@ Nextcloud, Bitwarden, Element (Matrix).
 separate `sovereign-mobile` repository, not this monorepo.
 
 **Device API tiers — in priority order:**
+
 1. **Web APIs** — `navigator.geolocation`, `getUserMedia` etc. Work natively in
    WebViews, also work in browser/PWA. Use these first.
 2. **Capacitor plugins** — for what Web APIs can't cover: native photo picker,
@@ -253,7 +255,7 @@ bin/sv              CLI (v0.5)
 ### Package naming and scope
 
 One owned npm scope for everything: **`@sovereignfs/*`**. The `fs` denotes
-*federated systems* — reflecting the project's long-term federated direction
+_federated systems_ — reflecting the project's long-term federated direction
 (federation itself is a post-v1 concern; see SRS §1.4 non-goals).
 
 - `packages/sdk` → `@sovereignfs/sdk` — **published** (plugin contract).
@@ -314,8 +316,9 @@ pnpm install:plugins    # clone declared sovereign/community plugins (stub until
 
 - ✅ Task 0.3.01 — Monorepo scaffold (merged to `main`).
 - ✅ Docs — Build, dev DX, deployment, and npm publishing strategy (merged to `main`).
-- ▶️ In review: Task 0.3.02 — Shared TypeScript config (`packages/tsconfig`).
-- ⏳ Next: Task 0.3.03 — Code quality tooling (ESLint + Prettier + hooks).
+- ✅ Task 0.3.02 — Shared TypeScript config (`packages/tsconfig`) (merged to `main`).
+- ▶️ In review: Task 0.3.03 — Code quality tooling (ESLint + Prettier + hooks).
+- ⏳ Next: Task 0.3.04 — `packages/db` (Drizzle client factory).
 
 Keep this file current: update the Status section as tasks complete, and add any
 new load-bearing convention that future sessions must not violate.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,14 +51,14 @@ git switch -c feat/your-feature-name
 
 **Branch prefixes:**
 
-| Prefix | Use for |
-|---|---|
-| `feat/` | New features or capabilities |
-| `fix/` | Bug fixes |
-| `docs/` | Documentation only |
+| Prefix   | Use for                                         |
+| -------- | ----------------------------------------------- |
+| `feat/`  | New features or capabilities                    |
+| `fix/`   | Bug fixes                                       |
+| `docs/`  | Documentation only                              |
 | `chore/` | Tooling, scaffolding, dependencies, maintenance |
 
-**Commit messages** should explain *why*, not just *what*. Keep the subject
+**Commit messages** should explain _why_, not just _what_. Keep the subject
 line under 72 characters. Body lines wrap at 100 characters.
 
 If you used an AI assistant to help write the code, include the co-author

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,6 +29,7 @@ A useful report includes:
 ## Scope
 
 **In scope:**
+
 - Authentication bypass or session hijacking
 - Privilege escalation (accessing admin routes as a regular user)
 - Remote code execution via the plugin system or SDK
@@ -36,6 +37,7 @@ A useful report includes:
 - SDK boundary violations that enable plugin-to-platform data leakage
 
 **Out of scope:**
+
 - Issues requiring physical access to the host machine
 - Vulnerabilities in the self-hoster's own infrastructure (reverse proxy
   misconfiguration, weak secrets, etc.)

--- a/docs/sovereign-implementation-tasks.md
+++ b/docs/sovereign-implementation-tasks.md
@@ -9,6 +9,7 @@
 ## How to use this document
 
 Each task maps to one Claude Code session and one PR. Before starting a session:
+
 1. Provide Claude Code with the relevant SRS sections as context
 2. Provide this document and point to the specific task
 3. Review the PR before moving to the next task — no task should start on an unmerged PR
@@ -30,6 +31,7 @@ Tasks are sequenced — each depends on the previous unless marked **[parallel]*
 **Goal:** Bare monorepo structure with pnpm workspaces and Turborepo configured. No application code.
 
 **Deliverables:**
+
 - Root `package.json` with pnpm workspace config
 - `pnpm-workspace.yaml` declaring `apps/*`, `packages/*`, `plugins/*`, `runtime`
 - `turbo.json` with basic pipeline: `build`, `dev`, `lint`, `typecheck`
@@ -41,6 +43,7 @@ Tasks are sequenced — each depends on the previous unless marked **[parallel]*
 **SRS reference:** 2.3 Monorepo Structure, 2.2 Tech Stack
 
 **Review checklist:**
+
 - `pnpm install` runs without errors
 - `turbo build` runs without errors (no-ops since no packages exist yet)
 - Directory structure matches SRS 2.3 exactly
@@ -52,6 +55,7 @@ Tasks are sequenced — each depends on the previous unless marked **[parallel]*
 **Goal:** Centralised TypeScript configuration inherited by all packages and apps.
 
 **Deliverables:**
+
 - `packages/tsconfig/` package with:
   - `base.json` — strict mode, path aliases, target ES2022
   - `nextjs.json` — extends base, Next.js specific settings
@@ -61,6 +65,7 @@ Tasks are sequenced — each depends on the previous unless marked **[parallel]*
 **SRS reference:** 2.2 Tech Stack
 
 **Review checklist:**
+
 - `packages/tsconfig/package.json` correctly exports all three configs
 - Configs are strict — `strict: true`, `noUncheckedIndexedAccess: true`
 
@@ -73,6 +78,7 @@ monorepo before any application code is written. All subsequent tasks inherit
 this baseline — nothing is merged without passing it.
 
 **Deliverables:**
+
 - `.editorconfig` at repo root — indent style (spaces, 2), line endings (LF),
   charset (UTF-8), trailing newline, trim trailing whitespace
 - `prettier.config.ts` at repo root — single quotes, semicolons, trailing
@@ -90,7 +96,7 @@ this baseline — nothing is merged without passing it.
   - `lint-staged` — runs `prettier --write` then `eslint --fix` on staged
     `.ts`/`.tsx`/`.css`/`.json` files
   - Scripts: `"format": "prettier --write ."`, `"format:check": "prettier
-    --check ."`, `"lint:fix": "eslint --fix ."`
+--check ."`, `"lint:fix": "eslint --fix ."`
 - `turbo.json` — confirm `lint` task is correctly wired across packages
 - Run `pnpm format` on all existing files (`.gitignore`, `README.md`,
   `package.json`, `pnpm-workspace.yaml`, `turbo.json`,
@@ -104,6 +110,7 @@ Code quality section. No Biome — ESLint is required for the custom
 **SRS reference:** NFR-06, PLT-10, SRS §2.2 Tech Stack
 
 **Review checklist:**
+
 - `pnpm format:check` passes on all files in the repo
 - `pnpm lint` passes with zero errors or warnings
 - Attempting to commit a file with formatting errors is blocked by the
@@ -118,6 +125,7 @@ Code quality section. No Biome — ESLint is required for the custom
 **Goal:** Shared database package providing a Drizzle client factory that supports both SQLite and PostgreSQL via a dialect flag.
 
 **Deliverables:**
+
 - `packages/db/` with:
   - `src/client.ts` — exports `createClient(config)` returning a Drizzle instance
   - `src/dialect.ts` — reads `DATABASE_URL` and `DB_DIALECT` env vars, returns correct dialect
@@ -137,6 +145,7 @@ Code quality section. No Biome — ESLint is required for the custom
 **SRS reference:** 3.7 Database Layer, 3.1 Deployment Model (tenant_id)
 
 **Review checklist:**
+
 - `createClient()` returns a working Drizzle instance for SQLite when `DB_DIALECT=sqlite`
 - `tenant_id` present on `users` table
 - Migration runner accepts an array of migration paths and runs them in order
@@ -149,6 +158,7 @@ Code quality section. No Biome — ESLint is required for the custom
 **Goal:** Manifest schema package providing TypeScript types and a validation function.
 
 **Deliverables:**
+
 - `packages/manifest/` with:
   - `src/types.ts` — full `SovereignManifest` interface and `Permission` type as defined in SRS section 5
   - `src/validate.ts` — `validateManifest(json): ValidationResult` — checks required fields, valid enum values, `repository` required when type is `sovereign` or `community`
@@ -163,6 +173,7 @@ Code quality section. No Biome — ESLint is required for the custom
 **SRS reference:** 3.8 Manifest System, Section 5 Plugin Manifest Reference
 
 **Review checklist:**
+
 - All fields from SRS Section 5 present in the TypeScript interface
 - `shell`, `database`, `runtime`, `type` fields all typed correctly with correct enum values
 - Validation tests pass
@@ -174,6 +185,7 @@ Code quality section. No Biome — ESLint is required for the custom
 **Goal:** Thin mailer package wrapping nodemailer with a simple `send()` interface.
 
 **Deliverables:**
+
 - `packages/mailer/` with:
   - `src/mailer.ts` — `createMailer(config)` factory, `send(options: MailOptions)` method
   - `src/types.ts` — `MailOptions`, `MailerConfig` interfaces
@@ -189,6 +201,7 @@ Code quality section. No Biome — ESLint is required for the custom
 **SRS reference:** NFR-02 (email optional), SDK surface `sdk.mailer.send()`
 
 **Review checklist:**
+
 - `send()` accepts `to`, `subject`, `html`, `text`
 - No-op behaviour when SMTP unconfigured — does not crash the runtime
 - No hardcoded credentials anywhere
@@ -203,6 +216,7 @@ a public contract for plugin developers; token names and component APIs must be
 treated with the same versioning discipline as the SDK.
 
 **Deliverables:**
+
 - `packages/ui/` with:
   - `src/tokens/primitives.css` — raw scale tokens with `--sv-` prefix:
     colour palette (`--sv-grey-50` … `--sv-grey-950`), spacing scale
@@ -244,6 +258,7 @@ consuming Next.js app (runtime) handles them natively. Token CSS files
 (`.css`, not `.module.css`) are plain CSS — tsup copies them to `dist/` via
 `loader: { '.css': 'copy' }` so they are importable as side-effect imports
 by the runtime shell.
+
 - `tsup.config.ts` — entry: `['src/index.ts']`, format: `['esm']`, dts: true,
   clean: true, external: `[/\.css$/]`, loader: `{ '.css': 'copy' }`
 - `package.json`:
@@ -259,6 +274,7 @@ by the runtime shell.
 **SRS reference:** 2.2 Tech Stack (`packages/ui`)
 
 **Review checklist:**
+
 - `Button` renders without errors when imported into a test file
 - No hardcoded colour, spacing, or radius values in any component CSS — only
   `--sv-*` token references
@@ -275,6 +291,7 @@ by the runtime shell.
 **Goal:** SDK package with full interface definitions for v1 surface. Implementations are stubs at this stage — real implementations come in later tasks.
 
 **Deliverables:**
+
 - `packages/sdk/` with:
   - `src/types.ts` — `Session`, `PlatformConfig`, `MailOptions`, `DrizzleClient` types
   - `src/auth.ts` — `getSession()`, `requireSession()` — stubs throwing `NotImplementedError`
@@ -292,6 +309,7 @@ verifies it catches a violation.
 **Build:** `tsup` — ESM only, TypeScript declarations. Published to npm as
 `@sovereignfs/sdk`; `package.json` must include `exports`, `main`, `types`,
 and `files` fields pointing to `dist/`.
+
 - `tsup.config.ts` — entry: `['src/index.ts']`, format: `['esm']`, dts: true,
   clean: true
 - `package.json`:
@@ -303,6 +321,7 @@ and `files` fields pointing to `dist/`.
 **SRS reference:** 3.6 SDK, NFR-06
 
 **Review checklist:**
+
 - All SDK methods from SRS 3.6 present
 - Unimplemented stubs throw `NotImplementedError` with a clear message
 - ESLint import boundary rule catches a `runtime/src` import in a test plugin
@@ -315,6 +334,7 @@ and `files` fields pointing to `dist/`.
 **Goal:** Auth server wrapping better-auth. Handles login, logout, registration, and session verification.
 
 **Deliverables:**
+
 - `apps/auth/` — Next.js app with:
   - better-auth configured with email/password provider
   - Session stored as httpOnly cookie
@@ -330,6 +350,7 @@ and `files` fields pointing to `dist/`.
 **SRS reference:** 3.3 Auth Layer, 4.3 Functional Requirements — Auth
 
 **Review checklist:**
+
 - Login sets httpOnly cookie
 - `/api/verify` returns 401 for invalid/expired token
 - First registered user gets `platform:admin`
@@ -343,6 +364,7 @@ and `files` fields pointing to `dist/`.
 **Goal:** Sovereign Core Next.js app scaffold with shell layout, middleware, and plugin launcher page. No plugins wired yet.
 
 **Deliverables:**
+
 - `runtime/` — Next.js 15 app with App Router:
   - `app/(platform)/layout.tsx` — shell layout: sidebar + content area (desktop), header + content + footer (mobile)
   - `app/(platform)/page.tsx` — launcher page (empty plugin grid for now)
@@ -353,7 +375,7 @@ and `files` fields pointing to `dist/`.
   - `app/login/page.tsx` — login page pointing to `apps/auth`
 - `runtime/next.config.ts` — must include:
   - `transpilePackages: ['@sovereignfs/sdk', '@sovereignfs/ui',
-    '@sovereignfs/db', '@sovereignfs/manifest', '@sovereignfs/mailer']` —
+'@sovereignfs/db', '@sovereignfs/manifest', '@sovereignfs/mailer']` —
     compiles all workspace package TypeScript sources directly during dev.
     Changes to any package file trigger HMR in the runtime without a separate
     watch build. (All packages share the single `@sovereignfs/*` scope; only
@@ -373,6 +395,7 @@ and `files` fields pointing to `dist/`.
 **SRS reference:** 3.4 Runtime Layer, 3.10 Shared Login State, PLT-01, PLT-02, PLT-08
 
 **Review checklist:**
+
 - Unauthenticated request to `/` redirects to `/login`
 - Shell renders correctly on desktop and mobile viewports
 - `app/plugins/` is gitignored
@@ -388,6 +411,7 @@ and `files` fields pointing to `dist/`.
 **Goal:** Pre-build script that reads plugin manifests, validates them, and injects plugin routes into the runtime.
 
 **Deliverables:**
+
 - `scripts/generate-registry.ts`:
   - Scans `plugins/*/manifest.json`
   - Validates each manifest via `packages/manifest`
@@ -416,6 +440,7 @@ and `files` fields pointing to `dist/`.
 **SRS reference:** 3.9 Plugin Loading Model
 
 **Review checklist:**
+
 - Invalid manifest causes script to exit non-zero with a readable error
 - `runtime/generated/registry.ts` is valid TypeScript after running
 - Symlinks created in dev mode, copies in production mode
@@ -428,6 +453,7 @@ and `files` fields pointing to `dist/`.
 **Goal:** Docker Compose setup orchestrating runtime and auth server for local development.
 
 **Deliverables:**
+
 - `docker-compose.yml` — two services on a shared network:
   - `runtime` — host-mapped `${RUNTIME_PORT:-3000}:3000`
   - `auth` — internal only; `expose: ["3001"]`, no host `ports` mapping. The
@@ -442,6 +468,7 @@ and `files` fields pointing to `dist/`.
 **SRS reference:** NFR-01, 2.4 Phased Roadmap v0.3, 3.1 Deployment Model (topology, ports)
 
 **Review checklist:**
+
 - `docker compose up` starts both services without errors
 - Runtime is reachable at `localhost:3000` (dev)
 - Auth server is **not** reachable from the host — only from the runtime
@@ -457,6 +484,7 @@ and `files` fields pointing to `dist/`.
 **Goal:** Console plugin directory structure, manifest, and basic routing wired into the runtime via the generate script.
 
 **Deliverables:**
+
 - `plugins/console/manifest.json` — type: `platform`, runtime: `native`, routePrefix: `/console`, adminOnly: true, shell: `default`
 - `plugins/console/app/layout.tsx` — console shell layout
 - `plugins/console/app/page.tsx` — console home (empty, links to sub-sections)
@@ -467,6 +495,7 @@ and `files` fields pointing to `dist/`.
 **SRS reference:** 3.5 Plugin System, 4.4 Functional Requirements — Console, PLT-03
 
 **Review checklist:**
+
 - `/console` returns 403 for `platform:user`, accessible for `platform:admin`
 - Generate script correctly picks up console manifest
 - Console appears in launcher for admin users only
@@ -478,6 +507,7 @@ and `files` fields pointing to `dist/`.
 **Goal:** User list, invite, role change, and deactivate/reactivate.
 
 **Deliverables:**
+
 - `plugins/console/app/users/page.tsx` — paginated user list: name, email, role, status, join date
 - `plugins/console/app/users/invite/page.tsx` — invite form: generates invite token, sends email via `sdk.mailer`
 - Role change and deactivate/reactivate as server actions
@@ -486,6 +516,7 @@ and `files` fields pointing to `dist/`.
 **SRS reference:** CON-02, CON-03, CON-04, CON-05
 
 **Review checklist:**
+
 - User list shows all users with correct data
 - Invite email sends (or logs no-op) when SMTP unconfigured
 - Role change persists correctly
@@ -498,6 +529,7 @@ and `files` fields pointing to `dist/`.
 **Goal:** Installed plugin list with enable/disable toggle.
 
 **Deliverables:**
+
 - `plugins/console/app/plugins/page.tsx` — list of installed plugins from registry: name, version, type, status
 - Enable/disable toggle as server action — writes to a `plugin_status` table in platform db
 - Runtime middleware respects disabled status — returns 404 for disabled plugin routes
@@ -506,6 +538,7 @@ and `files` fields pointing to `dist/`.
 **SRS reference:** CON-06, CON-07, PLT-04
 
 **Review checklist:**
+
 - Disabling a plugin blocks its routes immediately (no rebuild required)
 - Disabled plugin disappears from launcher
 - Re-enabling restores access
@@ -517,6 +550,7 @@ and `files` fields pointing to `dist/`.
 **Goal:** Tenant name configuration and system health dashboard.
 
 **Deliverables:**
+
 - `plugins/console/app/settings/page.tsx` — tenant name field, invite-only toggle
 - `plugins/console/app/health/page.tsx` — runtime version, database type + connection status, auth server status, disk usage
 - Tenant name stored in `tenants` table, exposed via `sdk.platform.getConfig()`
@@ -525,6 +559,7 @@ and `files` fields pointing to `dist/`.
 **SRS reference:** CON-08, CON-09, CON-10, PLT-06
 
 **Review checklist:**
+
 - Tenant name change reflects in `sdk.platform.getConfig()` immediately
 - Health page shows accurate database type (SQLite vs Postgres)
 - Invite-only toggle takes effect on next registration attempt without restart
@@ -538,12 +573,19 @@ and `files` fields pointing to `dist/`.
 **Goal:** Full implementation of the install script stubbed in Task 0.3.01.
 
 **Deliverables:**
+
 - `sovereign.plugins.json` at repo root — config file declaring which sovereign/community plugins to install:
   ```json
   {
     "plugins": [
-      { "id": "com.sovereign.tasks", "repository": "https://github.com/CommonsEngine/sovereign-plugin-tasks" },
-      { "id": "com.sovereign.splitify", "repository": "https://github.com/CommonsEngine/sovereign-plugin-splitify" }
+      {
+        "id": "com.sovereign.tasks",
+        "repository": "https://github.com/CommonsEngine/sovereign-plugin-tasks"
+      },
+      {
+        "id": "com.sovereign.splitify",
+        "repository": "https://github.com/CommonsEngine/sovereign-plugin-splitify"
+      }
     ]
   }
   ```
@@ -553,6 +595,7 @@ and `files` fields pointing to `dist/`.
 **SRS reference:** 2.3 Monorepo Structure, 3.5 Plugin System
 
 **Review checklist:**
+
 - Running script clones declared plugins into correct directories
 - Already-cloned plugins are skipped without error
 - `pnpm generate` runs automatically after install
@@ -563,6 +606,7 @@ and `files` fields pointing to `dist/`.
 **Goal:** Runtime configured as an installable PWA.
 
 **Deliverables:**
+
 - `@ducanh2912/next-pwa` configured in `runtime/next.config.ts`
 - `public/manifest.json` — PWA manifest: name, icons, theme colour
 - Service worker caching shell and static assets
@@ -571,6 +615,7 @@ and `files` fields pointing to `dist/`.
 **SRS reference:** 3.11 PWA, PLT-09
 
 **Review checklist:**
+
 - Lighthouse PWA audit passes
 - App installable on desktop Chrome and mobile Safari
 - Offline load shows shell (not blank page)
@@ -583,6 +628,7 @@ and `files` fields pointing to `dist/`.
 from Next.js standalone output.
 
 **Deliverables:**
+
 - `Dockerfile` (runtime) — three-stage:
   - `deps` — `node:<pinned>-alpine` + corepack pnpm; install with
     `--frozen-lockfile`
@@ -602,6 +648,7 @@ from Next.js standalone output.
 **SRS reference:** NFR-01, 2.4 Phased Roadmap v0.5, 3.1 Deployment Model
 
 **Review checklist:**
+
 - Images build without errors
 - Each image is reasonably small (standalone output keeps them lean; target
   < 250MB per image)
@@ -617,6 +664,7 @@ from Next.js standalone output.
 **Goal:** Confirm full parity between SQLite and Postgres deployments.
 
 **Deliverables:**
+
 - `docker-compose.prod.yml` updated with a Postgres service variant
 - All migrations run cleanly against Postgres
 - End-to-end smoke test: login, console access, plugin enable/disable — all working on Postgres
@@ -625,6 +673,7 @@ from Next.js standalone output.
 **SRS reference:** NFR-03, 3.7 Database Layer
 
 **Review checklist:**
+
 - Switching `DB_DIALECT=postgres` and `DATABASE_URL` is the only change required
 - No SQLite-specific queries anywhere in application code
 - Migrations apply cleanly to a fresh Postgres instance
@@ -636,6 +685,7 @@ from Next.js standalone output.
 **Goal:** `sv` CLI with essential commands for managing a Sovereign deployment.
 
 **Deliverables:**
+
 - `bin/sv` — TypeScript entry point, executed via `tsx` (no separate compile
   step; consistent with the `scripts/` pattern)
 - Commands:
@@ -658,6 +708,7 @@ consistent info/success/warn/error formatting. CLI is monorepo-internal in v1
 **SRS reference:** 2.4 Phased Roadmap v0.5, 2.2 Tech Stack
 
 **Review checklist:**
+
 - `sv dev` starts both services correctly
 - `sv plugin add` clones and wires a plugin end-to-end
 - `sv plugin remove` cleans up symlinks/copies and updates registry
@@ -671,6 +722,7 @@ consistent info/success/warn/error formatting. CLI is monorepo-internal in v1
 **Goal:** Complete remaining SDK implementations. `sdk.auth` and `sdk.mailer` were wired in Task 0.4.02. This task completes `sdk.db` and `sdk.platform`, and also upgrades middleware from `/api/verify` round-trips to local JWT verification.
 
 **Deliverables:**
+
 - `runtime/src/sdk/db.ts` — real `getClient()` returning scoped Drizzle instance
 - `runtime/src/sdk/platform.ts` — real `getConfig()` reading from `tenants` table
 - `runtime/src/middleware.ts` — updated to verify JWT locally using `SOVEREIGN_AUTH_SECRET` (replaces `/api/verify` round-trip per SRS AUTH-05)
@@ -679,6 +731,7 @@ consistent info/success/warn/error formatting. CLI is monorepo-internal in v1
 **SRS reference:** 3.6 SDK
 
 **Review checklist:**
+
 - `sdk.auth.requireSession()` throws when called from an unauthenticated context
 - `sdk.db.getClient()` returns a working Drizzle instance
 - `sdk.mailer.send()` delegates correctly to packages/mailer
@@ -691,6 +744,7 @@ consistent info/success/warn/error formatting. CLI is monorepo-internal in v1
 **Goal:** Complete self-hosting and plugin developer documentation.
 
 **Deliverables:**
+
 - `docs/self-hosting.md` — complete: requirements, Docker deploy, env vars, first run, Postgres switch, upgrade path
 - `docs/plugin-development.md` — complete: manifest reference, SDK usage, file structure, how to submit to registry
 - `docs/architecture.md` — summary of SRS architecture sections for contributors
@@ -700,6 +754,7 @@ consistent info/success/warn/error formatting. CLI is monorepo-internal in v1
 **SRS reference:** NFR-10, 2.4 Phased Roadmap v1.0
 
 **Review checklist:**
+
 - A developer with no prior Sovereign knowledge can deploy from scratch following `self-hosting.md`
 - Plugin developer guide covers all manifest fields with examples
 - All env vars documented with descriptions and whether required or optional
@@ -711,6 +766,7 @@ consistent info/success/warn/error formatting. CLI is monorepo-internal in v1
 **Goal:** GitHub Actions pipelines for continuous validation and npm publishing.
 
 **Deliverables:**
+
 - `.github/workflows/ci.yml` — validation, triggers on push to `main` and all
   pull requests:
   - `format` — runs `prettier --check .` across the repo; fails on any
@@ -737,6 +793,7 @@ consistent info/success/warn/error formatting. CLI is monorepo-internal in v1
 **SRS reference:** SRS 3.9 (CI validation step), PLT-07, NFR-06, NFR-04
 
 **Review checklist:**
+
 - All five validation jobs pass on a clean checkout
 - Unformatted file causes `format` job to fail
 - Import boundary violation in a plugin causes `lint` job to fail
@@ -752,6 +809,7 @@ consistent info/success/warn/error formatting. CLI is monorepo-internal in v1
 **Goal:** Define and document the process for submitting a community plugin to `registry/plugins.json`.
 
 **Deliverables:**
+
 - `registry/plugins.json` — initial structure with console as the only platform entry
 - `registry/CONTRIBUTING.md` — submission requirements: manifest must be valid, repository must be public, must include LICENSE file, must target compatible platform version
 - PR template for registry submissions
@@ -760,6 +818,7 @@ consistent info/success/warn/error formatting. CLI is monorepo-internal in v1
 **SRS reference:** 2.7 Open Source Strategy, 3.8 Manifest System
 
 **Review checklist:**
+
 - `plugins.json` validates against manifest schema
 - Submission requirements are clear and enforceable via manifest validation
 
@@ -770,6 +829,7 @@ consistent info/success/warn/error formatting. CLI is monorepo-internal in v1
 **Goal:** SDK API review, cleanup, and semver commitment documented.
 
 **Deliverables:**
+
 - SDK API review — remove anything experimental or inconsistent
 - `packages/sdk/CHANGELOG.md` — initial entry marking v1.0.0 as stable
 - `docs/sdk-stability.md` — documents what stable means: patch = no breaking changes, minor = additive only, major = breaking with migration guide
@@ -778,10 +838,11 @@ consistent info/success/warn/error formatting. CLI is monorepo-internal in v1
 **SRS reference:** NFR-04
 
 **Review checklist:**
+
 - No stub implementations remain in the v1 SDK surface
 - All unimplemented stubs (storage, notifications, events) clearly marked as unstable/experimental
 - Semver policy documented and linked from README
 
 ---
 
-*Version 0.8 — June 2026. Changes from v0.7: npm scope unified to a single owned scope `@sovereignfs/*` for all packages (was split `@commonsengine/sovereign-*` + `@sovereign/*`); transpilePackages lists, package build/publish notes, and publish.yml updated accordingly; internal packages marked `private`. Earlier v0.7 changes (Docker two-container topology, three-stage prod images, ci.yml/publish.yml split) retained. Task breakdown covers platform only. Plugin-specific task breakdowns (Tasks, Splitify) are maintained in their respective repositories.*
+_Version 0.8 — June 2026. Changes from v0.7: npm scope unified to a single owned scope `@sovereignfs/_`for all packages (was split`@commonsengine/sovereign-_`+`@sovereign/_`); transpilePackages lists, package build/publish notes, and publish.yml updated accordingly; internal packages marked `private`. Earlier v0.7 changes (Docker two-container topology, three-stage prod images, ci.yml/publish.yml split) retained. Task breakdown covers platform only. Plugin-specific task breakdowns (Tasks, Splitify) are maintained in their respective repositories.\*

--- a/docs/sovereign-proposal-plan-srs.md
+++ b/docs/sovereign-proposal-plan-srs.md
@@ -1,4 +1,5 @@
 # Sovereign
+
 ## Project Concept · Project Plan · Software Requirements Specification
 
 **Version:** 0.6
@@ -66,11 +67,13 @@ Sovereign is open source, privacy-first, and designed to be owned entirely by th
 ### 1.2 Problem Statement
 
 **For individuals and small teams:**
+
 - Productivity tools are scattered across many services, most of them owned by large companies with no meaningful privacy commitment.
 - Paid licenses accumulate quickly. Closed-source tools offer no auditability.
 - Developers who want to build personal tools face the same bootstrapping cost every time: auth, user management, database setup, email, deployment.
 
 **For developers specifically:**
+
 - Building a new app from scratch requires repeating the same platform layer — auth, sessions, storage abstractions, mailer — for every project.
 - Deploying independent tools separately leads to fragmented infrastructure with no shared identity or unified interface.
 
@@ -87,6 +90,7 @@ Sovereign provides a self-hosted workspace runtime with:
 ### 1.4 Goals and Non-Goals
 
 **Goals (v1):**
+
 - Working self-hostable runtime with auth, plugin loading, and SDK
 - Three core plugins: Console (admin), Tasks, Splitify
 - SQLite by default, Postgres-ready
@@ -94,6 +98,7 @@ Sovereign provides a self-hosted workspace runtime with:
 - Clean plugin developer experience with manifest schema and SDK types
 
 **Non-Goals (v1):**
+
 - Multi-tenancy (multiple independent workspaces on one deployment)
 - Plugin sandboxing or process isolation
 - Native mobile app — deferred to post-v1. Planned as a universal Capacitor
@@ -141,22 +146,22 @@ Sovereign v3 is a clean rewrite. Two prior iterations existed:
 
 ### 2.2 Tech Stack
 
-| Layer | Choice | Rationale |
-|---|---|---|
-| Runtime framework | Next.js 15 (App Router) | SSR, server actions, API routes, PWA support — single framework for the whole runtime |
-| Language | TypeScript | Type safety across monorepo; SDK types are the plugin contract |
-| Monorepo tooling | Turborepo + pnpm workspaces | Task orchestration, build caching, clean package boundaries. pnpm enforces strict dependency declarations — no phantom dependencies across plugins. |
-| Auth | better-auth (wrapped in `apps/auth`) | Comprehensive, self-hostable, actively maintained |
-| Database ORM | Drizzle | Supports SQLite and Postgres with the same API; lightweight; good migration story |
-| Database default | SQLite (better-sqlite3) | Zero config for self-hosters; adequate for personal/small-team use |
-| Database production | PostgreSQL | Config change, not a code change |
-| Email | Custom `packages/mailer` (SMTP) | Self-hostable, no third-party email dependency |
-| UI components | `packages/ui` (shared component library) | Consistent design system across runtime and plugins |
-| CLI | `citty` + `consola`, TypeScript via `tsx` | `citty` is lightweight, TypeScript-first, handles nested subcommands cleanly. `consola` pairs naturally for consistent terminal output. `tsx` avoids a separate CLI compile step. Monorepo-internal in v1. |
-| Code quality | ESLint 9 (flat config) + `typescript-eslint` + Prettier + `simple-git-hooks` + `lint-staged` | ESLint for lint rules including the SDK import boundary; Prettier for formatting (separate concerns). `simple-git-hooks` + `lint-staged` enforce both on staged files at commit time. No Biome — ESLint is required for the custom boundary rule. |
-| Package bundler | `tsup` (esbuild-based) | Consistent build tool across all TypeScript packages. ESM output only. TypeScript declarations included. CSS files treated as external in `packages/ui` so the consuming Next.js app processes them. |
-| PWA | @ducanh2912/next-pwa | Service worker, installable shell |
-| Containerisation | Docker + Docker Compose | Standard self-hosting deployment path |
+| Layer               | Choice                                                                                       | Rationale                                                                                                                                                                                                                                         |
+| ------------------- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Runtime framework   | Next.js 15 (App Router)                                                                      | SSR, server actions, API routes, PWA support — single framework for the whole runtime                                                                                                                                                             |
+| Language            | TypeScript                                                                                   | Type safety across monorepo; SDK types are the plugin contract                                                                                                                                                                                    |
+| Monorepo tooling    | Turborepo + pnpm workspaces                                                                  | Task orchestration, build caching, clean package boundaries. pnpm enforces strict dependency declarations — no phantom dependencies across plugins.                                                                                               |
+| Auth                | better-auth (wrapped in `apps/auth`)                                                         | Comprehensive, self-hostable, actively maintained                                                                                                                                                                                                 |
+| Database ORM        | Drizzle                                                                                      | Supports SQLite and Postgres with the same API; lightweight; good migration story                                                                                                                                                                 |
+| Database default    | SQLite (better-sqlite3)                                                                      | Zero config for self-hosters; adequate for personal/small-team use                                                                                                                                                                                |
+| Database production | PostgreSQL                                                                                   | Config change, not a code change                                                                                                                                                                                                                  |
+| Email               | Custom `packages/mailer` (SMTP)                                                              | Self-hostable, no third-party email dependency                                                                                                                                                                                                    |
+| UI components       | `packages/ui` (shared component library)                                                     | Consistent design system across runtime and plugins                                                                                                                                                                                               |
+| CLI                 | `citty` + `consola`, TypeScript via `tsx`                                                    | `citty` is lightweight, TypeScript-first, handles nested subcommands cleanly. `consola` pairs naturally for consistent terminal output. `tsx` avoids a separate CLI compile step. Monorepo-internal in v1.                                        |
+| Code quality        | ESLint 9 (flat config) + `typescript-eslint` + Prettier + `simple-git-hooks` + `lint-staged` | ESLint for lint rules including the SDK import boundary; Prettier for formatting (separate concerns). `simple-git-hooks` + `lint-staged` enforce both on staged files at commit time. No Biome — ESLint is required for the custom boundary rule. |
+| Package bundler     | `tsup` (esbuild-based)                                                                       | Consistent build tool across all TypeScript packages. ESM output only. TypeScript declarations included. CSS files treated as external in `packages/ui` so the consuming Next.js app processes them.                                              |
+| PWA                 | @ducanh2912/next-pwa                                                                         | Service worker, installable shell                                                                                                                                                                                                                 |
+| Containerisation    | Docker + Docker Compose                                                                      | Standard self-hosting deployment path                                                                                                                                                                                                             |
 
 ### 2.3 Monorepo Structure
 
@@ -207,6 +212,7 @@ sovereign/
 ```
 
 **Plugin internal structure:**
+
 ```
 plugins/tasks/
 ├── manifest.json               # Plugin identity, permissions, routing
@@ -226,6 +232,7 @@ plugins/tasks/
 > This roadmap covers the Sovereign platform and runtime only. Reference plugin roadmaps (Tasks, Splitify) are maintained separately — see [2.5 Reference Plugins Roadmap](#25-reference-plugins-roadmap).
 
 **v0.3 — Foundation**
+
 - Monorepo scaffolding (Turborepo, packages, apps)
 - Auth server (`apps/auth`) with better-auth: login, logout, register, session
 - Runtime shell: layout, navigation, plugin launcher page
@@ -236,12 +243,14 @@ plugins/tasks/
 - Docker Compose for local dev
 
 **v0.4 — Console plugin**
+
 - User management (list, invite, role assignment, deactivate)
 - Plugin management (installed plugins, enable/disable)
 - Workspace settings (name, branding basics)
 - System health dashboard
 
 **v0.5 — Polish and self-hosting**
+
 - PWA shell
 - Docker production image
 - Self-hosting documentation
@@ -249,6 +258,7 @@ plugins/tasks/
 - `sv` CLI: `install`, `build`, `serve`, `plugin add/remove`
 
 **v1.0 — Public release**
+
 - Full documentation
 - Plugin developer guide
 - `registry/plugins.json` structure and contribution process
@@ -259,11 +269,13 @@ plugins/tasks/
 Tasks and Splitify are maintained in separate repositories under the Sovereign project. They are the primary reference implementations demonstrating how third-party plugins integrate with the Sovereign SDK. Their development tracks loosely alongside the platform but on independent timelines.
 
 **sovereign-plugin-tasks**
+
 - v0.1 — Task CRUD, list management, basic assignment; validates SDK `auth` and `db`
 - v0.2 — Due dates, filtering (all / active / completed)
 - v1.0 — Stable, documented reference plugin
 
 **sovereign-plugin-splitify**
+
 - v0.1 — Groups, expense entry, equal split, balance calculation; validates SDK `mailer`
 - v0.2 — Split by amount and percentage, settlement tracking, settlement summary email
 - v0.3 — Multi-currency entry (conversion deferred)
@@ -315,10 +327,10 @@ as separate containers on a shared internal network.
 Containers always listen on fixed **internal** ports; the **host** mapping
 differs by environment and is overridable via env. Defaults:
 
-| Service | Internal (container) | Dev (host) | Prod (host) | Env override |
-|---|---|---|---|---|
-| Runtime | 3000 | 3000 | 4000 | `RUNTIME_PORT` |
-| Auth | 3001 | 3001 | not exposed | `AUTH_PORT` |
+| Service | Internal (container) | Dev (host) | Prod (host) | Env override   |
+| ------- | -------------------- | ---------- | ----------- | -------------- |
+| Runtime | 3000                 | 3000       | 4000        | `RUNTIME_PORT` |
+| Auth    | 3001                 | 3001       | not exposed | `AUTH_PORT`    |
 
 In dev, `next dev` runs the two apps directly on 3000/3001. In production, the
 containers listen on 3000/3001 internally and the runtime is mapped to host
@@ -357,18 +369,21 @@ path in v1.
 A thin Next.js application (`apps/auth`) wrapping better-auth. It is the only process besides the runtime that runs in production.
 
 **Responsibilities:**
+
 - User login, logout, registration (with invite-only toggle)
 - Session management via httpOnly cookies
 - Session verification endpoint consumed by the runtime
 - JWT issuance signed with a shared secret
 
 **What it is not:**
+
 - An OAuth provider (future consideration)
 - A user directory (user records live in the platform database, not the auth server)
 
 The auth server and runtime share a `SOVEREIGN_AUTH_SECRET` environment variable.
 
 **Session verification strategy (phased):**
+
 - **v0.3:** The runtime middleware calls the auth server's `/api/verify` endpoint on each request. Simpler to implement and easier to reason about during early development.
 - **v0.5 target:** Local JWT verification using the shared secret — the runtime verifies tokens without a round-trip to the auth server. This is the correct long-term approach for performance and resilience.
 
@@ -381,6 +396,7 @@ AUTH-05 describes the v0.5 target state. The `/api/verify` endpoint (AUTH-06) re
 The runtime is the Sovereign Core — a Next.js 15 application using the App Router.
 
 **Responsibilities:**
+
 - Platform shell: navigation, launcher, layout
 - Request middleware: session verification, permission enforcement, plugin route protection
 - Plugin registry: reads `runtime/generated/registry.ts` to know which plugins are installed
@@ -395,11 +411,11 @@ Plugins are the primary unit of functionality in Sovereign. Everything beyond th
 
 **Plugin types:**
 
-| Type | Meaning | Location | `type` value |
-|---|---|---|---|
-| Platform | Ships in the monorepo, maintained by the Sovereign team | `/plugins/[id]/` (in repo) | `"platform"` |
-| Sovereign | Separate repo, maintained by the Sovereign team (e.g. Tasks, Splitify) | `/plugins/[id]/` (cloned by install script) | `"sovereign"` |
-| Community | Third-party, any maintainer, any source | `/plugins/[id]/` (cloned or manually placed) | `"community"` |
+| Type      | Meaning                                                                | Location                                     | `type` value  |
+| --------- | ---------------------------------------------------------------------- | -------------------------------------------- | ------------- |
+| Platform  | Ships in the monorepo, maintained by the Sovereign team                | `/plugins/[id]/` (in repo)                   | `"platform"`  |
+| Sovereign | Separate repo, maintained by the Sovereign team (e.g. Tasks, Splitify) | `/plugins/[id]/` (cloned by install script)  | `"sovereign"` |
+| Community | Third-party, any maintainer, any source                                | `/plugins/[id]/` (cloned or manually placed) | `"community"` |
 
 **Plugin activation:**
 A plugin is active if its directory exists under `/plugins`, its manifest validates successfully, and it appears in the generated registry. Adding a plugin requires running the install script (or manual placement) followed by a rebuild. Removing a plugin means removing its directory and rebuilding.
@@ -467,10 +483,7 @@ Every plugin contains a `manifest.json` at its root. The `packages/manifest` pac
   "type": "sovereign",
   "runtime": "native",
   "routePrefix": "/tasks",
-  "permissions": [
-    "auth:session",
-    "db:readWrite"
-  ],
+  "permissions": ["auth:session", "db:readWrite"],
   "adminOnly": false,
   "database": "shared",
   "shell": "default",
@@ -503,10 +516,10 @@ Plugins are Next.js route segments. A pre-build script (`scripts/generate-regist
 
 **Injection strategy varies by environment:**
 
-| Environment | Strategy | Rationale |
-|---|---|---|
-| Development (`NODE_ENV=development`) | Symlinks | Fast, no file duplication, changes in `/plugins` reflect immediately |
-| Production / CI (`NODE_ENV=production`) | Full copy | Hermetic, Docker-safe, no symlink resolution issues |
+| Environment                             | Strategy  | Rationale                                                            |
+| --------------------------------------- | --------- | -------------------------------------------------------------------- |
+| Development (`NODE_ENV=development`)    | Symlinks  | Fast, no file duplication, changes in `/plugins` reflect immediately |
+| Production / CI (`NODE_ENV=production`) | Full copy | Hermetic, Docker-safe, no symlink resolution issues                  |
 
 The generate script reads `NODE_ENV` and applies the appropriate strategy automatically. The Turborepo build pipeline always runs in production mode, so Docker builds always use copies.
 
@@ -521,13 +534,13 @@ There is no hot-swap or dynamic loading in v1. This is an intentional simplicity
 
 **Runtime types** (only `native` implemented in v1):
 
-| Type | Description | SDK Access |
-|---|---|---|
-| `native` | Next.js route segment, build-time composed into the runtime | Full SDK package |
-| `static` | Pre-built SPA bundle (Vite, Vue, Angular, etc), served as static assets by the runtime, iframe-mounted in the shell | REST API |
-| `iframe-local` | Separate local server process, iframe-mounted in the shell | `postMessage` |
-| `iframe-remote` | Remotely hosted app, iframe-mounted in the shell | `postMessage` |
-| `external` | Deep link only, no embedding. Sovereign acts purely as a launcher entry point | None |
+| Type            | Description                                                                                                         | SDK Access       |
+| --------------- | ------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `native`        | Next.js route segment, build-time composed into the runtime                                                         | Full SDK package |
+| `static`        | Pre-built SPA bundle (Vite, Vue, Angular, etc), served as static assets by the runtime, iframe-mounted in the shell | REST API         |
+| `iframe-local`  | Separate local server process, iframe-mounted in the shell                                                          | `postMessage`    |
+| `iframe-remote` | Remotely hosted app, iframe-mounted in the shell                                                                    | `postMessage`    |
+| `external`      | Deep link only, no embedding. Sovereign acts purely as a launcher entry point                                       | None             |
 
 > **Note:** `native` is the only runtime type implemented in v1. All other runtime types are declared for forward-compatibility and architectural planning purposes. Their specifications, behaviour, and SDK access mechanisms are subject to change before implementation.
 
@@ -559,6 +572,7 @@ A single TypeScript codebase for both iOS and Android. The shell's logic is
 minimal: instance URL configuration on first launch, persistent URL storage,
 WebView loading, and native permission declarations. Capacitor is chosen over
 Hotwire Native (Swift + Kotlin) because:
+
 - Single codebase — no native language required from contributors
 - Rich plugin ecosystem (`@capacitor/camera`, `@capacitor/push-notifications`,
   `@capacitor/biometric-auth` etc.) covering device APIs beyond Web standards
@@ -568,11 +582,11 @@ Hotwire Native (Swift + Kotlin) because:
 
 **Device API strategy — three tiers:**
 
-| Tier | Technology | Examples | Works in browser too? |
-|---|---|---|---|
-| Web APIs | Standard browser APIs, work natively in WebView | GPS (`navigator.geolocation`), camera/mic (`getUserMedia`), accelerometer, Web Push | ✅ |
-| Capacitor plugins | JS bridge to native code, richer access and better UX | Native photo picker, APNs/FCM push, Face ID / fingerprint, background location, haptics | ❌ (native shell only) |
-| SDK abstraction | `sdk.device.*` detects environment, routes to correct tier | `sdk.device.getLocation()`, `sdk.device.capturePhoto()` | ✅ (falls back to Web API) |
+| Tier              | Technology                                                 | Examples                                                                                | Works in browser too?      |
+| ----------------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------- | -------------------------- |
+| Web APIs          | Standard browser APIs, work natively in WebView            | GPS (`navigator.geolocation`), camera/mic (`getUserMedia`), accelerometer, Web Push     | ✅                         |
+| Capacitor plugins | JS bridge to native code, richer access and better UX      | Native photo picker, APNs/FCM push, Face ID / fingerprint, background location, haptics | ❌ (native shell only)     |
+| SDK abstraction   | `sdk.device.*` detects environment, routes to correct tier | `sdk.device.getLocation()`, `sdk.device.capturePhoto()`                                 | ✅ (falls back to Web API) |
 
 Plugin developers use `sdk.device.*` only — they never call Web APIs or
 Capacitor plugins directly. The SDK implementation picks the right tier based
@@ -591,10 +605,10 @@ independently of the platform.
 
 **Roles** follow a namespaced pattern: `platform:` prefix for platform-level roles. This scales to plugin-level roles in the future (`tasks:admin`, `splitify:owner` etc.) without naming conflicts.
 
-| Role | Description |
-|---|---|
-| `platform:user` | Assigned to every user by default on registration. Access to installed plugins and own profile. |
-| `platform:admin` | Full platform access. Manages users, plugins, and tenant configuration. |
+| Role             | Description                                                                                     |
+| ---------------- | ----------------------------------------------------------------------------------------------- |
+| `platform:user`  | Assigned to every user by default on registration. Access to installed plugins and own profile. |
+| `platform:admin` | Full platform access. Manages users, plugins, and tenant configuration.                         |
 
 The first user to register on a fresh instance is automatically assigned `platform:admin`. All subsequent users receive `platform:user` by default and can be promoted by an admin via Console.
 
@@ -602,14 +616,14 @@ The first user to register on a fresh instance is automatically assigned `platfo
 
 Capabilities are hardcoded per role in v1 — defined in the runtime, not stored in the database. The data model is designed to support database-driven capability assignment in a future version without requiring a schema change.
 
-| Capability | `platform:user` | `platform:admin` |
-|---|---|---|
-| `plugin:access` — access installed and enabled plugins | ✓ | ✓ |
-| `profile:manage` — manage own profile and credentials | ✓ | ✓ |
-| `console:access` — access the Console plugin | ✗ | ✓ |
-| `user:manage` — invite, deactivate, and assign roles to users | ✗ | ✓ |
-| `plugin:manage` — install, remove, enable, disable plugins | ✗ | ✓ |
-| `tenant:configure` — configure tenant settings | ✗ | ✓ |
+| Capability                                                    | `platform:user` | `platform:admin` |
+| ------------------------------------------------------------- | --------------- | ---------------- |
+| `plugin:access` — access installed and enabled plugins        | ✓               | ✓                |
+| `profile:manage` — manage own profile and credentials         | ✓               | ✓                |
+| `console:access` — access the Console plugin                  | ✗               | ✓                |
+| `user:manage` — invite, deactivate, and assign roles to users | ✗               | ✓                |
+| `plugin:manage` — install, remove, enable, disable plugins    | ✗               | ✓                |
+| `tenant:configure` — configure tenant settings                | ✗               | ✓                |
 
 Capabilities use the same namespaced pattern as roles and connect directly to the manifest system — a plugin declaring `"adminOnly": true` in its manifest maps to requiring `console:access` capability at the middleware level.
 
@@ -617,61 +631,61 @@ Granular per-user capability overrides and per-plugin role assignments are expli
 
 ### 4.2 Functional Requirements — Platform
 
-| ID | Requirement |
-|---|---|
-| PLT-01 | The runtime must render a launcher/home page listing all installed and enabled plugins the current user has access to. |
-| PLT-02 | The runtime must enforce session authentication on all plugin routes. Unauthenticated requests redirect to the login page. |
-| PLT-03 | The runtime must enforce `platform:admin` role on all Console routes. Non-admin authenticated requests receive a 403. |
-| PLT-04 | The runtime must read installed plugins from `runtime/generated/registry.ts` at startup. |
-| PLT-05 | The runtime must apply all pending database migrations (platform + plugins) on startup before accepting requests. |
-| PLT-06 | The runtime must expose platform config (tenant name, feature flags) via `sdk.platform.getConfig()`. |
-| PLT-07 | The pre-build generate script must validate all plugin manifests and fail the build if any manifest is invalid. |
+| ID     | Requirement                                                                                                                      |
+| ------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| PLT-01 | The runtime must render a launcher/home page listing all installed and enabled plugins the current user has access to.           |
+| PLT-02 | The runtime must enforce session authentication on all plugin routes. Unauthenticated requests redirect to the login page.       |
+| PLT-03 | The runtime must enforce `platform:admin` role on all Console routes. Non-admin authenticated requests receive a 403.            |
+| PLT-04 | The runtime must read installed plugins from `runtime/generated/registry.ts` at startup.                                         |
+| PLT-05 | The runtime must apply all pending database migrations (platform + plugins) on startup before accepting requests.                |
+| PLT-06 | The runtime must expose platform config (tenant name, feature flags) via `sdk.platform.getConfig()`.                             |
+| PLT-07 | The pre-build generate script must validate all plugin manifests and fail the build if any manifest is invalid.                  |
 | PLT-08 | The platform shell must include a consistent navigation component showing the active plugin and links to all accessible plugins. |
-| PLT-09 | The runtime must be installable as a PWA from a supported browser. |
-| PLT-10 | Plugin SDK boundary violations (direct imports from `runtime/src`) must be caught by ESLint at CI. |
+| PLT-09 | The runtime must be installable as a PWA from a supported browser.                                                               |
+| PLT-10 | Plugin SDK boundary violations (direct imports from `runtime/src`) must be caught by ESLint at CI.                               |
 
 ### 4.3 Functional Requirements — Auth
 
-| ID | Requirement |
-|---|---|
-| AUTH-01 | Users must be able to log in with email and password. |
-| AUTH-02 | Users must be able to log out, invalidating their session. |
-| AUTH-03 | Registration must support an invite-only toggle. When enabled, only users with a valid invite token can register. When disabled, open registration is permitted. |
-| AUTH-04 | Sessions must be persisted via httpOnly cookies. |
+| ID      | Requirement                                                                                                                                                                                                                                     |
+| ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| AUTH-01 | Users must be able to log in with email and password.                                                                                                                                                                                           |
+| AUTH-02 | Users must be able to log out, invalidating their session.                                                                                                                                                                                      |
+| AUTH-03 | Registration must support an invite-only toggle. When enabled, only users with a valid invite token can register. When disabled, open registration is permitted.                                                                                |
+| AUTH-04 | Sessions must be persisted via httpOnly cookies.                                                                                                                                                                                                |
 | AUTH-05 | The runtime middleware must call `/api/verify` on the auth server for session verification in v0.3. From v0.5, the runtime must verify session tokens locally using the shared secret without a round-trip to the auth server on every request. |
-| AUTH-06 | The auth server must expose a `/api/verify` endpoint for explicit token verification when needed. |
-| AUTH-07 | Password reset via email must be supported. |
-| AUTH-08 | The first user to register on a fresh instance must receive the `platform:admin` role automatically. All subsequent users receive `platform:user` by default. |
+| AUTH-06 | The auth server must expose a `/api/verify` endpoint for explicit token verification when needed.                                                                                                                                               |
+| AUTH-07 | Password reset via email must be supported.                                                                                                                                                                                                     |
+| AUTH-08 | The first user to register on a fresh instance must receive the `platform:admin` role automatically. All subsequent users receive `platform:user` by default.                                                                                   |
 
 ### 4.4 Functional Requirements — Console Plugin
 
-| ID | Requirement |
-|---|---|
-| CON-01 | Console is accessible only to users with the `platform:admin` role (`console:access` capability). |
-| CON-02 | Admin must be able to view a list of all registered users with their role, status, and join date. |
-| CON-03 | Admin must be able to invite new users by email (generates an invite token, sends invite email). |
-| CON-04 | Admin must be able to deactivate and reactivate user accounts. |
-| CON-05 | Admin must be able to change a user's role between `platform:admin` and `platform:user`. |
-| CON-06 | Admin must be able to view all installed plugins, their version, and their enabled/disabled status. |
-| CON-07 | Admin must be able to enable or disable an installed plugin (disabling hides it from the launcher and blocks its routes). |
-| CON-08 | Admin must be able to configure tenant settings: tenant name. |
+| ID     | Requirement                                                                                                                                                                   |
+| ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| CON-01 | Console is accessible only to users with the `platform:admin` role (`console:access` capability).                                                                             |
+| CON-02 | Admin must be able to view a list of all registered users with their role, status, and join date.                                                                             |
+| CON-03 | Admin must be able to invite new users by email (generates an invite token, sends invite email).                                                                              |
+| CON-04 | Admin must be able to deactivate and reactivate user accounts.                                                                                                                |
+| CON-05 | Admin must be able to change a user's role between `platform:admin` and `platform:user`.                                                                                      |
+| CON-06 | Admin must be able to view all installed plugins, their version, and their enabled/disabled status.                                                                           |
+| CON-07 | Admin must be able to enable or disable an installed plugin (disabling hides it from the launcher and blocks its routes).                                                     |
+| CON-08 | Admin must be able to configure tenant settings: tenant name.                                                                                                                 |
 | CON-09 | Console must display a system health summary: runtime version, database type and connection status, auth server status, disk usage (SQLite file size or Postgres connection). |
-| CON-10 | Admin must be able to toggle invite-only registration from Console without editing environment config. |
+| CON-10 | Admin must be able to toggle invite-only registration from Console without editing environment config.                                                                        |
 
 ### 4.5 Non-Functional Requirements
 
-| ID | Requirement |
-|---|---|
-| NFR-01 | The full stack must be self-hostable on a single machine with Docker Compose. |
-| NFR-02 | No external service dependency for core functionality. Email is optional (SMTP config). |
-| NFR-03 | Database must be switchable between SQLite and PostgreSQL via environment configuration with no code changes. |
-| NFR-04 | The SDK public API must be stable across patch versions. Breaking changes require a minor version bump and a migration note. |
-| NFR-05 | All plugin manifests must be validated at build time. An invalid manifest must fail the build. |
-| NFR-06 | Plugin code must not import from `runtime/src` directly. ESLint enforces this. |
-| NFR-07 | The runtime must start and be ready to serve requests within 10 seconds on modest hardware (2-core VPS, 1GB RAM). |
+| ID     | Requirement                                                                                                                          |
+| ------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+| NFR-01 | The full stack must be self-hostable on a single machine with Docker Compose.                                                        |
+| NFR-02 | No external service dependency for core functionality. Email is optional (SMTP config).                                              |
+| NFR-03 | Database must be switchable between SQLite and PostgreSQL via environment configuration with no code changes.                        |
+| NFR-04 | The SDK public API must be stable across patch versions. Breaking changes require a minor version bump and a migration note.         |
+| NFR-05 | All plugin manifests must be validated at build time. An invalid manifest must fail the build.                                       |
+| NFR-06 | Plugin code must not import from `runtime/src` directly. ESLint enforces this.                                                       |
+| NFR-07 | The runtime must start and be ready to serve requests within 10 seconds on modest hardware (2-core VPS, 1GB RAM).                    |
 | NFR-08 | Authentication tokens must use signed JWTs. Secrets must be configurable via environment variables and must not have default values. |
-| NFR-09 | All user passwords must be hashed with a strong adaptive algorithm (bcrypt or argon2, as provided by better-auth). |
-| NFR-10 | The project must include a documented upgrade path between versions (migration guide in docs). |
+| NFR-09 | All user passwords must be hashed with a strong adaptive algorithm (bcrypt or argon2, as provided by better-auth).                   |
+| NFR-10 | The project must include a documented upgrade path between versions (migration guide in docs).                                       |
 
 ### 4.6 Out of Scope (v1)
 
@@ -713,17 +727,17 @@ interface SovereignManifest {
   // Database isolation preference
   // "shared"   — uses the platform database (default, v1 behaviour)
   // "isolated" — requests a separate database instance (declared but not implemented in v1)
-  database?: "shared" | "isolated";
+  database?: 'shared' | 'isolated';
 
   // Plugin type — determines origin and trust level
   // "platform"  — ships in the monorepo, maintained by the Sovereign team
   // "sovereign" — separate repo, maintained by the Sovereign team (e.g. Tasks, Splitify)
   // "community" — third-party, any maintainer, any source
-  type: "platform" | "sovereign" | "community";
+  type: 'platform' | 'sovereign' | 'community';
 
   // How the plugin is rendered (only "native" implemented in v1)
   // All types except "native" are subject to change before implementation
-  runtime: "native" | "static" | "iframe-local" | "iframe-remote" | "external";
+  runtime: 'native' | 'static' | 'iframe-local' | 'iframe-remote' | 'external';
 
   // URL prefix for the plugin under the runtime
   routePrefix: string;
@@ -734,7 +748,7 @@ interface SovereignManifest {
   // Shell layout preference
   // "default" — full shell (sidebar on desktop, header + footer on mobile). Applied when field is omitted.
   // "minimal" — shell chrome hidden entirely, content area only. Useful for immersive or full-bleed plugins.
-  shell?: "default" | "minimal";
+  shell?: 'default' | 'minimal';
 
   // If true, plugin requires platform:admin role (console:access capability)
   adminOnly?: boolean;
@@ -749,50 +763,50 @@ interface SovereignManifest {
 }
 
 type Permission =
-  | "auth:session"
-  | "db:readWrite"
-  | "db:readOnly"
-  | "mailer:send"
-  | "storage:readWrite"       // not implemented v1
-  | "notifications:send"      // not implemented v1
-  | "events:publish"          // not implemented v1
-  | "events:subscribe"        // not implemented v1
-  | "admin:*";                // grants admin-only routes. Equivalent to declaring adminOnly: true in the manifest — the middleware maps adminOnly to this capability check. Prefer adminOnly in the manifest; admin:* in permissions is for future fine-grained plugin-level admin scopes.
+  | 'auth:session'
+  | 'db:readWrite'
+  | 'db:readOnly'
+  | 'mailer:send'
+  | 'storage:readWrite' // not implemented v1
+  | 'notifications:send' // not implemented v1
+  | 'events:publish' // not implemented v1
+  | 'events:subscribe' // not implemented v1
+  | 'admin:*'; // grants admin-only routes. Equivalent to declaring adminOnly: true in the manifest — the middleware maps adminOnly to this capability check. Prefer adminOnly in the manifest; admin:* in permissions is for future fine-grained plugin-level admin scopes.
 ```
 
 ---
 
 ## 6. Decision Log
 
-| Date | Decision | Rationale |
-|---|---|---|
-| Jun 2026 | Plugin type field renamed from `source` to `type`; values changed to `platform`, `sovereign`, `community` | `source` described origin mechanics, not plugin classification. `type` is semantically cleaner. `sovereign` distinguishes Sovereign-maintained external plugins from true third-party community plugins. `workspace` reserved as a future user-facing concept — likely an organisational layer within a tenant (one tenant may have multiple workspaces), distinct from the deployment/tenant boundary. |
-| Jun 2026 | Drizzle ORM over Prisma | Lighter, supports SQLite and Postgres with same API, better fit for Next.js server actions. |
-| Jun 2026 | Single-tenant per deployment in v1 | Target use case is personal/small-group. Multi-tenancy adds complexity with no near-term benefit. `tenant_id` included in schema for future path. |
-| Jun 2026 | Console as core plugin, not a separate app | Consistent with plugin architecture. Avoids running a third Next.js process. Admin scope enforced by middleware. |
-| Jun 2026 | SQLite default, Postgres optional | Zero-config for self-hosters. Postgres switch is an environment config change only. |
-| Jun 2026 | SDK packages under MIT, runtime under AGPL-3.0 | Lowers barrier for plugin developers while protecting the core runtime. |
-| Jun 2026 | Code formatting: Prettier; linting: ESLint 9 flat config + typescript-eslint; pre-commit: simple-git-hooks + lint-staged | ESLint is required for the custom `no-restricted-imports` SDK boundary rule — Biome has no equivalent plugin system yet, making a hybrid setup necessary. Prettier and ESLint handle separate concerns (formatting vs correctness); `eslint-config-prettier` resolves conflicts. `simple-git-hooks` is chosen over Husky — no install script, no shell files, single `package.json` entry. `lint-staged` scopes hooks to staged files only for speed. `.editorconfig` provides editor-level baseline independent of tooling. |
-| Jun 2026 | Native mobile app deferred to post-v1; approach decided | PWA covers the install-from-browser use case for v1. Native app is planned post-v1 as a universal Capacitor shell — one App Store binary, user enters their instance URL on first launch. Same pattern as Nextcloud, Bitwarden, Element. Deferred due to scope, not technical dead end. |
-| Jun 2026 | Capacitor chosen over Hotwire Native for mobile shell | Capacitor provides a single TypeScript codebase for iOS + Android, a rich plugin ecosystem for device APIs, and a standardised bridge pattern that integrates cleanly with the SDK. Hotwire Native gives a better raw native feel but requires Swift + Kotlin, no plugin ecosystem, and every device API integration is a custom bridge. For a minimal shell (URL config + WebView) the cross-platform and ecosystem benefits of Capacitor outweigh the native-feel advantage of Hotwire Native. |
-| Jun 2026 | Device APIs exposed via `sdk.device.*`; three-tier implementation strategy | Web APIs (geolocation, getUserMedia etc.) work natively in WebViews and cover most cases. Capacitor plugins cover the remainder (native photo picker, APNs/FCM push, biometric auth, haptics). Plugin developers use `sdk.device.*` only — the SDK detects the environment and routes to the correct tier. Plugins are portable across browser, PWA, and native shell without changes. |
-| Jun 2026 | Plugin schema isolation via table name prefix | Simpler than Postgres schemas. One migration runner, one connection, no cross-plugin query complexity. |
-| Jun 2026 | `packages/ui` uses CSS custom properties + CSS Modules; no Tailwind | Tailwind creates ongoing content-scan config maintenance across all plugins, cannot ship pre-built CSS from a shared library, and fights component abstraction. CSS custom properties (plain `.css` files) are universally consumable — plugin developers reference tokens from any CSS without a JS import. CSS Modules are built into Next.js with no extra deps, RSC-safe, and familiar. Two-tier token architecture: primitives (raw scale) + semantic (contextual meaning, `--sv-color-surface` etc.). All tokens prefixed `--sv-*` — consistent with `sv` CLI identity, short, unambiguous. Semantic layer is the tenant-theming surface (CON-08); primitives stay fixed. |
-| Jun 2026 | `sv` CLI built with `citty` + `consola`, TypeScript via `tsx`; monorepo-internal in v1 | `citty` is lightweight, TypeScript-first, and maps cleanly to the `sv plugin add/remove` nested command structure. `consola` is the natural pairing for consistent terminal output (info/success/warn/error). Running via `tsx` keeps the CLI consistent with `scripts/` and avoids a separate compile step. CLI is not distributed as a standalone npm package in v1 — self-hosters run it from their cloned repo. Global install deferred. |
-| Jun 2026 | Three-tier build model: tsup for packages, `next build` for apps, generate script for plugin composition | Packages (db, manifest, mailer, ui, sdk) are compiled with `tsup` — fast, consistent, ESM output with TypeScript declarations. Apps (runtime, auth) use `next build`. Plugins are not compiled independently — the generate script source-composes them into the runtime, and they are compiled as part of the runtime's `next build`. Turborepo orchestrates the correct order. |
-| Jun 2026 | ESM only for all package output | Next.js 15, Vite, and current tooling handle ESM natively. CJS compat shims add complexity with no benefit for this stack. All packages output ESM. |
-| Jun 2026 | npm-published packages: `@sovereignfs/sdk` and `@sovereignfs/ui` only | `sdk` is the plugin↔platform contract — external plugin developers must install it. `ui` is the design system — plugin developers install it to use components and tokens. All other packages (db, manifest, mailer, tsconfig) are workspace-internal infrastructure; publishing them would expose platform internals with no benefit. They are marked `"private": true`. |
-| Jun 2026 | Single owned npm scope `@sovereignfs/*` for all packages | A split scope was considered (public `@commonsengine/sovereign-*` + internal `@sovereign/*`) and rejected: the internal `@sovereign/*` alias references an npm scope owned by a third party, which is a latent dependency-confusion footgun (safe only while every internal dependency stays `workspace:*` and `private`). Owning one scope and using it everywhere closes that gap. `@sovereign` is taken on npm and `@sovereignos`/`-stack`/`-core` collide with existing products, so `@sovereignfs` is the owned scope (`fs` = *federated systems*, signalling the project's long-term federated direction; federation itself remains a post-v1 non-goal per §1.4). One scope means one mental model, simpler tooling globs, and no rename if an internal package is ever published. The publish/no-publish boundary is enforced by `"private": true` in each package's `package.json`, not by the scope name. |
-| Jun 2026 | `packages/ui` CSS strategy: CSS Modules marked external in tsup; token CSS shipped as plain files | tsup (esbuild) does not process CSS Modules — class name scoping requires the consuming bundler. All consumers of `packages/ui` are Next.js apps (the runtime and plugin route segments compiled by the runtime), so Next.js handles CSS Modules natively. Token CSS files (`.css`, not `.module.css`) are plain CSS and are shipped as-is; the runtime shell imports them globally so tokens are available everywhere without a per-plugin import. |
-| Jun 2026 | Plugin developers install `@sovereignfs/sdk` and `@sovereignfs/ui` from npm; all other packages are unreachable | Plugin developers add `@sovereignfs/sdk` and `@sovereignfs/ui` as dependencies in their plugin's `package.json`. They never interact with db, mailer, manifest, or tsconfig directly (those are `private`). This enforces the plugin contract boundary at the package level, complementing the ESLint `no-restricted-imports` rule. |
-| Jun 2026 | Dev DX: `transpilePackages` replaces `tsup --watch`; packages export TypeScript source for workspace consumption | In dev, all workspace packages expose their TypeScript source via `exports: { ".": "./src/index.ts" }`. The consuming Next.js apps (runtime and apps/auth) list all workspace packages in `transpilePackages` in their `next.config.ts`. Next.js/SWC compiles package source directly as part of its own compilation pass — no intermediate `dist/` build, no watch process. Changes to any package trigger HMR in the consuming app instantly. tsup is production-only (generates `dist/` for npm publish and Docker builds). |
-| Jun 2026 | `resolve.symlinks: false` in runtime webpack config for plugin HMR | In dev, plugins are symlinked into `runtime/app/plugins/[id]/` by the generate script. Webpack's default behaviour resolves symlinks to their real filesystem path before setting up file watchers, which breaks HMR — changes to `plugins/[id]/app/` are not detected. Setting `config.resolve.symlinks = false` makes webpack use the symlink path as-is; file changes in the plugin source directory propagate through the symlink and trigger HMR correctly. |
-| Jun 2026 | Generate script runs once on dev startup (sync) then enters watch mode; no manual `pnpm generate` needed | The runtime's `dev` script runs `tsx scripts/generate-registry.ts` synchronously on startup to create/update plugin symlinks, then starts the Next.js dev server. The generate script also supports a `--watch` flag for ongoing plugin directory monitoring. Developers never need to run `pnpm generate` manually during a dev session — the startup sequence handles it. Adding a new plugin directory during a running dev session triggers automatic re-linking. |
-| Jun 2026 | Docker Compose is the sole supported deployment path; PM2 dropped | Two containers (runtime + auth) on one Compose file. Docker's own restart policy supervises processes — no in-container PM2. PM2 as a bare-Node alternative was considered and dropped to keep the supported surface small; it can be reintroduced post-v1 if there is demand. Next.js `output: 'standalone'` makes each app a self-contained `node server.js`. |
-| Jun 2026 | Auth server is internal-only; runtime is the only externally exposed service | The auth container is never host-mapped — it is reachable only on the internal Docker network via `SOVEREIGN_AUTH_URL` (`http://auth:3001`). The runtime is the single public entry point, facing the reverse proxy. This removes the auth surface from the public network. |
-| Jun 2026 | Fixed internal ports (3000 runtime / 3001 auth); host ports differ by env (4000/4001 default in prod) | Containers always listen on 3000/3001 internally; the dev-vs-prod distinction is a host port mapping concern, not an app config change. Production host defaults are 4000 (runtime) and 4001 (auth, though auth is not host-mapped). Overridable via `RUNTIME_PORT` / `AUTH_PORT`. |
-| Jun 2026 | npm publishing: per-package version tags trigger a CI publish job | `@sovereignfs/sdk` and `@sovereignfs/ui` have independent release cycles (SDK changes can be breaking; UI is mostly additive), so they are released on per-package tags (`sdk-v*`, `ui-v*`) rather than a single repo-wide tag. A GitHub Actions job builds the tagged package with tsup and runs `pnpm publish` using a `NODE_AUTH_TOKEN` secret. No other packages are published. |
+| Date     | Decision                                                                                                                 | Rationale                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| -------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Jun 2026 | Plugin type field renamed from `source` to `type`; values changed to `platform`, `sovereign`, `community`                | `source` described origin mechanics, not plugin classification. `type` is semantically cleaner. `sovereign` distinguishes Sovereign-maintained external plugins from true third-party community plugins. `workspace` reserved as a future user-facing concept — likely an organisational layer within a tenant (one tenant may have multiple workspaces), distinct from the deployment/tenant boundary.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| Jun 2026 | Drizzle ORM over Prisma                                                                                                  | Lighter, supports SQLite and Postgres with same API, better fit for Next.js server actions.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| Jun 2026 | Single-tenant per deployment in v1                                                                                       | Target use case is personal/small-group. Multi-tenancy adds complexity with no near-term benefit. `tenant_id` included in schema for future path.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| Jun 2026 | Console as core plugin, not a separate app                                                                               | Consistent with plugin architecture. Avoids running a third Next.js process. Admin scope enforced by middleware.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| Jun 2026 | SQLite default, Postgres optional                                                                                        | Zero-config for self-hosters. Postgres switch is an environment config change only.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| Jun 2026 | SDK packages under MIT, runtime under AGPL-3.0                                                                           | Lowers barrier for plugin developers while protecting the core runtime.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| Jun 2026 | Code formatting: Prettier; linting: ESLint 9 flat config + typescript-eslint; pre-commit: simple-git-hooks + lint-staged | ESLint is required for the custom `no-restricted-imports` SDK boundary rule — Biome has no equivalent plugin system yet, making a hybrid setup necessary. Prettier and ESLint handle separate concerns (formatting vs correctness); `eslint-config-prettier` resolves conflicts. `simple-git-hooks` is chosen over Husky — no install script, no shell files, single `package.json` entry. `lint-staged` scopes hooks to staged files only for speed. `.editorconfig` provides editor-level baseline independent of tooling.                                                                                                                                                                                                                                                                                                                                                                                       |
+| Jun 2026 | Native mobile app deferred to post-v1; approach decided                                                                  | PWA covers the install-from-browser use case for v1. Native app is planned post-v1 as a universal Capacitor shell — one App Store binary, user enters their instance URL on first launch. Same pattern as Nextcloud, Bitwarden, Element. Deferred due to scope, not technical dead end.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| Jun 2026 | Capacitor chosen over Hotwire Native for mobile shell                                                                    | Capacitor provides a single TypeScript codebase for iOS + Android, a rich plugin ecosystem for device APIs, and a standardised bridge pattern that integrates cleanly with the SDK. Hotwire Native gives a better raw native feel but requires Swift + Kotlin, no plugin ecosystem, and every device API integration is a custom bridge. For a minimal shell (URL config + WebView) the cross-platform and ecosystem benefits of Capacitor outweigh the native-feel advantage of Hotwire Native.                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| Jun 2026 | Device APIs exposed via `sdk.device.*`; three-tier implementation strategy                                               | Web APIs (geolocation, getUserMedia etc.) work natively in WebViews and cover most cases. Capacitor plugins cover the remainder (native photo picker, APNs/FCM push, biometric auth, haptics). Plugin developers use `sdk.device.*` only — the SDK detects the environment and routes to the correct tier. Plugins are portable across browser, PWA, and native shell without changes.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| Jun 2026 | Plugin schema isolation via table name prefix                                                                            | Simpler than Postgres schemas. One migration runner, one connection, no cross-plugin query complexity.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| Jun 2026 | `packages/ui` uses CSS custom properties + CSS Modules; no Tailwind                                                      | Tailwind creates ongoing content-scan config maintenance across all plugins, cannot ship pre-built CSS from a shared library, and fights component abstraction. CSS custom properties (plain `.css` files) are universally consumable — plugin developers reference tokens from any CSS without a JS import. CSS Modules are built into Next.js with no extra deps, RSC-safe, and familiar. Two-tier token architecture: primitives (raw scale) + semantic (contextual meaning, `--sv-color-surface` etc.). All tokens prefixed `--sv-*` — consistent with `sv` CLI identity, short, unambiguous. Semantic layer is the tenant-theming surface (CON-08); primitives stay fixed.                                                                                                                                                                                                                                    |
+| Jun 2026 | `sv` CLI built with `citty` + `consola`, TypeScript via `tsx`; monorepo-internal in v1                                   | `citty` is lightweight, TypeScript-first, and maps cleanly to the `sv plugin add/remove` nested command structure. `consola` is the natural pairing for consistent terminal output (info/success/warn/error). Running via `tsx` keeps the CLI consistent with `scripts/` and avoids a separate compile step. CLI is not distributed as a standalone npm package in v1 — self-hosters run it from their cloned repo. Global install deferred.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| Jun 2026 | Three-tier build model: tsup for packages, `next build` for apps, generate script for plugin composition                 | Packages (db, manifest, mailer, ui, sdk) are compiled with `tsup` — fast, consistent, ESM output with TypeScript declarations. Apps (runtime, auth) use `next build`. Plugins are not compiled independently — the generate script source-composes them into the runtime, and they are compiled as part of the runtime's `next build`. Turborepo orchestrates the correct order.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| Jun 2026 | ESM only for all package output                                                                                          | Next.js 15, Vite, and current tooling handle ESM natively. CJS compat shims add complexity with no benefit for this stack. All packages output ESM.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| Jun 2026 | npm-published packages: `@sovereignfs/sdk` and `@sovereignfs/ui` only                                                    | `sdk` is the plugin↔platform contract — external plugin developers must install it. `ui` is the design system — plugin developers install it to use components and tokens. All other packages (db, manifest, mailer, tsconfig) are workspace-internal infrastructure; publishing them would expose platform internals with no benefit. They are marked `"private": true`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| Jun 2026 | Single owned npm scope `@sovereignfs/*` for all packages                                                                 | A split scope was considered (public `@commonsengine/sovereign-*` + internal `@sovereign/*`) and rejected: the internal `@sovereign/*` alias references an npm scope owned by a third party, which is a latent dependency-confusion footgun (safe only while every internal dependency stays `workspace:*` and `private`). Owning one scope and using it everywhere closes that gap. `@sovereign` is taken on npm and `@sovereignos`/`-stack`/`-core` collide with existing products, so `@sovereignfs` is the owned scope (`fs` = _federated systems_, signalling the project's long-term federated direction; federation itself remains a post-v1 non-goal per §1.4). One scope means one mental model, simpler tooling globs, and no rename if an internal package is ever published. The publish/no-publish boundary is enforced by `"private": true` in each package's `package.json`, not by the scope name. |
+| Jun 2026 | `packages/ui` CSS strategy: CSS Modules marked external in tsup; token CSS shipped as plain files                        | tsup (esbuild) does not process CSS Modules — class name scoping requires the consuming bundler. All consumers of `packages/ui` are Next.js apps (the runtime and plugin route segments compiled by the runtime), so Next.js handles CSS Modules natively. Token CSS files (`.css`, not `.module.css`) are plain CSS and are shipped as-is; the runtime shell imports them globally so tokens are available everywhere without a per-plugin import.                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| Jun 2026 | Plugin developers install `@sovereignfs/sdk` and `@sovereignfs/ui` from npm; all other packages are unreachable          | Plugin developers add `@sovereignfs/sdk` and `@sovereignfs/ui` as dependencies in their plugin's `package.json`. They never interact with db, mailer, manifest, or tsconfig directly (those are `private`). This enforces the plugin contract boundary at the package level, complementing the ESLint `no-restricted-imports` rule.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| Jun 2026 | Dev DX: `transpilePackages` replaces `tsup --watch`; packages export TypeScript source for workspace consumption         | In dev, all workspace packages expose their TypeScript source via `exports: { ".": "./src/index.ts" }`. The consuming Next.js apps (runtime and apps/auth) list all workspace packages in `transpilePackages` in their `next.config.ts`. Next.js/SWC compiles package source directly as part of its own compilation pass — no intermediate `dist/` build, no watch process. Changes to any package trigger HMR in the consuming app instantly. tsup is production-only (generates `dist/` for npm publish and Docker builds).                                                                                                                                                                                                                                                                                                                                                                                     |
+| Jun 2026 | `resolve.symlinks: false` in runtime webpack config for plugin HMR                                                       | In dev, plugins are symlinked into `runtime/app/plugins/[id]/` by the generate script. Webpack's default behaviour resolves symlinks to their real filesystem path before setting up file watchers, which breaks HMR — changes to `plugins/[id]/app/` are not detected. Setting `config.resolve.symlinks = false` makes webpack use the symlink path as-is; file changes in the plugin source directory propagate through the symlink and trigger HMR correctly.                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| Jun 2026 | Generate script runs once on dev startup (sync) then enters watch mode; no manual `pnpm generate` needed                 | The runtime's `dev` script runs `tsx scripts/generate-registry.ts` synchronously on startup to create/update plugin symlinks, then starts the Next.js dev server. The generate script also supports a `--watch` flag for ongoing plugin directory monitoring. Developers never need to run `pnpm generate` manually during a dev session — the startup sequence handles it. Adding a new plugin directory during a running dev session triggers automatic re-linking.                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| Jun 2026 | Docker Compose is the sole supported deployment path; PM2 dropped                                                        | Two containers (runtime + auth) on one Compose file. Docker's own restart policy supervises processes — no in-container PM2. PM2 as a bare-Node alternative was considered and dropped to keep the supported surface small; it can be reintroduced post-v1 if there is demand. Next.js `output: 'standalone'` makes each app a self-contained `node server.js`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| Jun 2026 | Auth server is internal-only; runtime is the only externally exposed service                                             | The auth container is never host-mapped — it is reachable only on the internal Docker network via `SOVEREIGN_AUTH_URL` (`http://auth:3001`). The runtime is the single public entry point, facing the reverse proxy. This removes the auth surface from the public network.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| Jun 2026 | Fixed internal ports (3000 runtime / 3001 auth); host ports differ by env (4000/4001 default in prod)                    | Containers always listen on 3000/3001 internally; the dev-vs-prod distinction is a host port mapping concern, not an app config change. Production host defaults are 4000 (runtime) and 4001 (auth, though auth is not host-mapped). Overridable via `RUNTIME_PORT` / `AUTH_PORT`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| Jun 2026 | npm publishing: per-package version tags trigger a CI publish job                                                        | `@sovereignfs/sdk` and `@sovereignfs/ui` have independent release cycles (SDK changes can be breaking; UI is mostly additive), so they are released on per-package tags (`sdk-v*`, `ui-v*`) rather than a single repo-wide tag. A GitHub Actions job builds the tagged package with tsup and runs `pnpm publish` using a `NODE_AUTH_TOKEN` secret. No other packages are published.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 
 ---
 
-*Version 0.10 — June 2026. Changes from v0.9: npm scope finalised as a single owned scope `@sovereignfs/*` for all packages (replacing the earlier split of `@commonsengine/sovereign-*` public + `@sovereign/*` internal — the latter aliased a third-party scope, a dependency-confusion risk). Only `@sovereignfs/sdk` and `@sovereignfs/ui` are published; internal packages are `"private": true`. Decision log updated.*
+_Version 0.10 — June 2026. Changes from v0.9: npm scope finalised as a single owned scope `@sovereignfs/_`for all packages (replacing the earlier split of`@commonsengine/sovereign-_`public +`@sovereign/_`internal — the latter aliased a third-party scope, a dependency-confusion risk). Only`@sovereignfs/sdk`and`@sovereignfs/ui`are published; internal packages are`"private": true`. Decision log updated.\*

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,0 +1,71 @@
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+import eslintConfigPrettier from 'eslint-config-prettier';
+import globals from 'globals';
+
+export default tseslint.config(
+  // Ignore generated, build, and dependency output across the monorepo.
+  {
+    ignores: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/.next/**',
+      '**/.turbo/**',
+      'runtime/app/plugins/**',
+      'runtime/generated/**',
+    ],
+  },
+
+  // Baseline JS recommended rules.
+  js.configs.recommended,
+
+  // TypeScript: recommended + strict (non-type-checked).
+  ...tseslint.configs.strict,
+
+  // Shared language options for all source files.
+  {
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module',
+      globals: {
+        ...globals.node,
+        ...globals.browser,
+      },
+    },
+  },
+
+  // SDK boundary rule (NFR-06): plugins may only use @sovereignfs/sdk and
+  // @sovereignfs/ui. They must never reach into runtime internals or the
+  // workspace-internal packages. This is load-bearing — never disable it.
+  {
+    files: ['plugins/**/*.{ts,tsx}'],
+    rules: {
+      '@typescript-eslint/no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['**/runtime/src', '**/runtime/src/*'],
+              message: 'Plugins must not import runtime internals. Use @sovereignfs/sdk instead.',
+            },
+            {
+              group: [
+                '@sovereignfs/db',
+                '@sovereignfs/db/*',
+                '@sovereignfs/manifest',
+                '@sovereignfs/manifest/*',
+                '@sovereignfs/mailer',
+                '@sovereignfs/mailer/*',
+              ],
+              message:
+                'Plugins may only use @sovereignfs/sdk and @sovereignfs/ui, not internal platform packages.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+
+  // Disable stylistic rules that conflict with Prettier. Must come last.
+  eslintConfigPrettier,
+);

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "sovereign",
   "version": "0.3.0",
   "private": true,
+  "type": "module",
   "description": "Sovereign — a modular, self-hostable workspace runtime.",
   "license": "AGPL-3.0",
   "packageManager": "pnpm@11.5.2",
@@ -11,15 +12,40 @@
   "scripts": {
     "build": "turbo build",
     "dev": "turbo dev",
-    "lint": "turbo lint",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "typecheck": "turbo typecheck",
-    "install:plugins": "tsx scripts/install-plugins.ts"
+    "install:plugins": "tsx scripts/install-plugins.ts",
+    "prepare": "simple-git-hooks"
+  },
+  "simple-git-hooks": {
+    "pre-commit": "pnpm lint-staged"
+  },
+  "lint-staged": {
+    "*.{ts,tsx}": [
+      "prettier --write",
+      "eslint --fix"
+    ],
+    "*.{js,mjs,cjs,json,jsonc,css,md,yml,yaml}": [
+      "prettier --write"
+    ]
   },
   "devDependencies": {
+    "@eslint/js": "^9.18.0",
     "@sovereignfs/tsconfig": "workspace:*",
     "@types/node": "^22.10.2",
+    "eslint": "^9.18.0",
+    "eslint-config-prettier": "^10.0.0",
+    "globals": "^15.14.0",
+    "jiti": "^2.4.2",
+    "lint-staged": "^15.3.0",
+    "prettier": "^3.5.0",
+    "simple-git-hooks": "^2.11.1",
     "tsx": "^4.19.2",
     "turbo": "^2.3.3",
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "typescript-eslint": "^8.20.0"
   }
 }

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -4,7 +4,11 @@
   "private": true,
   "description": "Shared TypeScript configurations for the Sovereign monorepo.",
   "license": "AGPL-3.0",
-  "files": ["base.json", "nextjs.json", "library.json"],
+  "files": [
+    "base.json",
+    "nextjs.json",
+    "library.json"
+  ],
   "exports": {
     "./base.json": "./base.json",
     "./nextjs.json": "./nextjs.json",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,12 +8,36 @@ importers:
 
   .:
     devDependencies:
+      '@eslint/js':
+        specifier: ^9.18.0
+        version: 9.39.4
       '@sovereignfs/tsconfig':
         specifier: workspace:*
         version: link:packages/tsconfig
       '@types/node':
         specifier: ^22.10.2
         version: 22.19.20
+      eslint:
+        specifier: ^9.18.0
+        version: 9.39.4(jiti@2.7.0)
+      eslint-config-prettier:
+        specifier: ^10.0.0
+        version: 10.1.8(eslint@9.39.4(jiti@2.7.0))
+      globals:
+        specifier: ^15.14.0
+        version: 15.15.0
+      jiti:
+        specifier: ^2.4.2
+        version: 2.7.0
+      lint-staged:
+        specifier: ^15.3.0
+        version: 15.5.2
+      prettier:
+        specifier: ^3.5.0
+        version: 3.8.4
+      simple-git-hooks:
+        specifier: ^2.11.1
+        version: 2.13.1
       tsx:
         specifier: ^4.19.2
         version: 4.22.4
@@ -23,6 +47,9 @@ importers:
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.20.0
+        version: 8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
 
   packages/tsconfig: {}
 
@@ -184,6 +211,64 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.21.2':
+    resolution: {integrity: sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/config-helpers@0.4.2':
+    resolution: {integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/core@0.17.0':
+    resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/eslintrc@3.3.5':
+    resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/js@9.39.4':
+    resolution: {integrity: sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/object-schema@2.1.7':
+    resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.4.1':
+    resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@humanfs/core@0.19.2':
+    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.8':
+    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/types@0.15.0':
+    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
+
   '@turbo/darwin-64@2.9.16':
     resolution: {integrity: sha512-jLjApWTSNd7JZ5JaLYfelW1ytnGQOvB7ivl+2RD1xQvJTbi8I9gBjzcga7tDZVPyaxpl10YTfJt3BrYXR18KDw==}
     cpu: [x64]
@@ -214,18 +299,584 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
   '@types/node@22.19.20':
     resolution: {integrity: sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==}
+
+  '@typescript-eslint/eslint-plugin@8.61.0':
+    resolution: {integrity: sha512-bFNvl9ZczlVb+wR2Akszf3gHfKVj/8WanXaGJ3UstTA7brNKg0cNdk6X1Psu5V7MZ2oQtzZKOEzIUehaoxbDGw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.61.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/parser@8.61.0':
+    resolution: {integrity: sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/project-service@8.61.0':
+    resolution: {integrity: sha512-DV42F7MLJO6Rax7SK1yg43tcnEfGUrurSpSxKuVX+a3RCTzBlH3fuxprrOJXKCJGAaw82xXocikJ0uQaqwXgGA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/scope-manager@8.61.0':
+    resolution: {integrity: sha512-IWdXFHFSb6mlC3HPc7QsLDm5zYEbUla6trDEHf32D3/dnuUyXd87plScSNXSbm0/RxMvObpI17sv/EDTGrGZkA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.61.0':
+    resolution: {integrity: sha512-O5Amvdv9ztMpxpf+vmFULGG78IE6Qwdr3bCGvqwG4nwc9H2qXkOYJJnRbRHyMkQTjv1d03olqwwwzHLMqpFePQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.61.0':
+    resolution: {integrity: sha512-TuBiQYIkd97yBfInHCTKVYMbX4kvEmpOEuixIuzCU9p8BGT1SfyyO0d0IfDMbPIHcjn/hWnusUX5e8v5Xg+X8A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/types@8.61.0':
+    resolution: {integrity: sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.61.0':
+    resolution: {integrity: sha512-42zatd5qSvvcV1JdDBCLxYRznvP4eIHpPoZXdkPFnAmanA4FuZ5dibSnCBggY8hQnqajPpoGjXFdZ7fIJKQnlA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.61.0':
+    resolution: {integrity: sha512-3bzFt7ImFMW/jVYwJamDoe/dMOdFLSC6pom6rRjdh4SZJEYupyMzem8e7vKZLclLfpHjlwSAXOUxtKxGXUiLqA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.61.0':
+    resolution: {integrity: sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  brace-expansion@1.1.15:
+    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  cli-cursor@5.0.0:
+    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
+    engines: {node: '>=18'}
+
+  cli-truncate@4.0.0:
+    resolution: {integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==}
+    engines: {node: '>=18'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  colorette@2.0.20:
+    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
+  commander@13.1.0:
+    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
+    engines: {node: '>=18'}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
 
   esbuild@0.28.0:
     resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
     engines: {node: '>=18'}
     hasBin: true
 
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  eslint-config-prettier@10.1.8:
+    resolution: {integrity: sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==}
+    hasBin: true
+    peerDependencies:
+      eslint: '>=7.0.0'
+
+  eslint-scope@8.4.0:
+    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@9.39.4:
+    resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  execa@8.0.1:
+    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
+    engines: {node: '>=16.17'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
+
+  get-stream@8.0.1:
+    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
+    engines: {node: '>=16'}
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  globals@15.15.0:
+    resolution: {integrity: sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==}
+    engines: {node: '>=18'}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  human-signals@5.0.0:
+    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
+    engines: {node: '>=16.17.0'}
+
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@4.0.0:
+    resolution: {integrity: sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==}
+    engines: {node: '>=12'}
+
+  is-fullwidth-code-point@5.1.0:
+    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
+    engines: {node: '>=18'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  is-stream@3.0.0:
+    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
+
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+    hasBin: true
+
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
+
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lint-staged@15.5.2:
+    resolution: {integrity: sha512-YUSOLq9VeRNAo/CTaVmhGDKG+LBtA8KF1X4K5+ykMSwWST1vDxJRB2kv2COgLb1fvpCo+A/y9A0G0znNVmdx4w==}
+    engines: {node: '>=18.12.0'}
+    hasBin: true
+
+  listr2@8.3.3:
+    resolution: {integrity: sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ==}
+    engines: {node: '>=18.0.0'}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  log-update@6.1.0:
+    resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
+    engines: {node: '>=18'}
+
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
+  mimic-fn@4.0.0:
+    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
+    engines: {node: '>=12'}
+
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  npm-run-path@5.3.0:
+    resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  onetime@6.0.0:
+    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
+    engines: {node: '>=12'}
+
+  onetime@7.0.0:
+    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
+    engines: {node: '>=18'}
+
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  pidtree@0.6.1:
+    resolution: {integrity: sha512-e0F9AOF1JMrCfBsyJOwU9lNvQ0WtXTq0j/4jk0BQ5JSI9VAybPXmDpPRw/2FQ3e5d3ZFN1mLh7jW99m/jjaptw==}
+    engines: {node: '>=0.10'}
+    hasBin: true
+
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
+  prettier@3.8.4:
+    resolution: {integrity: sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
+  restore-cursor@5.1.0:
+    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
+    engines: {node: '>=18'}
+
+  rfdc@1.4.1:
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
+  semver@7.8.3:
+    resolution: {integrity: sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  simple-git-hooks@2.13.1:
+    resolution: {integrity: sha512-WszCLXwT4h2k1ufIXAgsbiTOazqqevFCIncOuUBZJ91DdvWcC5+OFkluWRQPrcuSYd8fjq+o2y1QfWqYMoAToQ==}
+    hasBin: true
+
+  slice-ansi@5.0.0:
+    resolution: {integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==}
+    engines: {node: '>=12'}
+
+  slice-ansi@7.1.2:
+    resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
+    engines: {node: '>=18'}
+
+  string-argv@0.3.2:
+    resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
+    engines: {node: '>=0.6.19'}
+
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
+  strip-final-newline@3.0.0:
+    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
+    engines: {node: '>=12'}
+
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
 
   tsx@4.22.4:
     resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
@@ -236,6 +887,17 @@ packages:
     resolution: {integrity: sha512-NqgRQy6j6dPYcdSdv0q1g9QsZg7SWg87RERM8otw/1AtKU2yTFVClOM7cbwKzOonZr/Ek1blTBucw64L9H0Bwg==}
     hasBin: true
 
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
+  typescript-eslint@8.61.0:
+    resolution: {integrity: sha512-8y31Rd0eGTrDKqhy6vT0HtzhN+YLjQizwX3aA3hPXP/ynSfnrBXcQY5IzsP9/DM7+klX4IUncZZjkchP0z+rUw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -243,6 +905,31 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
 
 snapshots:
 
@@ -324,6 +1011,68 @@ snapshots:
   '@esbuild/win32-x64@0.28.0':
     optional: true
 
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.7.0))':
+    dependencies:
+      eslint: 9.39.4(jiti@2.7.0)
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.21.2':
+    dependencies:
+      '@eslint/object-schema': 2.1.7
+      debug: 4.4.3
+      minimatch: 3.1.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.4.2':
+    dependencies:
+      '@eslint/core': 0.17.0
+
+  '@eslint/core@0.17.0':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/eslintrc@3.3.5':
+    dependencies:
+      ajv: 6.15.0
+      debug: 4.4.3
+      espree: 10.4.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.2.0
+      minimatch: 3.1.5
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/js@9.39.4': {}
+
+  '@eslint/object-schema@2.1.7': {}
+
+  '@eslint/plugin-kit@0.4.1':
+    dependencies:
+      '@eslint/core': 0.17.0
+      levn: 0.4.1
+
+  '@humanfs/core@0.19.2':
+    dependencies:
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
+    dependencies:
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
+
   '@turbo/darwin-64@2.9.16':
     optional: true
 
@@ -342,9 +1091,194 @@ snapshots:
   '@turbo/windows-arm64@2.9.16':
     optional: true
 
+  '@types/estree@1.0.9': {}
+
+  '@types/json-schema@7.0.15': {}
+
   '@types/node@22.19.20':
     dependencies:
       undici-types: 6.21.0
+
+  '@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.61.0
+      '@typescript-eslint/type-utils': 8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.61.0
+      eslint: 9.39.4(jiti@2.7.0)
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.61.0
+      '@typescript-eslint/types': 8.61.0
+      '@typescript-eslint/typescript-estree': 8.61.0(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.61.0
+      debug: 4.4.3
+      eslint: 9.39.4(jiti@2.7.0)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.61.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.61.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.61.0
+      debug: 4.4.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.61.0':
+    dependencies:
+      '@typescript-eslint/types': 8.61.0
+      '@typescript-eslint/visitor-keys': 8.61.0
+
+  '@typescript-eslint/tsconfig-utils@8.61.0(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
+  '@typescript-eslint/type-utils@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.61.0
+      '@typescript-eslint/typescript-estree': 8.61.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      debug: 4.4.3
+      eslint: 9.39.4(jiti@2.7.0)
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/types@8.61.0': {}
+
+  '@typescript-eslint/typescript-estree@8.61.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.61.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.61.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.61.0
+      '@typescript-eslint/visitor-keys': 8.61.0
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.8.3
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
+      '@typescript-eslint/scope-manager': 8.61.0
+      '@typescript-eslint/types': 8.61.0
+      '@typescript-eslint/typescript-estree': 8.61.0(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.7.0)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.61.0':
+    dependencies:
+      '@typescript-eslint/types': 8.61.0
+      eslint-visitor-keys: 5.0.1
+
+  acorn-jsx@5.3.2(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
+  acorn@8.16.0: {}
+
+  ajv@6.15.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
+
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
+
+  argparse@2.0.1: {}
+
+  balanced-match@1.0.2: {}
+
+  balanced-match@4.0.4: {}
+
+  brace-expansion@1.1.15:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
+  callsites@3.1.0: {}
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  chalk@5.6.2: {}
+
+  cli-cursor@5.0.0:
+    dependencies:
+      restore-cursor: 5.1.0
+
+  cli-truncate@4.0.0:
+    dependencies:
+      slice-ansi: 5.0.0
+      string-width: 7.2.0
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  colorette@2.0.20: {}
+
+  commander@13.1.0: {}
+
+  concat-map@0.0.1: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-is@0.1.4: {}
+
+  emoji-regex@10.6.0: {}
+
+  environment@1.1.0: {}
 
   esbuild@0.28.0:
     optionalDependencies:
@@ -375,8 +1309,372 @@ snapshots:
       '@esbuild/win32-ia32': 0.28.0
       '@esbuild/win32-x64': 0.28.0
 
+  escape-string-regexp@4.0.0: {}
+
+  eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)):
+    dependencies:
+      eslint: 9.39.4(jiti@2.7.0)
+
+  eslint-scope@8.4.0:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@4.2.1: {}
+
+  eslint-visitor-keys@5.0.1: {}
+
+  eslint@9.39.4(jiti@2.7.0):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.21.2
+      '@eslint/config-helpers': 0.4.2
+      '@eslint/core': 0.17.0
+      '@eslint/eslintrc': 3.3.5
+      '@eslint/js': 9.39.4
+      '@eslint/plugin-kit': 0.4.1
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.9
+      ajv: 6.15.0
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.7.0
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      eslint-visitor-keys: 4.2.1
+
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
+
+  esutils@2.0.3: {}
+
+  eventemitter3@5.0.4: {}
+
+  execa@8.0.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 8.0.1
+      human-signals: 5.0.0
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.3.0
+      onetime: 6.0.0
+      signal-exit: 4.1.0
+      strip-final-newline: 3.0.0
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.4.2
+      keyv: 4.5.4
+
+  flatted@3.4.2: {}
+
   fsevents@2.3.3:
     optional: true
+
+  get-east-asian-width@1.6.0: {}
+
+  get-stream@8.0.1: {}
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  globals@14.0.0: {}
+
+  globals@15.15.0: {}
+
+  has-flag@4.0.0: {}
+
+  human-signals@5.0.0: {}
+
+  ignore@5.3.2: {}
+
+  ignore@7.0.5: {}
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  imurmurhash@0.1.4: {}
+
+  is-extglob@2.1.1: {}
+
+  is-fullwidth-code-point@4.0.0: {}
+
+  is-fullwidth-code-point@5.1.0:
+    dependencies:
+      get-east-asian-width: 1.6.0
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-number@7.0.0: {}
+
+  is-stream@3.0.0: {}
+
+  isexe@2.0.0: {}
+
+  jiti@2.7.0: {}
+
+  js-yaml@4.2.0:
+    dependencies:
+      argparse: 2.0.1
+
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+
+  lilconfig@3.1.3: {}
+
+  lint-staged@15.5.2:
+    dependencies:
+      chalk: 5.6.2
+      commander: 13.1.0
+      debug: 4.4.3
+      execa: 8.0.1
+      lilconfig: 3.1.3
+      listr2: 8.3.3
+      micromatch: 4.0.8
+      pidtree: 0.6.1
+      string-argv: 0.3.2
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - supports-color
+
+  listr2@8.3.3:
+    dependencies:
+      cli-truncate: 4.0.0
+      colorette: 2.0.20
+      eventemitter3: 5.0.4
+      log-update: 6.1.0
+      rfdc: 1.4.1
+      wrap-ansi: 9.0.2
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
+  lodash.merge@4.6.2: {}
+
+  log-update@6.1.0:
+    dependencies:
+      ansi-escapes: 7.3.0
+      cli-cursor: 5.0.0
+      slice-ansi: 7.1.2
+      strip-ansi: 7.2.0
+      wrap-ansi: 9.0.2
+
+  merge-stream@2.0.0: {}
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
+
+  mimic-fn@4.0.0: {}
+
+  mimic-function@5.0.1: {}
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
+
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.15
+
+  ms@2.1.3: {}
+
+  natural-compare@1.4.0: {}
+
+  npm-run-path@5.3.0:
+    dependencies:
+      path-key: 4.0.0
+
+  onetime@6.0.0:
+    dependencies:
+      mimic-fn: 4.0.0
+
+  onetime@7.0.0:
+    dependencies:
+      mimic-function: 5.0.1
+
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  path-exists@4.0.0: {}
+
+  path-key@3.1.1: {}
+
+  path-key@4.0.0: {}
+
+  picomatch@2.3.2: {}
+
+  picomatch@4.0.4: {}
+
+  pidtree@0.6.1: {}
+
+  prelude-ls@1.2.1: {}
+
+  prettier@3.8.4: {}
+
+  punycode@2.3.1: {}
+
+  resolve-from@4.0.0: {}
+
+  restore-cursor@5.1.0:
+    dependencies:
+      onetime: 7.0.0
+      signal-exit: 4.1.0
+
+  rfdc@1.4.1: {}
+
+  semver@7.8.3: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  signal-exit@4.1.0: {}
+
+  simple-git-hooks@2.13.1: {}
+
+  slice-ansi@5.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 4.0.0
+
+  slice-ansi@7.1.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
+  string-argv@0.3.2: {}
+
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
+
+  strip-final-newline@3.0.0: {}
+
+  strip-json-comments@3.1.1: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
+  ts-api-utils@2.5.0(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
 
   tsx@4.22.4:
     dependencies:
@@ -393,6 +1691,41 @@ snapshots:
       '@turbo/windows-64': 2.9.16
       '@turbo/windows-arm64': 2.9.16
 
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
+  typescript-eslint@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.61.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.61.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.7.0)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  word-wrap@1.2.5: {}
+
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+
+  yaml@2.9.0: {}
+
+  yocto-queue@0.1.0: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,10 +1,13 @@
 packages:
-  - "apps/*"
-  - "packages/*"
-  - "plugins/*"
-  - "runtime"
+  - 'apps/*'
+  - 'packages/*'
+  - 'plugins/*'
+  - 'runtime'
 
 # Transitive deps allowed to run install scripts (pnpm blocks them by default).
 # esbuild (via tsx) needs its postinstall to link the platform binary.
+# simple-git-hooks: declined — the root `prepare` script installs the git hooks
+# explicitly, so the dependency's own postinstall is redundant.
 allowBuilds:
   esbuild: true
+  simple-git-hooks: false

--- a/prettier.config.ts
+++ b/prettier.config.ts
@@ -1,0 +1,12 @@
+import type { Config } from 'prettier';
+
+const config: Config = {
+  singleQuote: true,
+  semi: true,
+  trailingComma: 'all',
+  printWidth: 100,
+  tabWidth: 2,
+  proseWrap: 'preserve',
+};
+
+export default config;

--- a/scripts/install-plugins.ts
+++ b/scripts/install-plugins.ts
@@ -10,18 +10,18 @@
  *
  * See: docs/sovereign-implementation-tasks.md — Task 0.5.00
  */
-import { existsSync } from "node:fs";
-import { resolve } from "node:path";
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
 
-const CONFIG_PATH = resolve(process.cwd(), "sovereign.plugins.json");
+const CONFIG_PATH = resolve(process.cwd(), 'sovereign.plugins.json');
 
 function main(): void {
   if (existsSync(CONFIG_PATH)) {
     console.log(`[install-plugins] Found config at ${CONFIG_PATH}`);
   } else {
-    console.log("[install-plugins] No sovereign.plugins.json found at repo root.");
+    console.log('[install-plugins] No sovereign.plugins.json found at repo root.');
   }
-  console.log("[install-plugins] not yet implemented (see Task 0.5.00).");
+  console.log('[install-plugins] not yet implemented (see Task 0.5.00).');
 }
 
 main();


### PR DESCRIPTION
## What and why

Establishes the monorepo code-quality baseline **before** application code is
written, so every later task inherits it and nothing merges without passing it
(SRS NFR-06, PLT-10, §2.2; CLAUDE.md Code quality section). Critically, it wires
the **SDK import-boundary rule** from day one — the first line of plugin code is
already constrained.

Two commits, kept separate for reviewability:
1. **Tooling** — the configs, deps, scripts, and hooks.
2. **Formatting** — the one-time repo-wide `pnpm format` pass.

## Changes

**Commit 1 — tooling**
- `eslint.config.ts` — ESLint 9 flat config: `@eslint/js` recommended +
  `typescript-eslint` strict (non-type-checked), `eslint-config-prettier` last.
  **SDK boundary rule (NFR-06):** `plugins/**` may not import `runtime/src` or
  the internal `@sovereignfs/{db,manifest,mailer}` packages — only
  `@sovereignfs/sdk` and `@sovereignfs/ui`.
- `prettier.config.ts` — single quotes, semicolons, trailing commas (all),
  printWidth 100, tabWidth 2, `proseWrap: preserve`.
- `.editorconfig`, `.prettierignore`.
- `package.json` — devDeps (eslint, typescript-eslint, prettier, `jiti` to load
  the `.ts` configs on the Node 20 floor, eslint-config-prettier, globals,
  simple-git-hooks, lint-staged); scripts `format` / `format:check` / `lint` /
  `lint:fix`; `prepare` hook; `simple-git-hooks` → `lint-staged`; `type: module`.
- `pnpm-workspace.yaml` — decline simple-git-hooks' redundant postinstall (the
  `prepare` script installs hooks explicitly; keeps `pnpm install` output clean).

**Commit 2 — formatting**
- Repo-wide Prettier pass. `proseWrap: preserve` keeps hand-wrapped prose intact,
  so the docs diff is table/marker normalisation only.
- CLAUDE.md Status section updated.

## Type of change
- [x] `chore` — tooling (no version bump)

## SRS reference
NFR-06 (SDK boundary), PLT-10, §2.2 Tech Stack. `.ts` configs + `jiti` and ESM
(`type: module`) align with the build-strategy decisions.

## Verification
- [x] `pnpm install` succeeds; pre-commit hook installed via `prepare`
- [x] `pnpm lint` — 0 errors/warnings
- [x] Boundary rule errors on both `runtime/src` and `@sovereignfs/db` imports in a `plugins/**` probe file
- [x] `pnpm format` → `pnpm format:check` clean: "All matched files use Prettier code style!"
- [x] Pre-commit hook **blocks** a real lint error (boundary violation → commit rejected and auto-reverted), while auto-fixing formatting

## Notes for reviewer
- **lint-staged** runs ESLint on `*.{ts,tsx}` only (ESLint can't lint css/json —
  a correction to the task's literal "ts/tsx/css/json" wording); Prettier handles
  the rest. Formatting is auto-fixed on commit; genuine lint errors block.
- Root `pnpm lint` runs `eslint .` directly — flat config + the repo-wide
  boundary rule operate cleanest from root; turbo's `lint` task stays for future
  per-package scripts.
- `typescript-eslint` is the non-type-checked **strict** tier; type-checked
  linting is a deliberate future upgrade once real TS source exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)