### PR TITLE
Add Docker Compose dev setup and self-hosting guide

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,27 @@
+# Dependencies — reinstalled inside the image
+node_modules
+**/node_modules
+
+# Next.js build output — rebuilt inside the image
+.next
+**/.next
+
+# Generated plugin directory — recreated by the generate script
+runtime/app/plugins
+
+# SQLite databases — mounted as a volume so data persists across rebuilds
+data/*.db
+
+# Environment files — injected at container runtime, never baked in
+.env
+.env.local
+.env.*.local
+
+# Version control
+.git
+.gitignore
+
+# Editor artefacts
+.vscode
+.idea
+*.swp

--- a/.env.example
+++ b/.env.example
@@ -44,3 +44,14 @@ SMTP_FROM=Sovereign <dev@localhost>
 # Mailpit host-port overrides (optional; defaults 1025 / 8025)
 # MAILPIT_SMTP_PORT=1025
 # MAILPIT_UI_PORT=8025
+
+# --- Docker Compose ---
+# Host port the runtime container is mapped to.
+# Default in dev (docker-compose.yml):      3000
+# Default in prod (docker-compose.prod.yml): 4000
+# RUNTIME_PORT=3000
+
+# Note: SOVEREIGN_AUTH_URL above is for native dev (localhost:3001).
+# When using Docker Compose, the runtime container overrides this to
+# http://auth:3001 (internal Docker network) automatically — do not change
+# SOVEREIGN_AUTH_URL for Docker use.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -324,6 +324,14 @@ pnpm install:plugins    # clone declared sovereign/community plugins (stub until
   `8025`), point `SMTP_HOST` at it, and read mail at `http://localhost:8025`.
   Email is off by default (SMTP_HOST unset → `send()` no-ops). See
   CONTRIBUTING — "Email in development".
+- **Docker Compose runs the full stack locally.** `docker compose up --build`
+  starts runtime (`:3000`), auth (internal-only, no host port), and Mailpit.
+  The runtime container hardcodes `SOVEREIGN_AUTH_URL=http://auth:3001` (the
+  internal service name) — do not set this var in `.env` for Docker use. For
+  production use `docker-compose.prod.yml` (standalone file, runtime on `:4000`,
+  no Mailpit). See `docs/self-hosting.md`. The `Dockerfile` (runtime) and
+  `apps/auth/Dockerfile` are dev-quality; Task 0.5.02 replaces them with
+  multi-stage standalone builds.
 - **Runtime dev = generate then `next dev`.** The runtime's `dev` script runs
   `scripts/generate-registry.ts` (composes plugins, writes the registry) before
   starting Next on `:3000`. Both apps load the single root `.env` via
@@ -360,7 +368,8 @@ pnpm install:plugins    # clone declared sovereign/community plugins (stub until
 - ✅ Chore — manifest `icon` field + plugin specs (Console/Launcher/Account/Tasks/Splitify/Plainwrite) + shell sidebar architecture (merged to `main`).
 - ✅ Task 0.3.09 — `apps/auth` (self-contained better-auth server) (merged to `main`).
 - ▶️ In review: Tasks 0.3.10 + 0.3.11 — Runtime scaffold + generate script (combined).
-- ⏳ Next: Task 0.3.12 — Docker Compose for local dev.
+- ▶️ In review: Task 0.3.12 — Docker Compose for local dev.
+- ⏳ Next: Task 0.4.01 — Console plugin scaffold.
 - ⏳ Spec complete: Launcher platform plugin (`docs/plugins/launcher.md`) — Task 0.4.05.
 - ⏳ Spec complete: Account platform plugin (`docs/plugins/account.md`) — Task 0.4.06.
 - ⏳ Spec complete: Shell sidebar three-section architecture (PLT-11–PLT-15, SRS updated).

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:24-alpine
+
+# Native build tools required for better-sqlite3 bindings
+RUN apk add --no-cache python3 make g++
+
+RUN corepack enable && corepack prepare pnpm@11.5.2 --activate
+
+WORKDIR /app
+
+COPY . .
+
+RUN pnpm install --frozen-lockfile
+
+# Generate plugin registry and symlinks before building
+RUN pnpm run generate
+
+RUN pnpm --filter @sovereignfs/runtime build
+
+EXPOSE 3000
+
+CMD ["pnpm", "--filter", "@sovereignfs/runtime", "start"]

--- a/apps/auth/Dockerfile
+++ b/apps/auth/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:24-alpine
+
+# Native build tools required for better-sqlite3 bindings
+RUN apk add --no-cache python3 make g++
+
+RUN corepack enable && corepack prepare pnpm@11.5.2 --activate
+
+WORKDIR /app
+
+# Build context is the monorepo root — required for pnpm workspace resolution.
+# In docker-compose.yml: build: { context: ., dockerfile: apps/auth/Dockerfile }
+COPY . .
+
+RUN pnpm install --frozen-lockfile
+
+RUN pnpm --filter @sovereignfs/auth build
+
+EXPOSE 3001
+
+CMD ["pnpm", "--filter", "@sovereignfs/auth", "start"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,61 @@
+# Production Docker Compose.
+#
+# Usage:  docker compose -f docker-compose.prod.yml up -d
+#
+# Mailpit is dev-only and is absent here. Configure a real SMTP provider via
+# the SMTP_* environment variables in your .env file.
+#
+# The auth server is internal-only — it is not mapped to a host port. Place a
+# reverse proxy (nginx, Caddy, Traefik) in front of the runtime container and
+# route all traffic through it. See docs/self-hosting.md for full instructions.
+#
+# Quick start:
+#   cp .env.example .env            # fill in AUTH_SECRET and all required vars
+#   docker compose -f docker-compose.prod.yml up --build -d
+services:
+  auth:
+    build:
+      context: .
+      dockerfile: apps/auth/Dockerfile
+    container_name: sovereign-auth
+    expose:
+      - '3001'
+    restart: unless-stopped
+    environment:
+      AUTH_SECRET: '${AUTH_SECRET}'
+      AUTH_DATABASE_URL: '${AUTH_DATABASE_URL:-file:./data/auth.db}'
+      AUTH_INVITE_ONLY: '${AUTH_INVITE_ONLY:-false}'
+      AUTH_BASE_URL: '${AUTH_BASE_URL:-http://auth:3001}'
+      NEXT_PUBLIC_RUNTIME_URL: '${NEXT_PUBLIC_RUNTIME_URL}'
+    volumes:
+      - ./data:/app/data
+    networks:
+      - sovereign_net
+
+  runtime:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: sovereign-runtime
+    ports:
+      - '${RUNTIME_PORT:-4000}:3000'
+    restart: unless-stopped
+    environment:
+      SOVEREIGN_AUTH_URL: 'http://auth:3001'
+      DATABASE_URL: '${DATABASE_URL:-file:./data/sovereign.db}'
+      DB_DIALECT: '${DB_DIALECT:-sqlite}'
+      SMTP_HOST: '${SMTP_HOST:-}'
+      SMTP_PORT: '${SMTP_PORT:-587}'
+      SMTP_USER: '${SMTP_USER:-}'
+      SMTP_PASS: '${SMTP_PASS:-}'
+      SMTP_FROM: '${SMTP_FROM:-}'
+    volumes:
+      - ./data:/app/data
+    depends_on:
+      - auth
+    networks:
+      - sovereign_net
+
+networks:
+  sovereign_net:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,14 @@
 # Local development services.
 #
-# For now this provides Mailpit so email flows are testable in dev (see
-# CONTRIBUTING — "Email in development"). Task 0.3.12 adds the `runtime` and
-# `auth` app services to this same file once they exist. Mailpit is dev-only and
-# is intentionally absent from docker-compose.prod.yml.
+# Runs Mailpit (email capture), the auth server, and the runtime together on a
+# shared internal network. See docs/self-hosting.md for setup instructions.
+#
+# For active code development (hot-reload), use `pnpm dev` instead. This file
+# is for spinning up the full containerised stack locally.
+#
+# Quick start:
+#   cp .env.example .env          # fill in AUTH_SECRET at minimum
+#   docker compose up --build
 services:
   mailpit:
     image: axllent/mailpit:latest
@@ -16,3 +21,58 @@ services:
       # Accept mail without auth/TLS so the dev app can send freely.
       MP_SMTP_AUTH_ACCEPT_ANY: 'true'
       MP_SMTP_AUTH_ALLOW_INSECURE: 'true'
+    networks:
+      - sovereign_net
+
+  auth:
+    build:
+      context: .
+      dockerfile: apps/auth/Dockerfile
+    container_name: sovereign-auth
+    # Internal only — not reachable from the host, only from the runtime
+    # container via http://auth:3001 on the shared network.
+    expose:
+      - '3001'
+    environment:
+      AUTH_SECRET: '${AUTH_SECRET}'
+      AUTH_DATABASE_URL: '${AUTH_DATABASE_URL:-file:./data/auth.db}'
+      AUTH_INVITE_ONLY: '${AUTH_INVITE_ONLY:-false}'
+      # better-auth base URL — internal service address used for server-side
+      # cookie domain and callback construction.
+      AUTH_BASE_URL: '${AUTH_BASE_URL:-http://auth:3001}'
+      NEXT_PUBLIC_RUNTIME_URL: '${NEXT_PUBLIC_RUNTIME_URL:-http://localhost:3000}'
+    volumes:
+      - ./data:/app/data
+    networks:
+      - sovereign_net
+
+  runtime:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: sovereign-runtime
+    ports:
+      - '${RUNTIME_PORT:-3000}:3000'
+    environment:
+      # Overrides the .env value (which points to localhost for native dev).
+      # Inside Docker, the runtime reaches auth via the internal service name.
+      SOVEREIGN_AUTH_URL: 'http://auth:3001'
+      DATABASE_URL: '${DATABASE_URL:-file:./data/sovereign.db}'
+      DB_DIALECT: '${DB_DIALECT:-sqlite}'
+      # Email routes to the Mailpit service on the internal network.
+      SMTP_HOST: mailpit
+      SMTP_PORT: '${MAILPIT_SMTP_PORT:-1025}'
+      SMTP_USER: '${SMTP_USER:-}'
+      SMTP_PASS: '${SMTP_PASS:-}'
+      SMTP_FROM: '${SMTP_FROM:-Sovereign <dev@localhost>}'
+    volumes:
+      - ./data:/app/data
+    depends_on:
+      - auth
+      - mailpit
+    networks:
+      - sovereign_net
+
+networks:
+  sovereign_net:
+    driver: bridge

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,0 +1,186 @@
+# Self-hosting Sovereign
+
+Sovereign is designed to run on a single machine. Docker Compose is the
+canonical deployment path — two containers (runtime + auth) on a shared
+internal network, with the runtime exposed as the single public entry point.
+
+---
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) with the Compose plugin (v2.20+)
+- A domain name (or `localhost` for local-only use)
+- An SMTP provider for email (optional — email is off by default)
+
+---
+
+## Quick start (local machine)
+
+```bash
+# 1. Clone
+git clone https://github.com/CommonsEngine/Sovereign.git
+cd Sovereign
+
+# 2. Configure environment
+cp .env.example .env
+```
+
+Open `.env` and set at minimum:
+
+```env
+# Required — generate a secret with: openssl rand -base64 32
+AUTH_SECRET=your-secret-here
+
+# The public URL users hit in their browser (no trailing slash)
+NEXT_PUBLIC_RUNTIME_URL=http://localhost:3000
+```
+
+```bash
+# 3. Start
+docker compose up --build
+```
+
+The runtime is now at **http://localhost:3000**.
+
+Open it in your browser — the first user to register automatically becomes the
+platform admin. If `AUTH_INVITE_ONLY=true`, skip ahead to the
+[invite-only](#invite-only-registration) section.
+
+---
+
+## Service topology
+
+```
+Browser → localhost:3000 (runtime)
+                │
+                └─ internal network ──► auth:3001  (auth server)
+                                   ──► mailpit:1025 (dev email, SMTP)
+```
+
+The **auth server is not mapped to a host port** — it is only reachable on the
+internal Docker network. The runtime is the single public entry point. In
+production, place a reverse proxy (nginx, Caddy, Traefik) in front of the
+runtime container.
+
+---
+
+## Environment variables
+
+All variables live in a single `.env` at the repo root. Copy `.env.example`
+to get started — every variable is documented there.
+
+| Variable                  | Required | Default                      | Description                                                                                     |
+| ------------------------- | -------- | ---------------------------- | ----------------------------------------------------------------------------------------------- |
+| `AUTH_SECRET`             | **yes**  | —                            | Secret key for the auth server. Generate with `openssl rand -base64 32`. Never share or commit. |
+| `NEXT_PUBLIC_RUNTIME_URL` | **yes**  | `http://localhost:3000`      | Public URL of the runtime — used by the auth server to redirect users after login.              |
+| `AUTH_INVITE_ONLY`        | no       | `false`                      | When `true`, registration requires a valid invite token. The first user is exempt.              |
+| `AUTH_DATABASE_URL`       | no       | `file:./data/auth.db`        | Auth server database. SQLite file path or a `postgres://` URL.                                  |
+| `DATABASE_URL`            | no       | `file:./data/sovereign.db`   | Runtime database. SQLite file path or a `postgres://` URL.                                      |
+| `DB_DIALECT`              | no       | `sqlite`                     | Set to `postgres` when using PostgreSQL.                                                        |
+| `SMTP_HOST`               | no       | —                            | SMTP server host. Leave unset to disable email (the app still runs).                            |
+| `SMTP_PORT`               | no       | `587`                        | SMTP port.                                                                                      |
+| `SMTP_USER`               | no       | —                            | SMTP username.                                                                                  |
+| `SMTP_PASS`               | no       | —                            | SMTP password.                                                                                  |
+| `SMTP_FROM`               | no       | —                            | Sender address, e.g. `Sovereign <noreply@example.com>`.                                         |
+| `RUNTIME_PORT`            | no       | `3000` (dev) / `4000` (prod) | Host port the runtime container is mapped to.                                                   |
+| `SOVEREIGN_AUTH_SECRET`   | no       | —                            | Shared JWT secret for local session verification (v0.5+). Leave unset for now.                  |
+
+---
+
+## Data persistence
+
+SQLite databases and uploaded files are stored in the `./data/` directory,
+which is mounted as a volume in both the runtime and auth containers:
+
+```
+data/
+  sovereign.db   # Runtime platform database
+  auth.db        # Auth server identity database
+  avatars/       # User avatar uploads (Task 0.4.06)
+```
+
+Back up the `data/` directory to preserve all application state.
+
+---
+
+## Production deployment
+
+Use `docker-compose.prod.yml` for production. It differs from the dev file in
+three ways: the runtime host port defaults to `4000`, both services restart
+automatically on failure, and Mailpit is absent (configure real SMTP instead).
+
+```bash
+cp .env.example .env
+# Edit .env — set AUTH_SECRET, NEXT_PUBLIC_RUNTIME_URL, SMTP_*, etc.
+
+docker compose -f docker-compose.prod.yml up --build -d
+```
+
+### Reverse proxy
+
+The auth server is internal-only. To make the login flow work end-to-end from
+a browser, you need a reverse proxy that puts the runtime on your domain.
+A minimal **Caddy** example:
+
+```
+your-domain.com {
+    reverse_proxy localhost:4000
+}
+```
+
+With Caddy in front, the runtime handles all public traffic (including
+redirecting to the auth server's login page internally). TLS is handled by
+Caddy automatically.
+
+---
+
+## Email in development
+
+The dev Compose file includes [Mailpit](https://mailpit.axllent.org/) — a
+local SMTP server with a web inbox. It runs automatically alongside the other
+services. No configuration needed:
+
+- **SMTP:** `mailpit:1025` (internal) — already wired in the Compose file
+- **Web inbox:** http://localhost:8025
+
+To capture email when using `pnpm dev` (native, outside Docker):
+
+```env
+SMTP_HOST=localhost
+SMTP_PORT=1025
+```
+
+Then start Mailpit separately:
+
+```bash
+# Docker (standalone)
+docker run -p 1025:1025 -p 8025:8025 axllent/mailpit
+
+# Or native binary — see https://mailpit.axllent.org/docs/install/
+```
+
+---
+
+## Invite-only registration
+
+When `AUTH_INVITE_ONLY=true`, only users with a valid invite token can
+register. The first user is always exempt — they register normally and become
+the platform admin.
+
+After the first user registers, invite new users via the Console:
+`/console/users/invite` (Task 0.4.02).
+
+---
+
+## Upgrading
+
+See `docs/upgrade.md` for version-specific migration notes (Task 0.5.06).
+
+The general upgrade process:
+
+```bash
+git pull
+docker compose up --build -d   # or docker-compose.prod.yml for production
+```
+
+Migrations run automatically on startup.


### PR DESCRIPTION
## Summary

- Extends `docker-compose.yml` with `runtime` and `auth` services on a shared internal Docker network (`sovereign_net`). Auth is expose-only (no host port mapping); the runtime is host-mapped at `${RUNTIME_PORT:-3000}:3000`. The runtime service hardcodes `SOVEREIGN_AUTH_URL=http://auth:3001` so `/api/verify` calls resolve correctly within the container network, without changing the `.env` value that native dev uses.
- Adds `docker-compose.prod.yml` as a standalone production file: runtime host port defaults to `4000`, both services have `restart: unless-stopped`, Mailpit absent.
- Adds `Dockerfile` (runtime) and `apps/auth/Dockerfile` — monorepo-root build context, installs workspace deps, runs generate + build, starts with `next start`.
- Adds `.dockerignore` excluding `node_modules`, `.next`, generated plugin dirs, and SQLite databases (persisted via volume mount).
- Extends `.env.example` with `RUNTIME_PORT` and a note on Docker vs native `SOVEREIGN_AUTH_URL` usage.
- Adds `docs/self-hosting.md` — getting started guide covering prerequisites, quick start, service topology, environment variables reference, data persistence, production deployment with reverse proxy, dev email setup, and upgrade path.

Satisfies NFR-01 (self-hostable on a single machine with Docker Compose). See SRS §3.1 (Deployment Model) for the two-container topology and internal-only auth rationale.

## Test plan

- [x] `docker compose up --build` starts all three services (mailpit, auth, runtime) without errors
- [x] Runtime is reachable at `http://localhost:3000`
- [x] Auth container has no host port binding — `docker ps` shows no `0.0.0.0:3001` mapping
- [x] `pnpm format:check` passes
- [x] `pnpm lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)