### PR TITLE
chore: pin shared dev tooling via pnpm catalog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,9 +311,16 @@ pnpm install:plugins    # clone declared sovereign/community plugins (stub until
 ## Environment notes
 
 - Node ≥20 (dev on 24.x), pnpm 11.5.2 (pinned via `packageManager`).
-- pnpm 11 blocks dependency build scripts by default. `esbuild` (via `tsx`) is
-  allowlisted in `pnpm-workspace.yaml` under `allowBuilds` — required, or `tsx`
-  has no native binary and pnpm's pre-script check fails.
+- pnpm 11 blocks dependency build scripts by default. `esbuild` (via `tsx`) and
+  `better-sqlite3` are allowlisted in `pnpm-workspace.yaml` under `allowBuilds`
+  — required for their native bindings. `simple-git-hooks` is set to `false`
+  there (the root `prepare` script installs the hooks instead).
+- **Shared dev tooling is pinned via the pnpm `catalog:`** in
+  `pnpm-workspace.yaml` (`typescript`, `tsup`). Every package references them as
+  `"typescript": "catalog:"` / `"tsup": "catalog:"` — never a literal version.
+  This stops `pnpm add` from floating one package onto a different major (it
+  once pulled TS 6 into a single package). When adding `typescript`/`tsup` to a
+  new package, use `catalog:`; to bump the version, edit the catalog once.
 
 ## Status
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "simple-git-hooks": "^2.11.1",
     "tsx": "^4.19.2",
     "turbo": "^2.3.3",
-    "typescript": "^5.7.2",
+    "typescript": "catalog:",
     "typescript-eslint": "^8.20.0",
     "vitest": "^4.1.8"
   }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -21,7 +21,7 @@
     "@sovereignfs/tsconfig": "workspace:*",
     "@types/better-sqlite3": "^7.6.13",
     "@types/pg": "^8.20.0",
-    "tsup": "^8.5.1",
-    "typescript": "^5.9.3"
+    "tsup": "catalog:",
+    "typescript": "catalog:"
   }
 }

--- a/packages/manifest/package.json
+++ b/packages/manifest/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@sovereignfs/tsconfig": "workspace:*",
-    "tsup": "^8.5.1",
-    "typescript": "^5.7.2"
+    "tsup": "catalog:",
+    "typescript": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,15 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    tsup:
+      specifier: ^8.5.1
+      version: 8.5.1
+    typescript:
+      specifier: ^5.9.3
+      version: 5.9.3
+
 importers:
 
   .:
@@ -45,7 +54,7 @@ importers:
         specifier: ^2.3.3
         version: 2.9.16
       typescript:
-        specifier: ^5.7.2
+        specifier: 'catalog:'
         version: 5.9.3
       typescript-eslint:
         specifier: ^8.20.0
@@ -76,10 +85,10 @@ importers:
         specifier: ^8.20.0
         version: 8.20.0
       tsup:
-        specifier: ^8.5.1
+        specifier: 'catalog:'
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.9.3
+        specifier: 'catalog:'
         version: 5.9.3
 
   packages/manifest:
@@ -92,10 +101,10 @@ importers:
         specifier: workspace:*
         version: link:../tsconfig
       tsup:
-        specifier: ^8.5.1
+        specifier: 'catalog:'
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.7.2
+        specifier: 'catalog:'
         version: 5.9.3
 
   packages/tsconfig: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,14 @@ packages:
   - 'plugins/*'
   - 'runtime'
 
+# Single source of truth for shared dev tooling versions. Packages reference
+# these with `"typescript": "catalog:"` etc. so a `pnpm add` can never float one
+# package onto a different major. Add a dep here when it is used by more than one
+# package (the toolchain), not for package-specific deps (zod, drizzle, …).
+catalog:
+  typescript: ^5.9.3
+  tsup: ^8.5.1
+
 # Transitive deps allowed to run install scripts (pnpm blocks them by default).
 # esbuild (via tsx) needs its postinstall to link the platform binary.
 # better-sqlite3 needs its postinstall to fetch/compile the native binding.


### PR DESCRIPTION
## What and why

`pnpm add` had floated `typescript` across packages onto three different ranges
(root `^5.7.2`, `packages/db` `^5.9.3`, and `packages/manifest` had briefly
resolved to **6.0.3** — a second TS major that typescript-eslint 8 doesn't
support). This introduces a pnpm `catalog:` as the single source of truth for
shared dev tooling, so a stray `pnpm add` can never split the toolchain again.

## Changes

- **`pnpm-workspace.yaml`** — `catalog:` with `typescript: ^5.9.3` and
  `tsup: ^8.5.1`.
- **Root, `packages/db`, `packages/manifest`** — reference the toolchain as
  `"typescript": "catalog:"` and `"tsup": "catalog:"` (no literal versions).
- **`CLAUDE.md`** — documents the convention (new packages use `catalog:` for
  typescript/tsup; bump the version in one place) and refreshes the
  `allowBuilds` note (better-sqlite3 allowed; simple-git-hooks declined).

Scope is the **cross-package toolchain only** — package-specific deps
(`zod`, `drizzle-orm`, `better-sqlite3`, `pg`) stay in their own `package.json`.

## Type of change
- [x] `chore` — tooling / dependency hygiene (no version bump)

## Verification
- [x] Clean reinstall (`rm -rf node_modules && pnpm install`) yields exactly **one** `typescript` (5.9.3) and one `tsup` variant — the orphaned TS 6.0.3 store entries are gone
- [x] Lockfile has a `catalogs:` section and `specifier: 'catalog:'` resolutions; no `6.0.3` references remain
- [x] `pnpm typecheck` (db + manifest), `pnpm test` (7/7), `pnpm lint`, `pnpm format:check`, `pnpm build` all pass

## Notes for reviewer
This is the follow-up flagged in PR #7. The payoff lands on the next task —
`packages/mailer` (0.3.06) will add `typescript`/`tsup` as `catalog:` from the
start rather than floating new versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)