### PR TITLE
Reserve cross-plugin data-sharing surface and permissions (RFC 0002)

### DIFF
--- a/docs/rfcs/0002-cross-plugin-data-sharing.md
+++ b/docs/rfcs/0002-cross-plugin-data-sharing.md
@@ -1,0 +1,202 @@
+# RFC 0002 — Cross-plugin data sharing
+
+**Status:** Draft\
+**Date:** June 2026\
+**Author:** kasunben\
+**Scope:** SDK (`packages/sdk`), manifest schema (`packages/manifest`), runtime, `packages/ui`, Console/Account\
+**Incorporated into plan:** Partially — the **reserved `sdk.data` surface** (stub) and the `data:provide` / `data:consume` permissions are added now (they throw `NotImplementedError`, like the other reserved surfaces). The consent model, manifest data-contract declarations, runtime resolution, audit log, and consent UI are **deferred** until this RFC is accepted and scheduled.
+
+---
+
+## Summary
+
+Define a **consent-gated, pull-based, read-only** mechanism that lets one plugin
+(the **consumer**) read another plugin's data (the **provider**) on behalf of the
+current user. A provider exposes one or more named, versioned **data contracts**;
+a consumer requests a contract and receives data only when the user has granted an
+explicit, revocable **consent grant**. The platform mediates every access — no
+plugin reads another plugin's tables directly.
+
+```ts
+// consumer
+const rows = await sdk.data.query({ providerId, contract: 'things', version: 1 }, params);
+// provider
+sdk.data.provide('things', async (params) => resolveThings(params));
+```
+
+## Motivation
+
+Sovereign's plugins each own a slice of a user's data behind the SDK boundary
+(plugins must not import `runtime/src` or another plugin's internals; data lives
+in slug-prefixed tables in the shared schema). That isolation is correct, but it
+blocks legitimate, user-desired flows where one plugin could enrich itself from
+another's data — e.g. a plugin that aggregates or reconciles records another
+plugin already maintains, so the user doesn't re-enter them.
+
+Today the only options are bad ones: duplicate data entry, or break the boundary.
+A first-class, **consent-first** sharing mechanism lets plugins compose around a
+user's data while keeping isolation, privacy, and user control intact — and keeps
+the principle that capabilities are explicit and platform-mediated.
+
+## Current state (what this builds on)
+
+- **SDK boundary:** plugins use `@sovereignfs/sdk` only; no cross-plugin imports
+  (CLAUDE.md hard rules, SRS §3.6). There is no sanctioned way for plugin B to
+  read plugin A's data.
+- **Reserved-surface pattern:** the SDK already declares post-v1 surfaces
+  (`storage`, `notifications`, `events`) as stubs that throw `NotImplementedError`
+  (`packages/sdk/src/unimplemented.ts`), and the manifest permission enum reserves
+  the matching capabilities (`packages/manifest/src/schema.ts`).
+- **Permissions:** plugins declare capabilities in their manifest; the runtime is
+  the enforcement point.
+- **Data scoping:** user-scoped tables carry `tenant_id` + `user_id`; all access is
+  already per-user, per-tenant.
+
+This RFC reuses that reserved-surface pattern: `sdk.data` and `data:*` permissions
+land now as stubs; the mechanism behind them is specified here for later.
+
+## Proposed design
+
+### 1. Data contracts
+
+A provider exposes **named, versioned, read-only** datasets ("contracts"). A
+contract is a stable shape (e.g. `things@1`) decoupled from the provider's
+internal tables — the provider may refactor storage without breaking consumers,
+as long as the contract shape holds. Versioning is by major integer; a provider
+may serve multiple versions during migration.
+
+### 2. Manifest declarations
+
+Plugins declare the contracts they expose and consume (deferred — added when
+accepted):
+
+```jsonc
+{
+  "data": {
+    "provides": [{ "contract": "things", "version": 1, "scope": "user" }],
+    "consumes": [{ "provider": "<pluginId>", "contract": "things", "version": 1 }],
+  },
+}
+```
+
+- `provides` registers the contracts a provider serves.
+- `consumes` is **informational** (powers consent UI, discovery, and build-time
+  checks) — it is **not** the access gate. The gate is the runtime consent grant.
+- Validated at build time against the manifest schema.
+
+### 3. Permissions
+
+Two reserved permissions gate participation (added now, enforced later):
+
+- `data:provide` — the plugin may expose contracts.
+- `data:consume` — the plugin may request other plugins' contracts.
+
+### 4. Consent
+
+Cross-plugin reads require an **explicit, recorded, revocable user consent grant**
+keyed on `(consumer plugin, provider plugin, contract, user)`:
+
+- On a consumer's first `query` without a grant, the runtime raises
+  `ConsentRequiredError` and surfaces a **consent prompt** describing exactly what
+  the consumer wants to read from which provider, for this user.
+- Grants are stored in a platform table (consumer, provider, contract, user,
+  `granted_at`, `revoked_at`, scope) and are **revocable** from Account (the user's
+  own grants) and visible/auditable in Console.
+- Revoking a grant blocks subsequent reads immediately.
+
+### 5. SDK surface
+
+```ts
+// consumer — resolves only with an active consent grant, else ConsentRequiredError
+sdk.data.query(ref: DataContractRef, params?): Promise<TRow[]>;
+// provider — register a resolver for a contract it exposes
+sdk.data.provide(contract: string, resolver: DataContractResolver): void;
+```
+
+`query` is **read-only** and the runtime scopes it to the current user + tenant
+before invoking the provider's resolver. The reserved stub
+(`packages/sdk/src/data.ts`) throws `NotImplementedError` until the mechanism
+lands; `ConsentRequiredError` is reserved in `packages/sdk/src/errors.ts`.
+
+### 6. Security and scoping
+
+- **Read-only.** No write-back across plugins in this RFC.
+- **Platform-mediated.** Consumers never touch provider tables; the runtime routes
+  `query` to the provider's registered resolver. The SDK boundary is preserved.
+- **User- and tenant-scoped.** The runtime injects the requesting user/tenant; a
+  provider resolver cannot read another user's data.
+- **Audited.** Every cross-plugin read is logged (consumer, provider, contract,
+  user, timestamp) for transparency.
+- **Sync is the consumer's job.** The mechanism is query/resolve; mapping fetched
+  data into the consumer's own records (and any scheduling) is plugin logic.
+
+### Example (abstract)
+
+> _Plugin A_ exposes a `things` contract (its records, as a stable read-only
+> shape). _Plugin B_ declares `consumes` of `A/things@1` and holds `data:consume`.
+> With the user's consent, _Plugin B_ calls
+> `sdk.data.query({ providerId: 'A', contract: 'things', version: 1 })` and maps
+> the result into its own records, re-syncing periodically. Without consent, the
+> call raises `ConsentRequiredError`.
+
+No real plugin is named here intentionally — the mechanism is generic and any
+plugin may be a provider, a consumer, or both.
+
+## Impact when accepted (deferred — beyond the reserved stub already landed)
+
+| Where                                    | Change                                                                                      |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `packages/manifest`                      | Add the optional `data.provides[]` / `data.consumes[]` declarations; tests; **minor** bump. |
+| `packages/sdk`                           | Implement `sdk.data.query`/`provide` against the runtime (replace the stub).                |
+| Runtime                                  | Provider-resolver registry, consent enforcement, user/tenant scoping, audit log.            |
+| Platform DB                              | `consent_grants` + `data_access_log` tables (with `tenant_id`).                             |
+| `packages/ui`                            | Consent-prompt dialog primitive.                                                            |
+| Console / Account                        | Manage/revoke grants (Account: own grants; Console: audit/oversight).                       |
+| SRS §3 / §5                              | Promote the mechanism from "post-v1 plan" to specified; manifest reference for `data.*`.    |
+| `docs/sovereign-implementation-tasks.md` | The implementation task (already stubbed as a future task entry).                           |
+
+## Alternatives considered
+
+1. **Direct cross-plugin table reads.** Breaks the SDK boundary and isolation;
+   a consumer would couple to a provider's storage. Rejected.
+2. **Push-only via `events`.** A provider could publish change events a consumer
+   subscribes to. Useful later, but it does not cover "read current state on
+   demand with consent," and pushes data without a per-contract consent gate.
+   Complementary, not a replacement — out of scope here.
+3. **Per-call consent prompts (no stored grant).** Prompting on every read is
+   hostile to sync/automation. A stored, revocable grant is the right model.
+4. **Write-through sharing.** Letting a consumer mutate a provider's data is a far
+   larger surface (conflict, ownership, audit). Explicitly out of scope; this RFC
+   is read-only.
+
+## Open questions
+
+1. **Grant granularity.** Per `(consumer, provider, contract)` (proposed) vs.
+   per-provider blanket consent. Proposal: per-contract — least surprise.
+2. **Contract discovery.** Do consumers bind to a fixed `providerId`, or to a
+   contract "kind" any provider can satisfy (e.g. several plugins exposing a
+   `things` contract)? Proposal: fixed `providerId` in v1; capability-style
+   discovery later.
+3. **Caching/staleness.** Does the runtime cache `query` results, or always hit the
+   provider resolver? Proposal: no platform cache in v1; consumers cache if needed.
+4. **Versioning negotiation.** Behaviour when a consumer requests a version the
+   provider no longer serves — hard error vs. negotiated downgrade. Proposal: hard
+   `error`; providers keep old majors during migration windows.
+5. **Consent expiry.** Should grants expire or require periodic re-confirmation?
+   Proposal: no expiry in v1; revocation is always available.
+
+## Adoption path
+
+1. **Now (this change):** reserved `sdk.data` stub + `data:provide`/`data:consume`
+   permissions + `ConsentRequiredError`, all additive (SDK/manifest **minor**
+   bumps). No behaviour change for existing plugins.
+2. **On acceptance:** apply the "Impact when accepted" table — manifest `data.*`,
+   consent tables + UI, runtime resolution, then SDK implementation.
+3. The mechanism becomes part of the public manifest + SDK contract from the
+   `@sovereignfs/sdk` / `@sovereignfs/manifest` minor release that ships it.
+
+## Changelog
+
+| Version | Date     | Change                                                          |
+| ------- | -------- | --------------------------------------------------------------- |
+| 0.1     | Jun 2026 | Initial draft; reserved `sdk.data` stub + `data:*` permissions. |

--- a/docs/sovereign-implementation-tasks.md
+++ b/docs/sovereign-implementation-tasks.md
@@ -961,6 +961,31 @@ consistent info/success/warn/error formatting. CLI is monorepo-internal in v1
 
 ---
 
+### Task 0.5.10 — Cross-plugin data sharing (consent-gated) **[future]**
+
+**Goal:** Implement the consent-gated, pull-based, read-only cross-plugin data-sharing mechanism specified in RFC 0002 / SRS §3.13. The reserved `sdk.data` surface and the `data:provide`/`data:consume` permissions already exist as stubs; this task makes them real. Depends on `sdk.db` (Task 0.5.05).
+
+**Deliverables:**
+
+- Manifest: optional `data.provides[]` / `data.consumes[]` declarations (provider id, contract, version, scope) in `packages/manifest`, with validation + tests
+- Platform DB: `consent_grants` (consumer, provider, contract, user, granted_at, revoked_at, scope) and `data_access_log` tables, both with `tenant_id`
+- Runtime: provider-resolver registry, consent enforcement, tenant/user scoping, audit logging; routes `sdk.data.query` to the provider's registered resolver
+- SDK: implement `sdk.data.query`/`provide` against the runtime (replace the stubs); raise `ConsentRequiredError` when no active grant exists
+- UI: a consent-prompt dialog primitive in `packages/ui`; grant management in Account (own grants) and oversight in Console
+- The mechanism is generic — no plugin is special-cased
+
+**SRS reference:** RFC 0002, SRS §3.13, §5 (manifest `data.*`)
+
+**Review checklist:**
+
+- A consumer `query` without a grant raises `ConsentRequiredError` and surfaces a consent prompt; granting consent then returns the provider's data
+- Reads are read-only, scoped to the requesting user + tenant, and recorded in the audit log
+- Revoking a grant immediately blocks subsequent reads
+- A consumer cannot reach a provider's raw tables — only its registered contract resolver
+- Existing plugins (no `data.*` declared) are unaffected
+
+---
+
 ### Task 1.0.01 — Registry contribution process
 
 **Goal:** Define and document the process for submitting a community plugin to `registry/plugins.json`.
@@ -1001,6 +1026,8 @@ consistent info/success/warn/error formatting. CLI is monorepo-internal in v1
 - Semver policy documented and linked from README
 
 ---
+
+_Version 1.13 — June 2026. Changes from v1.12: reserved the cross-plugin data-sharing surface (RFC 0002, SRS §3.13). Added **Task 0.5.10 — Cross-plugin data sharing (consent-gated)** `[future]` — implements the consent-gated, pull-based, read-only mechanism (consent grants + audit log, manifest `data.*` declarations, runtime resolution, `packages/ui` consent prompt, Account/Console management); depends on `sdk.db` (Task 0.5.05). Landing now (additive, no behaviour change): the reserved `sdk.data` stub (`query`/`provide` → `NotImplementedError`) and `ConsentRequiredError` in `packages/sdk`, and the reserved `data:provide`/`data:consume` permissions in `packages/manifest`, with tests; `@sovereignfs/sdk` → 0.5.0, `@sovereignfs/manifest` → 0.3.0. Also git-/Prettier-ignores `docs/local/` (private working area). Earlier notes retained._
 
 _Version 1.12 — June 2026. Planning change (no task completed, no version bumps): RFC 0001 (overlay shell variant) accepted and incorporated. Added **Task 0.5.09 — Overlay shell mode** `[parallel]` to the v0.5 phase: a third `shell` mode (`overlay`) that renders a plugin as a dismissable dialog over the current page (App Router parallel + intercepting routes — `@modal` slot + dual composition by the generate script), with a full-page fallback on hard navigation, plus a `packages/ui` `Dialog` primitive and migration of Console/Account. Sequenced as a v0.5 polish item (no hard dependency on the other v0.5 tasks; needs the UI `Dialog`). Corresponding SRS edits: §3.8 (third shell mode), §3.9 (dual composition), §5 (manifest `shell` enum gains `'overlay'`), CON-11 (root-plugin eligibility excludes overlay), and a decision-log row. The manifest enum change and all code land in Task 0.5.09, not in this planning change. Earlier notes retained._
 

--- a/docs/sovereign-proposal-plan-srs.md
+++ b/docs/sovereign-proposal-plan-srs.md
@@ -692,6 +692,31 @@ The shell app lives in a separate repository (`sovereign-mobile`) under
 the Sovereign project, not in this monorepo. It is developed and versioned
 independently of the platform.
 
+### 3.13 Cross-Plugin Data Sharing (post-v1 plan)
+
+Plugins are isolated behind the SDK boundary — a plugin may not import another
+plugin's internals or read its tables. Some user-desired flows, however, want one
+plugin to enrich itself from another's data (so the user doesn't re-enter it).
+Sovereign will support this through a **consent-gated, pull-based, read-only**
+mechanism — specified in **RFC 0002 — Cross-plugin data sharing** — never by
+relaxing isolation.
+
+Model: a **provider** plugin exposes named, versioned, read-only **data
+contracts**; a **consumer** plugin requests a contract via `sdk.data.query(...)`
+and a provider registers resolvers via `sdk.data.provide(...)`. Access is
+permitted only when the user holds an explicit, revocable **consent grant** for
+`(consumer, provider, contract)`; otherwise the call raises
+`ConsentRequiredError`. Every read is platform-mediated (no direct cross-plugin
+table access), tenant- and user-scoped, read-only, and audited. Consumers manage
+their own grants from Account; Console provides oversight.
+
+Two reserved manifest permissions gate participation — `data:provide` and
+`data:consume` — and the SDK ships a reserved `sdk.data` surface that throws
+`NotImplementedError` until the mechanism is implemented (mirroring the other
+post-v1 surfaces). The full design — manifest `data.provides[]`/`data.consumes[]`
+declarations, the consent and audit tables, runtime resolution, and consent UI —
+is deferred per RFC 0002.
+
 ---
 
 ## 4. Software Requirements Specification
@@ -881,6 +906,8 @@ type Permission =
   | 'notifications:send' // not implemented v1
   | 'events:publish' // not implemented v1
   | 'events:subscribe' // not implemented v1
+  | 'data:provide' // cross-plugin data sharing — expose contracts (RFC 0002); reserved, not implemented v1
+  | 'data:consume' // cross-plugin data sharing — consume contracts (RFC 0002); reserved, not implemented v1
   | 'admin:*'; // grants admin-only routes. Equivalent to declaring adminOnly: true in the manifest — the middleware maps adminOnly to this capability check. Prefer adminOnly in the manifest; admin:* in permissions is for future fine-grained plugin-level admin scopes.
 ```
 
@@ -931,8 +958,11 @@ type Permission =
 | Jun 2026 | API Composer plugin: managed JSON storage, protocol adapters, API keys; platform reserves the `/api/*` public namespace (PLT-16)                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | Generated-API records live as JSON documents in one shared `apicomposer_records` table — no runtime DDL, fully dialect-agnostic, fits the file-based migration model; constraints are enforced by the engine, an accepted trade-off at small-API scale. The metadata model (projects/resources/methods) is protocol-neutral behind a `ProtocolAdapter` interface — REST in v0.1, GraphQL later without core changes (same seam pattern as Plainwrite). External callers cannot present a session cookie, so generated APIs use per-project hashed API keys (Bearer header, reveal-once) plus a per-method public toggle; `/api/*` is therefore exempt from the session-redirect middleware and rewritten to the provider plugin's serve route (PLT-16, one provider per instance in v1). Declarative CRUD only in v0.1 — custom logic is deferred to a sandboxed-hooks milestone, consistent with deferring plugin sandboxing in v1.                                                                                                                                                                    |
 | Jun 2026 | PaperTrail adapted from the legacy architecture: plugin-owned projects containing boards; owner/editor/viewer roles; JSON export/import as the legacy migration bridge                                                                                                                                                                                                                                                                                                                                                                                                                                       | The legacy plugin (Vite SPA + Express router + Prisma extension + `plugin.json` capabilities) maps cleanly onto the v3 native model: canvas becomes a client component, the Express router becomes plugin route handlers under `/papertrail/api/*` (session-protected — no public-route dependency), Prisma models carry over to Drizzle with `tenant_id` added. The old platform-owned "project" concept no longer exists, so PaperTrail owns a projects→boards hierarchy (lifting the legacy one-board-per-project limit); the five legacy capability roles collapse to owner/editor/viewer as data-scoped membership. No automated data migration across architectures — the existing JSON board export/import is the bridge. Repo stays `kasunben/PaperTrail`, adapted in place. New-vs-legacy hardening: server-side markup sanitisation and private-address SSRF blocking on link previews.                                                                                                                                                                                                       |
 | Jun 2026 | Shell gains a third mode, `overlay`: a plugin renders as a dismissable dialog over the current page, with a full-page fallback on hard navigation (RFC 0001 accepted)                                                                                                                                                                                                                                                                                                                                                                                                                                        | Some plugins are interruptions, not destinations (Console, Account, quick-capture/settings-like plugins) — a user mid-task wants a quick layer that dismisses back to where they were, not a context-destroying navigation. Implemented with App Router parallel + intercepting routes: the generate script composes an `overlay` plugin's `app/` tree twice — an interception copy under `(platform)/@modal/(.)<routePrefix>/` (soft nav → dialog over the current page) and the ordinary full-page fallback under `(platform)/(plugins)/<routePrefix>/` (hard load, deep link, login redirect). URLs stay real and unchanged, so `adminOnly` gating and the login redirect keep working; the underlying page stays mounted; plugins write ordinary pages and flip one manifest field (the runtime owns the dialog chrome via a `@modal` slot + a `Dialog` primitive in `packages/ui`). Kept as one mutually-exclusive `shell` enum value, not a separate `presentation` field. `overlay` plugins serve `/` as a full page only, so they are ineligible as the root plugin (CON-11).                   |
+| Jun 2026 | Cross-plugin data sharing is consent-gated, pull-based, read-only, and platform-mediated (RFC 0002); reserved `sdk.data` surface + `data:provide`/`data:consume` permissions land now as stubs                                                                                                                                                                                                                                                                                                                                                                                                               | Plugin isolation (the SDK boundary) must hold, but users legitimately want one plugin to read another's data without re-entry. The mechanism: a provider exposes named, versioned read-only **data contracts**; a consumer calls `sdk.data.query(...)` and a provider registers `sdk.data.provide(...)`. Access requires an explicit, revocable user **consent grant** for `(consumer, provider, contract)`, else `ConsentRequiredError`; reads are tenant/user-scoped, read-only, and audited. Push-via-`events` and write-through were rejected as the primary model (out of scope / too large). The reserved SDK stub + permissions are additive (SDK/manifest minor bumps) with no behaviour change; the consent model, manifest `data.*` declarations, runtime resolution, and consent UI are deferred per RFC 0002. The mechanism is generic — any plugin may be provider or consumer.                                                                                                                                                                                                            |
 
 ---
+
+_Version 0.21 — June 2026. Changes from v0.20: Added §3.13 Cross-Plugin Data Sharing (post-v1 plan) and RFC 0002 (`docs/rfcs/0002-cross-plugin-data-sharing.md`, draft) — a consent-gated, pull-based, read-only mechanism for one plugin to read another's data, platform-mediated and audited. The reserved `sdk.data` surface (`packages/sdk`, stub) and the `data:provide`/`data:consume` manifest permissions (`packages/manifest`) land now (additive; SDK → 0.5.0, manifest → 0.3.0); the consent model, manifest `data.*` declarations, runtime, and consent UI are deferred. SRS §5 manifest reference lists the reserved permissions; one decision-log row added; build plan gains a future task (Task 0.5.10)._
 
 _Version 0.20 — June 2026. Changes from v0.19: Accepted RFC 0001 and incorporated the `overlay` shell mode into the plan. SRS §3.8 documents the third shell mode; §3.9 the dual composition (`@modal` interception copy + full-page fallback); §5 manifest reference adds `'overlay'` to the `shell` enum; CON-11 root-plugin eligibility gains "non-overlay"; one decision-log row added. The build plan gains the overlay wiring task (Task 0.5.09). RFC 0001 marked accepted/incorporated. (Code — manifest enum, generate script, `@modal` slot, `packages/ui` Dialog, Console/Account manifest migration — lands in that task, not in this doc change.)_
 

--- a/packages/manifest/package.json
+++ b/packages/manifest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sovereignfs/manifest",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "description": "Plugin manifest schema, types, and validation for Sovereign.",

--- a/packages/manifest/src/schema.ts
+++ b/packages/manifest/src/schema.ts
@@ -2,7 +2,8 @@ import { z } from 'zod';
 
 /**
  * SDK capabilities a plugin may declare. Mirrors the `Permission` union in
- * SRS §5. Several are reserved for post-v1 (storage, notifications, events).
+ * SRS §5. Several are reserved for post-v1 (storage, notifications, events,
+ * and cross-plugin data sharing — `data:provide` / `data:consume`, RFC 0002).
  */
 export const permissionSchema = z.enum([
   'auth:session',
@@ -13,6 +14,8 @@ export const permissionSchema = z.enum([
   'notifications:send',
   'events:publish',
   'events:subscribe',
+  'data:provide',
+  'data:consume',
   'admin:*',
 ]);
 

--- a/packages/manifest/src/validate.test.ts
+++ b/packages/manifest/src/validate.test.ts
@@ -77,4 +77,12 @@ describe('validateManifest', () => {
     const res = validateManifest(withoutIcon);
     expect(res.valid).toBe(true);
   });
+
+  it('accepts the reserved cross-plugin data-sharing permissions (RFC 0002)', () => {
+    const res = validateManifest({
+      ...base,
+      permissions: ['auth:session', 'db:readWrite', 'data:provide', 'data:consume'],
+    });
+    expect(res.valid).toBe(true);
+  });
 });

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sovereignfs/sdk",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "module",
   "description": "Sovereign SDK — the plugin↔platform contract (types and interfaces).",
   "license": "AGPL-3.0",

--- a/packages/sdk/src/data.ts
+++ b/packages/sdk/src/data.ts
@@ -1,0 +1,60 @@
+import { NotImplementedError } from './errors';
+
+/**
+ * A reference to a versioned data contract exposed by a *provider* plugin, used
+ * by a *consumer* plugin to request it.
+ */
+export interface DataContractRef {
+  /** The provider plugin's manifest `id`. */
+  providerId: string;
+  /** The named, read-only contract the provider exposes (e.g. `"expenses"`). */
+  contract: string;
+  /** Contract major version the consumer was built against. */
+  version: number;
+}
+
+/**
+ * A resolver a provider registers to answer read requests for one of its
+ * contracts. The runtime invokes it only for consumers that hold an active
+ * user consent grant, already scoped to the requesting user and tenant.
+ */
+export type DataContractResolver<TParams = unknown, TRow = unknown> = (
+  params: TParams,
+) => Promise<TRow[]>;
+
+/**
+ * Cross-plugin data sharing (RFC 0002) — **reserved surface, not yet implemented**.
+ *
+ * A consent-gated, pull-based, read-only channel from a consumer plugin to a
+ * provider plugin's data:
+ *
+ * - A consumer calls {@link query}. The runtime resolves it only if the current
+ *   user has an active consent grant for `(consumer, provider, contract)`,
+ *   otherwise it raises `ConsentRequiredError`. Access is tenant- and
+ *   user-scoped and read-only.
+ * - A provider registers a {@link provide} resolver per contract it exposes.
+ *
+ * Full implementation (consent model, manifest data-contract declarations,
+ * audit log) is deferred to a future task; until then both methods throw
+ * `NotImplementedError` — mirroring the other reserved surfaces.
+ */
+export const data = {
+  /** Consumer: read a provider plugin's contract for the current user (consent-gated). */
+  query<TParams = unknown, TRow = unknown>(
+    _ref: DataContractRef,
+    _params?: TParams,
+  ): Promise<TRow[]> {
+    throw new NotImplementedError(
+      'sdk.data.query() (cross-plugin data sharing, RFC 0002) is not implemented yet.',
+    );
+  },
+  /** Provider: register a resolver for one of the contracts this plugin exposes. */
+  provide<TParams = unknown, TRow = unknown>(
+    _contract: string,
+    _resolver: DataContractResolver<TParams, TRow>,
+  ): void {
+    throw new NotImplementedError(
+      'sdk.data.provide() (cross-plugin data sharing, RFC 0002) is not implemented yet.',
+    );
+  },
+};

--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -17,3 +17,16 @@ export class NotAuthenticatedError extends Error {
     this.name = 'NotAuthenticatedError';
   }
 }
+
+/**
+ * Thrown by `sdk.data.query()` when the current user has not granted the calling
+ * (consumer) plugin consent to read the requested provider contract — the
+ * consent-gated cross-plugin data-sharing mechanism (RFC 0002). Reserved
+ * alongside that surface; not raised until the mechanism is implemented.
+ */
+export class ConsentRequiredError extends Error {
+  constructor(message = 'User consent is required to access this plugin data.') {
+    super(message);
+    this.name = 'ConsentRequiredError';
+  }
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,4 +1,5 @@
 import * as auth from './auth';
+import { data } from './data';
 import * as db from './db';
 import * as mailer from './mailer';
 import * as platform from './platform';
@@ -9,10 +10,12 @@ import { events, notifications, storage } from './unimplemented';
  *
  * `auth` and `mailer` are wired with real runtime implementations (Task 0.4.02).
  * `db` and `platform` remain as stubs until Task 0.5.05.
- * `storage`, `notifications`, and `events` are reserved for post-v1.
+ * `data` (cross-plugin data sharing, RFC 0002), `storage`, `notifications`, and
+ * `events` are reserved — declared but not yet implemented.
  */
 export const sdk = {
   auth,
+  data,
   db,
   mailer,
   platform,
@@ -21,7 +24,8 @@ export const sdk = {
   events,
 };
 
-export { NotImplementedError, NotAuthenticatedError } from './errors';
+export { NotImplementedError, NotAuthenticatedError, ConsentRequiredError } from './errors';
+export type { DataContractRef, DataContractResolver } from './data';
 export type {
   Session,
   SessionUser,

--- a/packages/sdk/src/sdk.test.ts
+++ b/packages/sdk/src/sdk.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll, describe, expect, it } from 'vitest';
-import { NotImplementedError, NotAuthenticatedError, sdk } from './index';
+import { ConsentRequiredError, NotImplementedError, NotAuthenticatedError, sdk } from './index';
 
 beforeAll(() => {
   // sdk.platform.getConfig() opens the platform DB from the environment;
@@ -22,6 +22,8 @@ describe('sdk', () => {
     expect(typeof sdk.notifications.send).toBe('function');
     expect(typeof sdk.events.publish).toBe('function');
     expect(typeof sdk.events.subscribe).toBe('function');
+    expect(typeof sdk.data.query).toBe('function');
+    expect(typeof sdk.data.provide).toBe('function');
   });
 
   it('db stub throws NotImplementedError (wired in Task 0.5.05)', () => {
@@ -41,9 +43,20 @@ describe('sdk', () => {
     expect(() => sdk.events.subscribe('e', () => undefined)).toThrow(NotImplementedError);
   });
 
-  it('exports NotAuthenticatedError', () => {
+  it('reserved cross-plugin data surface (RFC 0002) throws NotImplementedError', () => {
+    expect(() => sdk.data.query({ providerId: 'p', contract: 'c', version: 1 })).toThrow(
+      NotImplementedError,
+    );
+    expect(() => sdk.data.provide('c', async () => [])).toThrow(NotImplementedError);
+  });
+
+  it('exports NotAuthenticatedError and ConsentRequiredError', () => {
     const err = new NotAuthenticatedError();
     expect(err.name).toBe('NotAuthenticatedError');
     expect(err).toBeInstanceOf(Error);
+
+    const consent = new ConsentRequiredError();
+    expect(consent.name).toBe('ConsentRequiredError');
+    expect(consent).toBeInstanceOf(Error);
   });
 });


### PR DESCRIPTION
Introduces a **consent-gated, pull-based, read-only** mechanism for one plugin to read another plugin's data, specified generically in **RFC 0002** and **SRS §3.13**. A provider exposes named, versioned read-only **data contracts**; a consumer reads them via `sdk.data.query()` only when the user holds an explicit, revocable **consent grant** (else `ConsentRequiredError`). Every read is platform-mediated, tenant/user-scoped, read-only, and audited — plugin isolation is preserved.

The RFC is deliberately **abstract** — it names no real plugin (generic "provider/consumer plugin").

## Landing now (additive, no behaviour change for existing plugins)
- Reserved **`sdk.data`** surface (`query`/`provide`) as `NotImplementedError` stubs, mirroring the `storage`/`notifications`/`events` reserved surfaces; wired into the SDK barrel with typed `DataContractRef`/`DataContractResolver`.
- **`ConsentRequiredError`** reserved in the SDK errors module.
- Reserved **`data:provide` / `data:consume`** permissions in the manifest schema.
- Tests for the reserved surface and permissions (sdk +1, manifest +1; 144 total pass).
- **RFC 0002** (draft) + **SRS §3.13** + decision-log row + §5 permission reference — all fully abstract.
- Future implementation task: **Task 0.5.10 — Cross-plugin data sharing (consent-gated)**.

## Deferred (per RFC 0002)
The consent model, manifest `data.provides[]`/`data.consumes[]` declarations, runtime resolution, audit log, and consent UI land in Task 0.5.10.

## Version bumps (additive public-contract changes, NFR-04)
- `@sovereignfs/sdk` 0.4.0 → 0.5.0
- `@sovereignfs/manifest` 0.2.0 → 0.3.0

## Also
- git-/Prettier-ignores `docs/local/` (a private working area kept out of the open-source repo; required so the format check passes with that area present).

## Notes
- Rebased onto current `main` after #28 (Docker) and #29 (overlay) merged. To avoid collisions with #29, the SRS version note is **0.21** and the build-plan entry is **Task 0.5.10** (the tasks doc also gets a `_Version 1.13_` note); the overlay's `0.20` / Task `0.5.09` are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)