### PR TITLE
Production Docker images from Next.js standalone output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,13 @@ they are authoritative over assumptions:
   show the output.
 - Never merge a PR automatically. Either wait for explicit instruction to merge,
   or ask for consent before doing so.
+- **Flag Docker-config impact immediately.** While building features or fixing
+  bugs, whenever a change requires updating the Docker setup (`Dockerfile`,
+  `apps/auth/Dockerfile`, `docker-compose.yml`, `docker-compose.prod.yml`,
+  `.dockerignore`) — e.g. a new/renamed env var, a new port, a new on-disk path
+  (writable dir or served asset dir), a new native dep, or anything affecting
+  `next build`/standalone output — call it out in the same turn and update the
+  relevant config (or ask), rather than letting it drift behind the code.
 - **Version bumps** are part of the PR — bump the relevant `package.json`(s)
   in the same branch, following semver tied to the change type:
   - `fix/` → **patch** (0.0.x)
@@ -216,6 +223,28 @@ pnpm lint:fix        # run ESLint with auto-fix
   production build (`next build`). The PWA assets and the `/offline` fallback
   are excluded from the middleware session gate (they must load without a
   session).
+- **Production images build from Next.js standalone output** (Task 0.5.02).
+  Both `next.config.ts` set `output: 'standalone'` **and**
+  `outputFileTracingRoot` to the monorepo root — required in a pnpm monorepo or
+  the trace misses workspace package files. The standalone tree mirrors the repo
+  layout, so the runner runs `node runtime/server.js` / `node apps/auth/server.js`
+  (not `next start`). The standalone server reads `PORT`/`HOSTNAME` env (the old
+  `next start --port` flag is gone): the runner sets `PORT` + `HOSTNAME=0.0.0.0`
+  (runtime 3000, auth 3001). `runtime/.next/static` and `runtime/public` (which
+  holds the generated PWA assets) must be **copied explicitly** into the runner —
+  standalone does not include them. Healthchecks use **`127.0.0.1`, not
+  `localhost`** (busybox `localhost`→`::1`, but the server binds IPv4
+  `0.0.0.0` → connection refused on `localhost`). The runtime's `HEALTHCHECK`
+  hits the public `/api/health` liveness route (excluded from the middleware
+  gate); the admin-key-gated `/api/admin/health` stays the richer report.
+  **`docker-compose.prod.yml` uses a named volume (`sovereign_data`), not a host
+  bind mount**, for `/app/data`: the images run **non-root**, and a named volume
+  inherits the image's `/app/data` ownership so SQLite/avatar writes work with
+  zero host `chown` (a bind mount keeps host ownership and breaks non-root writes
+  on Linux — macOS VirtioFS hides this). Dev (`docker-compose.yml`) keeps the
+  `./data` bind mount (runs as root). The relative SQLite path resolves against
+  cwd (`/app`) because `findWorkspaceRoot()` falls back to cwd when no
+  `pnpm-workspace.yaml` ancestor exists — the standalone case.
 
 ## Design system (`packages/ui`)
 
@@ -413,8 +442,9 @@ pnpm install:plugins    # clone sovereign/community plugins declared in sovereig
   internal service name) — do not set this var in `.env` for Docker use. For
   production use `docker-compose.prod.yml` (standalone file, runtime on `:4000`,
   no Mailpit). See `docs/self-hosting.md`. The `Dockerfile` (runtime) and
-  `apps/auth/Dockerfile` are dev-quality; Task 0.5.02 replaces them with
-  multi-stage standalone builds.
+  `apps/auth/Dockerfile` are three-stage standalone production builds (Task
+  0.5.02) — both compose files build from them (dev runs them as root with a
+  `./data` bind mount; prod runs them non-root with a named volume).
 - **Runtime dev = `scripts/dev.ts`.** The runtime's `dev` script runs the
   orchestrator, which composes plugins (writes the registry, copies plugin
   `app/` trees), then runs the generate watcher + `next dev` on `:3000`. Both
@@ -460,8 +490,9 @@ pnpm install:plugins    # clone sovereign/community plugins declared in sovereig
 - ✅ Task 0.4.05 — Launcher plugin (`plugins/launcher/` home grid; gated `/api/plugins` + `selectLauncherPlugins` helper; chrome plugins excluded from grid and sidebar middle section; `/` serves the root plugin in place via middleware rewrite — `/` and `/launcher` both render the Launcher) (merged to `main`).
 - ✅ Task 0.4.06 — Account plugin (Profile + Preferences + Security): display name + avatar, IANA timezone + Light/Dark/System theme, password change, active-session list/revoke; `account_prefs` table; `sdk.auth` gained `changePassword`/`listSessions`/`revokeSession`; `freshAge: 0` so session listing isn't gated by session age. Completes the v0.4 chrome-plugin trio (Console, Launcher, Account) (merged to `main`).
 - ✅ Task 0.5.00 — `scripts/install-plugins.ts` (platform → 0.5.0, enters v0.5): reads `sovereign.plugins.json`, shallow-clones declared plugins into `plugins/<id>/` (skips existing), then runs `pnpm generate`; cloned plugins gitignored (allowlist keeps the three committed platform plugins) (merged to `main`).
-- ▶️ In review: Task 0.5.01 — PWA configuration (`runtime` → 0.5.0): `@ducanh2912/next-pwa` wraps `runtime/next.config.ts` (disabled in dev), `runtime/public/manifest.json` + generated PNG icons (192/512/maskable + apple-touch), manifest/theme-colour linked via root-layout metadata/viewport, `/offline` fallback page; service worker generated into `runtime/public/` at build (gitignored + eslint/prettier-ignored). SRS §3.11, PLT-09.
-- ⏳ Next: Task 0.5.02 — Production Docker image: multi-stage `Dockerfile` (runtime) + `apps/auth/Dockerfile` from Next.js standalone output (`output: 'standalone'`), non-root runner, `HEALTHCHECK`, and `docker-compose.prod.yml` wired to the built images (SRS deployment). Branch from an up-to-date `main` once #27 merges.
+- ✅ Task 0.5.01 — PWA configuration (`runtime` → 0.5.0): `@ducanh2912/next-pwa` wraps `runtime/next.config.ts` (disabled in dev), `runtime/public/manifest.json` + generated PNG icons (192/512/maskable + apple-touch), manifest/theme-colour linked via root-layout metadata/viewport, `/offline` fallback page; service worker generated into `runtime/public/` at build (gitignored + eslint/prettier-ignored). SRS §3.11, PLT-09 (merged to `main`).
+- ▶️ In review: Task 0.5.02 — Production Docker image: `Dockerfile` (runtime) + `apps/auth/Dockerfile` rewritten as three-stage (`deps`/`builder`/`runner`) builds from Next.js standalone output (`output: 'standalone'` + `outputFileTracingRoot` = monorepo root in both `next.config.ts`); non-root `nextjs` runner, `HEALTHCHECK` against the new public `runtime/app/api/health` liveness route (auth already had `/api/health`); `docker-compose.prod.yml` adds healthchecks, `depends_on: condition: service_healthy`, and switches prod data to a **named volume** (non-root + bind mount breaks SQLite writes on Linux). ~264 MB true image size (≈7× smaller than the old dev image). SRS NFR-01, §3.1.
+- ⏳ Next: Task 0.5.03 — Postgres validation: confirm full SQLite↔Postgres parity (drizzle-kit migrations, both dialects exercised). Branch from an up-to-date `main` once the production-Docker PR merges.
 - ⏳ Spec complete: Shell sidebar three-section architecture (PLT-11–PLT-15, SRS updated).
 - ⏳ Spec complete: Plainwrite sovereign plugin (`docs/plugins/plainwrite.md`, v0.2 — provider + SSG adapters).
 - ⏳ Spec complete: API Composer sovereign plugin (`docs/plugins/api-composer.md`) — GUI API builder, `/api` namespace (PLT-16, Task 0.5.08).

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,57 @@
-FROM node:24-alpine
+# Production image for the Sovereign runtime (Next.js standalone output).
+#
+# Build context is the monorepo root — required for pnpm workspace resolution:
+#   docker build -f Dockerfile -t sovereign-runtime .
+#
+# No secrets are baked in: all configuration is injected at runtime via env.
 
-# Native build tools required for better-sqlite3 bindings
+# ---- deps: install workspace dependencies ---------------------------------
+FROM node:24-alpine AS deps
+# Native toolchain for better-sqlite3's musl build (no prebuilt for Alpine).
 RUN apk add --no-cache python3 make g++
-
 RUN corepack enable && corepack prepare pnpm@11.5.2 --activate
-
 WORKDIR /app
-
+# .dockerignore strips node_modules/.next/.env/.git; copying the whole tree
+# keeps pnpm workspace resolution intact.
 COPY . .
-
 RUN pnpm install --frozen-lockfile
 
-# Generate plugin registry and symlinks before building
+# ---- builder: compose plugins + build the standalone server ---------------
+FROM deps AS builder
+ENV NODE_ENV=production
+# Composes plugin app/ trees into the route group — must precede the build.
 RUN pnpm run generate
-
+# tsup packages → next build → runtime/.next/standalone
 RUN pnpm --filter @sovereignfs/runtime build
 
+# ---- runner: minimal non-root production image ----------------------------
+FROM node:24-alpine AS runner
+ENV NODE_ENV=production
+# The standalone server reads PORT/HOSTNAME; bind on all interfaces so the
+# published port mapping reaches it.
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+WORKDIR /app
+
+RUN addgroup -S nodejs && adduser -S nextjs -G nodejs
+
+# Standalone output (tracing rooted at the monorepo root) replicates the repo
+# layout: server.js lives under runtime/, with traced node_modules + packages.
+COPY --from=builder --chown=nextjs:nodejs /app/runtime/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/runtime/.next/static ./runtime/.next/static
+# public/ holds the PWA assets generated at build (sw.js, workbox-*, fallback-*,
+# manifest.json, icons).
+COPY --from=builder --chown=nextjs:nodejs /app/runtime/public ./runtime/public
+
+# SQLite + avatars persist here (mounted as a volume). The relative DB path
+# resolves against the cwd (/app) at runtime, so it must be writable by the
+# non-root runner.
+RUN mkdir -p /app/data && chown nextjs:nodejs /app/data
+
+USER nextjs
 EXPOSE 3000
 
-CMD ["pnpm", "--filter", "@sovereignfs/runtime", "start"]
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:3000/api/health || exit 1
+
+CMD ["node", "runtime/server.js"]

--- a/apps/auth/Dockerfile
+++ b/apps/auth/Dockerfile
@@ -1,20 +1,51 @@
-FROM node:24-alpine
+# Production image for the Sovereign auth server (Next.js standalone output).
+#
+# Build context is the monorepo root — required for pnpm workspace resolution:
+#   docker build -f apps/auth/Dockerfile -t sovereign-auth .
+#
+# No secrets are baked in: all configuration is injected at runtime via env.
 
-# Native build tools required for better-sqlite3 bindings
+# ---- deps: install workspace dependencies ---------------------------------
+FROM node:24-alpine AS deps
+# Native toolchain for better-sqlite3's musl build (no prebuilt for Alpine).
 RUN apk add --no-cache python3 make g++
-
 RUN corepack enable && corepack prepare pnpm@11.5.2 --activate
-
 WORKDIR /app
-
-# Build context is the monorepo root — required for pnpm workspace resolution.
-# In docker-compose.yml: build: { context: ., dockerfile: apps/auth/Dockerfile }
+# .dockerignore strips node_modules/.next/.env/.git; copying the whole tree
+# keeps pnpm workspace resolution intact.
 COPY . .
-
 RUN pnpm install --frozen-lockfile
 
+# ---- builder: build the standalone server ---------------------------------
+FROM deps AS builder
+ENV NODE_ENV=production
 RUN pnpm --filter @sovereignfs/auth build
 
+# ---- runner: minimal non-root production image ----------------------------
+FROM node:24-alpine AS runner
+ENV NODE_ENV=production
+# The standalone server reads PORT/HOSTNAME (the old `next start --port 3001`
+# flag does not apply); bind on all interfaces so the runtime can reach it.
+ENV PORT=3001
+ENV HOSTNAME=0.0.0.0
+WORKDIR /app
+
+RUN addgroup -S nodejs && adduser -S nextjs -G nodejs
+
+# Standalone output (tracing rooted at the monorepo root) replicates the repo
+# layout: server.js lives under apps/auth/, with traced node_modules + packages.
+# The auth app ships no public/ directory.
+COPY --from=builder --chown=nextjs:nodejs /app/apps/auth/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/apps/auth/.next/static ./apps/auth/.next/static
+
+# auth.db persists here (mounted as a volume). The relative DB path resolves
+# against the cwd (/app) at runtime, so it must be writable by the runner.
+RUN mkdir -p /app/data && chown nextjs:nodejs /app/data
+
+USER nextjs
 EXPOSE 3001
 
-CMD ["pnpm", "--filter", "@sovereignfs/auth", "start"]
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:3001/api/health || exit 1
+
+CMD ["node", "apps/auth/server.js"]

--- a/apps/auth/next.config.ts
+++ b/apps/auth/next.config.ts
@@ -7,6 +7,11 @@ import type { NextConfig } from 'next';
 loadEnvConfig(resolve(process.cwd(), '../..'), process.env.NODE_ENV !== 'production');
 
 const nextConfig: NextConfig = {
+  // Self-contained production server (`.next/standalone`) for the Docker image.
+  // Tracing is rooted at the monorepo root so workspace package files are
+  // included in the standalone output.
+  output: 'standalone',
+  outputFileTracingRoot: resolve(process.cwd(), '../..'),
   // Compile the design system from source (no watch build needed in dev).
   transpilePackages: ['@sovereignfs/ui'],
 };

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -29,7 +29,17 @@ services:
       NEXT_PUBLIC_RUNTIME_URL: '${NEXT_PUBLIC_RUNTIME_URL}'
       SOVEREIGN_ADMIN_KEY: '${SOVEREIGN_ADMIN_KEY}'
     volumes:
-      - ./data:/app/data
+      # Named volume (not a host bind mount): Docker initialises it with the
+      # image's /app/data ownership, so the non-root runner can write SQLite +
+      # avatars with zero host-side setup. Back up with `docker run --rm -v
+      # sovereign_data:/data -v "$PWD":/backup alpine tar czf /backup/data.tgz -C /data .`
+      - sovereign_data:/app/data
+    healthcheck:
+      test: ['CMD', 'wget', '-qO-', 'http://127.0.0.1:3001/api/health']
+      interval: 30s
+      timeout: 5s
+      start_period: 20s
+      retries: 3
     networks:
       - sovereign_net
 
@@ -53,11 +63,23 @@ services:
       SMTP_PASS: '${SMTP_PASS:-}'
       SMTP_FROM: '${SMTP_FROM:-}'
     volumes:
-      - ./data:/app/data
+      # Shared with the auth service — both resolve relative SQLite paths
+      # against /app (the cwd), so both DBs and avatars land in this volume.
+      - sovereign_data:/app/data
+    healthcheck:
+      test: ['CMD', 'wget', '-qO-', 'http://127.0.0.1:3000/api/health']
+      interval: 30s
+      timeout: 5s
+      start_period: 20s
+      retries: 3
     depends_on:
-      - auth
+      auth:
+        condition: service_healthy
     networks:
       - sovereign_net
+
+volumes:
+  sovereign_data:
 
 networks:
   sovereign_net:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,10 @@ services:
       context: .
       dockerfile: apps/auth/Dockerfile
     container_name: sovereign-auth
+    # The production image runs as a non-root user; here we override to root so
+    # writes to the host `./data` bind mount work regardless of host ownership.
+    # (Prod uses a named volume instead and keeps the non-root user.)
+    user: root
     # Internal only — not reachable from the host, only from the runtime
     # container via http://auth:3001 on the shared network.
     expose:
@@ -52,6 +56,9 @@ services:
       context: .
       dockerfile: Dockerfile
     container_name: sovereign-runtime
+    # See the auth service: root override so the host `./data` bind mount is
+    # writable. Prod (docker-compose.prod.yml) keeps the image's non-root user.
+    user: root
     ports:
       - '${RUNTIME_PORT:-3000}:3000'
     environment:

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -90,8 +90,8 @@ to get started — every variable is documented there.
 
 ## Data persistence
 
-SQLite databases and uploaded files are stored in the `./data/` directory,
-which is mounted as a volume in both the runtime and auth containers:
+SQLite databases and uploaded files live under `/app/data` inside both the
+runtime and auth containers:
 
 ```
 data/
@@ -100,7 +100,20 @@ data/
   avatars/       # User avatar uploads (Task 0.4.06)
 ```
 
-Back up the `data/` directory to preserve all application state.
+How that directory is persisted depends on the compose file:
+
+- **Dev (`docker-compose.yml`)** — bind-mounted to the repo's `./data/`
+  directory (the containers run as root, so host ownership is a non-issue).
+  Back up by copying `./data/`.
+- **Prod (`docker-compose.prod.yml`)** — a named Docker volume
+  (`sovereign_data`). The production images run as a **non-root** user, and a
+  named volume inherits the image's `/app/data` ownership, so writes work with
+  zero host-side `chown`. Back up the volume with:
+
+  ```bash
+  docker run --rm -v sovereign_data:/data -v "$PWD":/backup alpine \
+    tar czf /backup/sovereign-data.tgz -C /data .
+  ```
 
 ---
 

--- a/runtime/app/api/health/route.ts
+++ b/runtime/app/api/health/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+
+/**
+ * Liveness probe for the runtime container's Docker HEALTHCHECK. Exposes no
+ * sensitive data and is reachable without authentication (excluded from the
+ * middleware session gate). For the richer admin health report (DB, auth
+ * reachability, uptime) see the admin-key-gated `/api/admin/health` (CON-09).
+ */
+export function GET(): Response {
+  return NextResponse.json({ status: 'ok' });
+}

--- a/runtime/middleware.ts
+++ b/runtime/middleware.ts
@@ -115,10 +115,11 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
 }
 
 export const config = {
-  // Gate everything except auth redirects, internal admin API, the offline
-  // fallback, the PWA assets (manifest, service worker, Workbox/fallback
+  // Gate everything except auth redirects, internal admin API, the public
+  // liveness probe (Docker HEALTHCHECK — must answer without a session), the
+  // offline fallback, the PWA assets (manifest, service worker, Workbox/fallback
   // bundles, icons — must load without a session), and Next static assets.
   matcher: [
-    '/((?!login|register|offline|api/admin|manifest.json|sw.js|workbox-|fallback-|icons/|_next/static|_next/image|favicon.ico).*)',
+    '/((?!login|register|offline|api/admin|api/health|manifest.json|sw.js|workbox-|fallback-|icons/|_next/static|_next/image|favicon.ico).*)',
   ],
 };

--- a/runtime/next.config.ts
+++ b/runtime/next.config.ts
@@ -7,6 +7,11 @@ import type { NextConfig } from 'next';
 loadEnvConfig(resolve(process.cwd(), '..'), process.env.NODE_ENV !== 'production');
 
 const nextConfig: NextConfig = {
+  // Self-contained production server (`.next/standalone`) for the Docker image.
+  // In a pnpm monorepo, file tracing must be rooted at the repo root or the
+  // traced output misses workspace package files.
+  output: 'standalone',
+  outputFileTracingRoot: resolve(process.cwd(), '..'),
   // Compile all workspace packages from source — package edits trigger HMR.
   transpilePackages: [
     '@sovereignfs/sdk',


### PR DESCRIPTION
Replaces the dev-quality single-stage Docker images (which shipped the whole monorepo and ran `next start`) with lean three-stage production images built from Next.js **standalone** output. True image size drops from ~1.7GB to ~264MB.

## What changed

- **Standalone builds** — both `next.config.ts` set `output: 'standalone'` and `outputFileTracingRoot` to the monorepo root (required in a pnpm workspace or the trace misses workspace package files). The runner runs `node server.js` instead of `next start`.
- **Three-stage Dockerfiles** (`deps` → `builder` → `runner`) for runtime and auth. The runner is a minimal non-root (`nextjs`) image with a `HEALTHCHECK`; `.next/static` and `public/` (PWA assets) are copied explicitly since standalone does not include them.
- **Port handling** — the standalone server reads `PORT`/`HOSTNAME` env (the old `next start --port` flag no longer applies), so the runners set `PORT` (3000/3001) and `HOSTNAME=0.0.0.0`.
- **Liveness route** — adds a public `runtime/app/api/health` route (the existing `/api/admin/health` is admin-key gated) and excludes it from the middleware session gate. Healthchecks use `127.0.0.1` (busybox `localhost` resolves to `::1`, but the server binds IPv4).
- **`docker-compose.prod.yml`** — adds healthchecks and `depends_on: condition: service_healthy`, and switches prod data to a **named volume** (a non-root user cannot write a host bind mount on Linux). The dev compose keeps the `./data` bind mount via a `user: root` override.
- No secrets are baked into the images; all config is injected at runtime.

## Verification

- Both images build cleanly; both containers report **healthy**.
- Runtime reachable on the host (`:4000`); auth is **internal-only** (not reachable on `:3001`).
- End-to-end across the two containers: sign-up → session cookie → authenticated runtime request returns `200` (vs `307 → /login` without a cookie), exercising the runtime→auth verify path over the internal network. Admin-health reports `database.status: ok` (non-root wrote SQLite to the named volume) and `auth.status: ok`.
- No `.env`/secrets baked into images.
- `pnpm format:check`, `pnpm lint`, `pnpm typecheck`, and `pnpm test` (142 tests) all pass.

**Note on size:** true uncompressed image size is ~264MB (just over the 250MB target — the overage is essentially the official `node:24-alpine` base). `docker images` reports 347MB because it includes buildx attestation manifests.

SRS NFR-01, §2.4 Roadmap v0.5, §3.1 Deployment Model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)