### PR TITLE
Add RFC 0003 (plugin monetization) and RFC 0004 (per-plugin database)

### DIFF
--- a/docs/rfcs/0003-plugin-monetization.md
+++ b/docs/rfcs/0003-plugin-monetization.md
@@ -1,0 +1,275 @@
+# RFC 0003 — Plugin monetization
+
+**Status:** Draft\
+**Date:** June 2026\
+**Author:** kasunben\
+**Scope:** Manifest schema (`packages/manifest`), SDK (`packages/sdk`), runtime middleware, plugin registry, `packages/ui`, Console/Account, SRS\
+**Incorporated into plan:** No — this document proposes; the SRS, manifest, SDK, and implementation tasks are updated only when this RFC is accepted.
+
+---
+
+## Summary
+
+Let **plugin authors monetize their plugins**. The platform and a set of
+always-free plugins stay open; an author may mark a plugin as paid and require an
+end user to **buy access** before its routes load. A plugin declares its model in
+its manifest:
+
+```jsonc
+{
+  "monetization": {
+    "model": "free" | "one_time" | "recurring" | "pay_what_you_want",
+    "interval": "day" | "week" | "month" | "year", // recurring only
+    "tiers": [{ "id": "pro", "name": "Pro", "price": { "amount": 900, "currency": "USD" } }],
+    "license": { "publicKey": "..." } // verifies author-issued entitlements
+  }
+}
+```
+
+The **plugin author is the merchant** and **fixes the price**. Access is granted
+by a **signed entitlement (license) the author issues on payment**, which the
+instance **verifies offline** against the author's public key — so monetization
+works on a self-hosted instance with **no mandatory central service**. Payment is
+collected through a **provider adapter** (manual/bank transfer, PayPal, Stripe to
+start; extensible). Enforcement is server-side: the runtime gates a paid plugin's
+routes by entitlement, and a reserved `sdk.billing` surface lets a plugin gate
+features by tier.
+
+## Motivation
+
+Sovereign's thesis is that the **plugin system is the product**. A durable plugin
+ecosystem needs a way for authors to be paid — otherwise non-trivial third-party
+plugins have no business model and the ecosystem stays hobby-scale. Today every
+installed plugin is free to every user on the instance; there is no notion of a
+paid plugin or of access tied to payment.
+
+The constraint is that Sovereign is **self-hosted** and "vendor lock-in is a
+defect" (§1.7). Monetization must not require routing every instance's money
+through a Sovereign-operated service, and it must keep working when a plugin is
+installed on an air-gapped or self-managed box. The design below treats
+monetization as an **optional, additive** capability layered on the existing
+plugin model, and keeps the core platform fully functional without it.
+
+This is **not** a hosted public marketplace (a v1 non-goal, §1.4/§4.6). It adds
+the _licensing/entitlement plumbing_ that lets an author sell access to a plugin;
+discovery and a hosted store are explicitly out of scope (see Alternatives).
+
+## Current state (what this builds on)
+
+- **Manifest** (`packages/manifest/src/schema.ts`, `.strict()`) declares a
+  plugin's `type` (`platform`/`sovereign`/`community`), `permissions`,
+  `repository`, etc. There is no pricing or access-cost concept.
+- **Route gating precedent:** the runtime middleware already gates routes by
+  `adminOnly` (403) and by disabled status (404), keyed on `routePrefix`. Because
+  the Edge middleware can't read the DB, it fetches the gating facts from a
+  Node-runtime route (the `/api/admin/plugins/disabled` pattern). Entitlement
+  gating reuses this exact shape.
+- **Reserved-surface pattern:** the SDK declares not-yet-implemented surfaces
+  (`storage`, `notifications`, `events`, and `data` from RFC 0002) as stubs that
+  throw `NotImplementedError`, with matching reserved manifest permissions. A
+  `billing` surface would follow the same pattern.
+- **Registry** (Task 1.0.01, `registry/plugins.json`) plus the manifest
+  `repository`/`type` fields are the natural place to publish an author's
+  license **public key** and establish author identity.
+- **Licensing** (§2.7): third-party plugins may use any license; commercial /
+  proprietary plugins are the motivating case for monetization.
+
+## Proposed design
+
+### 1. Monetization models and tiers
+
+A plugin's manifest declares one **model**, author-fixed:
+
+- `free` — default; no entitlement required (equivalent to omitting the field).
+- `one_time` — a single payment grants perpetual access.
+- `recurring` — access requires an active subscription billed every `interval`
+  (`day`/`week`/`month`/`year`).
+- `pay_what_you_want` — the user chooses any amount ≥ an optional floor; grants
+  access like `one_time` (or `recurring` if combined — out of scope v1).
+
+**Tiers** (optional) are named access levels (e.g. `basic`/`pro`) with their own
+price; the active tier is carried in the entitlement so a plugin can unlock
+features accordingly. Prices are integer **minor units** + ISO 4217 currency
+(the money convention used across the platform).
+
+### 2. What is monetizable
+
+- **Platform** plugins (Console, Account, Launcher) and the platform itself are
+  **always free** — they are core, ship in the monorepo, and cannot declare
+  `monetization`.
+- Only `sovereign` / `community` plugins may be paid.
+- An instance operator may always **disable** a paid plugin (existing CON-07); a
+  disabled plugin is never billable.
+
+### 3. Author-as-merchant via decentralized signed licenses (recommended)
+
+The plugin author is the merchant of record and is paid directly. Access is
+proven by an **author-issued, signed entitlement token** — a "license":
+
+1. The author holds a **keypair**. The **public key** is published in the
+   plugin's manifest (`monetization.license.publicKey`) and/or the registry entry.
+2. A user on an instance initiates purchase. The instance hands off to the
+   author's **checkout** (the author's payment provider) or, for manual/bank, to
+   the author's payment instructions.
+3. On confirmed payment the author's billing issues a **signed license** scoped to
+   `{ pluginId, subscriber identity, tier, issuedAt, expiresAt? }`, signed with
+   the author's private key.
+4. The instance stores the license and **verifies its signature offline** against
+   the author's public key on every entitlement check. No call to a Sovereign
+   service is required.
+5. `recurring` licenses carry `expiresAt`; the instance treats an expired license
+   as no access and prompts renewal. Renewal re-issues a license (online check to
+   the author's endpoint, or a fresh signed token). A **grace period** is allowed
+   before hard lock.
+6. **Manual / bank transfer** is a first-class flow: the author confirms receipt
+   out of band and issues the signed license, which the user (or the instance
+   admin) imports. No automation or live gateway needed.
+
+This keeps money and merchant responsibility with the author, requires **no
+central service**, supports offline verification, and naturally accommodates
+manual payment — at the cost of authors running (or using a hosted) license-issuing
+checkout, and of revocation requiring expiry/online re-checks (see Open questions).
+
+### 4. Manifest declarations
+
+`monetization` is an **optional** object (deferred — added when accepted):
+
+```jsonc
+"monetization": {
+  "model": "recurring",
+  "interval": "month",
+  "tiers": [
+    { "id": "basic", "name": "Basic", "price": { "amount": 500, "currency": "USD" } },
+    { "id": "pro",   "name": "Pro",   "price": { "amount": 1500, "currency": "USD" } }
+  ],
+  "license": { "publicKey": "<base64 ed25519 public key>" }
+}
+```
+
+Validated at build time against the manifest schema (a `free`/absent value keeps
+every existing manifest valid). The manifest declares pricing; the operator and
+users do not change it.
+
+### 5. Payment-provider adapters
+
+A small **`PaymentProvider` interface** abstracts collection so adapters are
+pluggable (same seam idea as the protocol adapters in other plugin specs):
+
+- **Manual / bank transfer** — present instructions; settlement and license
+  issuance are confirmed out of band by the author.
+- **Stripe** — hosted Checkout + signed **webhooks**; recurring handled by Stripe
+  subscriptions; webhook → license issue/renew/revoke.
+- **PayPal** — hosted checkout + IPN/webhooks, same shape.
+- **Extensible** — new providers implement the interface without core changes.
+
+**No card data ever touches the instance** — hosted checkout only (keeps PCI
+scope off the platform).
+
+### 6. Entitlement enforcement
+
+Server-side and authoritative; the client is never trusted.
+
+- The runtime **middleware gates a paid plugin's `routePrefix`** by entitlement,
+  reusing the `adminOnly`/disabled pattern (Edge middleware fetches entitlement
+  facts from a Node-runtime route). No valid entitlement → redirect to a
+  **paywall** page (or `402 Payment Required` for API routes).
+- A reserved **`sdk.billing` / `sdk.entitlements`** surface lets a plugin check
+  the current user's entitlement and **tier** to gate features in-app
+  (`sdk.billing.requireEntitlement()` / `getEntitlement()`), throwing/normalizing
+  when absent. Until implemented it throws `NotImplementedError`.
+- Entitlements are stored per `{ user, plugin, tier, status, source, expiresAt }`
+  in the platform DB (with `tenant_id`).
+
+### 7. UX
+
+- **Account** — purchase / import a license, view active subscriptions and
+  renewal dates, cancel.
+- **Console** — view entitlements across users, import/confirm manual payments,
+  troubleshoot (admin oversight; the operator is not the merchant).
+- **Paywall** — a runtime-owned page shown when a user without entitlement hits a
+  paid plugin, showing the author's tiers/prices and a purchase/redeem action.
+
+### 8. Security and legal
+
+- License **signature verification** with the author's public key; support **key
+  rotation** (publish new keys via registry; keep old keys valid for issued
+  licenses).
+- The **author is merchant of record** — taxes, invoicing, refunds, and
+  chargebacks are the author's responsibility, not the instance operator's or the
+  Sovereign project's.
+- Billing/PII data is minimized and subject to the platform's privacy posture
+  (GDPR); the instance stores entitlements, not card data.
+
+### 9. Self-host reconciliation
+
+Monetization is **optional and additive**: an instance with no paid plugins, or
+offline, is unaffected. Entitlements verify **offline** against published author
+keys, so a paid plugin keeps working without contacting any Sovereign service.
+This satisfies §1.7 ("no cloud dependency for **core** functionality") — paid
+plugins are not core — and avoids making the project a payment intermediary.
+
+## Impact when accepted (deferred — no edits yet)
+
+| Where                                    | Change                                                                                                       |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `packages/manifest`                      | Optional `monetization` object (model/interval/tiers/license); validation + tests; **minor** bump.           |
+| `packages/sdk`                           | Reserved `sdk.billing`/`entitlements` surface (stub) + `EntitlementRequiredError`; **minor** bump.           |
+| Runtime middleware + a Node route        | Entitlement gating by `routePrefix` (paywall / `402`), mirroring the disabled-plugin gating pattern.         |
+| Runtime                                  | `PaymentProvider` adapter interface; manual/bank, Stripe, PayPal adapters; webhook endpoints + verification. |
+| Platform DB                              | `entitlements` (+ a payments/transactions ledger), with `tenant_id`.                                         |
+| Plugin registry                          | Publish author identity + license public key(s); key rotation.                                               |
+| `packages/ui`                            | Paywall / pricing components; subscription-management UI.                                                    |
+| Console / Account                        | Subscription management (Account) and entitlement oversight + manual-payment confirmation (Console).         |
+| SRS §1.4 / §4.6 / §1.7                   | Clarify that monetization (licensing plumbing, not a hosted marketplace) is in scope; reconcile wording.     |
+| `docs/sovereign-implementation-tasks.md` | A phased implementation task (manifest + entitlement gating first; providers; subscription UX).              |
+
+## Alternatives considered
+
+1. **Central Sovereign billing / marketplace** (a hosted store; Stripe Connect to
+   route payouts to authors; central license issuance and discovery). Best UX and
+   the only clean path to plugin **discovery**, but introduces a central
+   dependency (against §1.7), makes the project a payment intermediary with the
+   attendant PCI/tax/legal burden, and squarely revisits the marketplace non-goal.
+   Recorded as a **possible future convenience layer** on top of the decentralized
+   model, not the v1 mechanism.
+2. **Operator-as-merchant** (the instance admin connects their own gateway and
+   sells plugin access to their users). Fits single-tenant self-host cleanly, but
+   does not pay plugin authors — so it does not serve the stated goal. Rejected.
+3. **Honor-system / unsigned flags** (mark a plugin paid, no cryptographic
+   entitlement). Trivial to bypass; provides no real gate. Rejected.
+
+## Open questions
+
+1. **Decentralized license-key vs central store** as the v1 mechanism — the
+   primary fork. Recommendation: decentralized signed licenses now; central store
+   as a later optional layer.
+2. **License token format** — signed JWT vs a compact license key; **offline-only**
+   verification vs an optional **online** status check (for instant revocation).
+3. **Revocation** on refund/chargeback — short-lived tokens + renewal, an online
+   revocation list, or accept eventual expiry. Trade-off vs offline guarantee.
+4. **Payout routing** if any central/hosted component is offered (Stripe Connect?
+   author-direct only?).
+5. **Free trials**, **regional pricing/currency**, **proration**, **taxes/invoicing**
+   — likely out of v1; confirm.
+6. **Author identity & key distribution/rotation** and the **trust model** for
+   `community` plugins (who vouches for a public key?).
+7. Exact **SRS wording** to revise in §1.4/§4.6 (marketplace non-goal) and §1.7
+   (cloud-dependency), so "no hosted marketplace" and "monetization exists" coexist.
+
+## Adoption path
+
+1. Accept RFC → land the manifest `monetization` field + reserved `sdk.billing`
+   stub and `entitlements` table (additive, no behaviour change) — the same
+   reserve-first step used for RFC 0002.
+2. Implement **entitlement gating** (middleware + paywall) against manually
+   imported signed licenses — proves the model end to end with the **manual/bank**
+   adapter and zero external dependencies.
+3. Add the **Stripe** then **PayPal** adapters (hosted checkout + webhooks) and the
+   subscription-management UX in Account/Console.
+4. Revisit a central discovery/checkout layer only if there is demand.
+
+## Changelog
+
+| Version | Date     | Change         |
+| ------- | -------- | -------------- |
+| 0.1     | Jun 2026 | Initial draft. |

--- a/docs/rfcs/0004-per-plugin-database.md
+++ b/docs/rfcs/0004-per-plugin-database.md
@@ -1,0 +1,199 @@
+# RFC 0004 — Per-plugin database
+
+**Status:** Draft\
+**Date:** June 2026\
+**Author:** kasunben\
+**Scope:** Manifest schema (`packages/manifest`), DB layer (`packages/db`), migration runner, runtime SDK bridge (`sdk.db`), SRS\
+**Incorporated into plan:** No — this document proposes; the SRS, manifest, DB layer, and implementation tasks are updated only when this RFC is accepted.
+
+---
+
+## Summary
+
+Let a plugin opt into a **dedicated database** instead of sharing the platform
+database, via the manifest field that **already exists** but is unimplemented:
+
+```jsonc
+{ "database": "shared" | "isolated" } // default: "shared"
+```
+
+`shared` (today's behaviour) keeps the plugin's tables in the one platform
+database, namespaced by slug prefix. `isolated` gives the plugin its **own
+store** — a separate SQLite file, or a separate Postgres schema/database — which
+the runtime hands the plugin through `sdk.db.getClient()`. This buys schema
+freedom, a clean data lifecycle (uninstall drops the whole store), per-plugin
+backup/export, and stronger blast-radius isolation, at the cost of extra
+connections/migration runners and no cross-plugin SQL.
+
+**Shared stays the default.** Isolation is opt-in for plugins that genuinely need
+it.
+
+## Motivation
+
+The platform deliberately chose **one shared database with slug-prefixed tables**
+for simplicity (SRS §3.7, decision log): one connection, one migration runner, no
+cross-plugin query complexity. That is the right default and stays so.
+
+But some plugins want more than a namespace:
+
+- **Clean data lifecycle / right-to-be-forgotten.** Uninstalling a plugin (or
+  purging its data) should be a single, total operation — drop a file or a
+  schema — not a careful sweep of prefixed tables that risks orphans.
+- **Per-plugin backup, export, and portability.** A self-contained store can be
+  snapshotted, moved, or handed to the user without entangling other plugins'
+  data.
+- **Blast-radius isolation.** A plugin's heavy/abusive workload, a runaway
+  migration, or corruption is contained to its own store.
+- **Schema freedom.** Inside its own store a plugin needn't carry the slug prefix
+  and can't accidentally collide with another plugin's table names.
+
+`database: "isolated"` was reserved in the manifest from the start precisely to
+leave room for this; the field exists today but is documented as "not implemented
+in v1" (SRS §4.6/§5). This RFC designs it as a **post-v1** capability.
+
+## Current state (what this builds on)
+
+- **The manifest field already exists:** `database?: 'shared' | 'isolated'`
+  (`packages/manifest/src/schema.ts`, SRS §5). `isolated` is declared but
+  unimplemented (SRS §4.6).
+- **The DB factory already has the seam:** `createClient({ dialect?, url? })`
+  (`packages/db/src/client.ts`) accepts per-call dialect/URL overrides;
+  `resolveSqlitePath` resolves relative `file:` paths against the workspace root
+  into `data/`. (Postgres is recognised but not wired until Task 0.5.03.)
+- **`sdk.db.getClient()`** (Task 0.5.05) is the single point where the runtime
+  decides which client a plugin receives — the natural place to route an isolated
+  plugin to its dedicated store.
+- **Per-plugin migrations are already the model:** SRS §3.7 plans migration files
+  under `plugins/[id]/migrations/`, aggregated by the `packages/db` runner.
+- **Existing invariants to honour:** dialect-agnostic (SQLite default, Postgres
+  via env), `tenant_id` on user-scoped tables, and the SDK boundary (plugins
+  never read another plugin's data directly).
+
+## Proposed design
+
+### 1. `shared` (default) vs `isolated` (opt-in)
+
+`database` is resolved at plugin-load time from the manifest. `shared` (or the
+field omitted) is unchanged: prefixed tables in the platform DB. `isolated`
+provisions a dedicated store on first use. **Platform/chrome plugins
+(Console/Account/Launcher) are always `shared`** — they are core and co-located
+with platform tables.
+
+### 2. Isolation mechanism by dialect
+
+- **SQLite** → a dedicated file per plugin, e.g. `data/plugins/<pluginId>.db`,
+  created via `createClient({ url: 'file:./data/plugins/<id>.db' })`. The existing
+  `resolveSqlitePath` + `mkdirSync` already handle the path and directory.
+- **Postgres** → two candidate mechanisms (see Open questions; **schema-per-plugin
+  recommended**):
+  - **Schema-per-plugin (recommended):** one connection/pool; each isolated plugin
+    gets its own Postgres schema (`CREATE SCHEMA`, `search_path`/qualified names).
+    Light, keeps a single pool, fits the "one connection" ethos, easy to drop
+    (`DROP SCHEMA … CASCADE`).
+  - **Database-per-plugin (alternative):** a separate Postgres database +
+    connection per plugin. Strongest isolation and the cleanest backup/drop, but a
+    **connection pool per plugin** (exhaustion risk at scale) and heavier ops
+    (provisioning a database needs elevated privileges).
+
+### 3. Client routing
+
+The runtime's `sdk.db` bridge consults the plugin's resolved `database` setting
+and returns either the shared platform client or a **dedicated client** built
+from `createClient({ dialect, url })`. A small **per-plugin client registry**
+(keyed by plugin id) caches clients and initialises them **lazily** on first
+`getClient()`. Plugins call `sdk.db.getClient()` exactly as before — isolation is
+transparent to plugin code.
+
+### 4. Migrations
+
+Each isolated plugin runs **its own migrations against its own store**, with its
+**own migration-tracking table** (so version state is per-database). The
+`packages/db` runner routes per plugin: platform migrations against the platform
+DB first, then each plugin's migrations against its resolved store (shared → the
+platform DB; isolated → its dedicated store). This extends the §3.7 aggregation
+model rather than replacing it.
+
+### 5. Slug prefix inside an isolated store
+
+Inside its own database a plugin **no longer needs the slug prefix** — schema
+freedom is a stated benefit. The trade-off: dropping the prefix makes a later
+**`shared` ↔ `isolated` switch** a table-rename data migration. Options (Open
+questions): keep the prefix everywhere for switchability, or drop it in isolated
+stores for cleanliness and treat the mode as fixed at install. Recommendation:
+treat `database` as **fixed at install**; switching is an explicit,
+migration-backed operation, not a manifest toggle.
+
+### 6. Lifecycle
+
+- **Provision** on first `getClient()` (create the file / `CREATE SCHEMA`).
+- **Uninstall / purge** drops the whole store (delete the file / `DROP SCHEMA …
+CASCADE`) — a single, total deletion.
+- **Backup/export** can target one plugin's store directly.
+
+### 7. Boundaries and multi-tenancy
+
+- `tenant_id` still applies to user-scoped tables **inside** an isolated store
+  (multi-tenancy readiness is unchanged).
+- Isolated stores make cross-plugin **joins impossible**, which **reinforces the
+  SDK boundary** — any cross-plugin read must go through the consent-gated
+  `sdk.data` mechanism (RFC 0002), never a direct query.
+
+## Impact when accepted (deferred — no edits yet)
+
+| Where                                    | Change                                                                                                           |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `packages/manifest`                      | No schema change (`database` already exists); document `isolated` as supported; validation/tests as needed.      |
+| `packages/db`                            | Per-plugin client factory + registry; Postgres schema (or database) provisioning + drop; reuse `createClient`.   |
+| Migration runner (`packages/db/migrate`) | Route each plugin's migrations to its resolved store; per-store tracking table.                                  |
+| Runtime SDK bridge                       | `sdk.db.getClient()` returns the shared or dedicated client per the plugin's `database` setting.                 |
+| Plugin lifecycle (Console / install)     | Provision on first use; drop store on uninstall/purge; per-plugin backup/export hooks.                           |
+| SRS §3.7 / §4.6 / §5 / decision log      | Update "no per-plugin DBs" / "not implemented" wording; record the opt-in isolated model and its default-shared. |
+| `docs/sovereign-implementation-tasks.md` | A phased implementation task (SQLite file isolation first; Postgres schema; lifecycle/backup).                   |
+
+## Alternatives considered
+
+1. **Status quo — shared-only with slug prefixes.** Simplest and stays the
+   **default**, but offers no clean per-plugin deletion, backup, or strong
+   isolation. Rejected as the _only_ option; retained as the default.
+2. **Database-per-plugin for Postgres** (instead of schema-per-plugin). Stronger
+   isolation and cleanest drop/backup, but a connection pool per plugin and
+   heavier provisioning. The primary Open question.
+3. **Bring-your-own / external database now** (operator points a plugin at an
+   external connection string, possibly a different engine). Most flexible but
+   adds secret management, config surface, and dialect-divergence risk. Deferred
+   to a future extension (Open questions).
+4. **A different engine per plugin** (e.g. a document store for one plugin).
+   Out of scope — the platform stays dialect-agnostic over SQLite/Postgres.
+
+## Open questions
+
+1. **Postgres mechanism — schema-per-plugin vs database-per-plugin.** The primary
+   fork; recommendation is schema-per-plugin for the single-pool/light footprint.
+2. **Slug prefix inside isolated stores**, and the **`shared` ↔ `isolated`
+   switching** story (fixed-at-install vs migration-backed toggle).
+3. **Connection pooling/limits** for Postgres; **lazy vs eager** client init;
+   handling many isolated plugins on one instance.
+4. **Bring-your-own external database** — operator env-config (never manifest
+   secrets); whether a non-platform engine is ever allowed.
+5. **Per-plugin backup/export tooling**, and the **uninstall data policy** (drop
+   immediately vs retain/export-then-drop).
+6. **Provisioning privileges** for Postgres (creating schemas/databases needs
+   rights the runtime DB role may not have by default).
+
+## Adoption path
+
+1. Accept RFC → confirm `database: "isolated"` is supported (manifest already
+   carries the field; no schema change) and update the SRS wording.
+2. Implement **SQLite file isolation** end to end (dedicated file via
+   `createClient`, per-plugin client registry, per-store migrations) — proves the
+   model with zero new infrastructure.
+3. Add the **Postgres** mechanism (schema-per-plugin per the resolved Open
+   question) once Postgres is wired (Task 0.5.03).
+4. Add lifecycle hooks (provision/drop) and per-plugin backup/export; revisit BYO
+   external databases only if there is demand.
+
+## Changelog
+
+| Version | Date     | Change         |
+| ------- | -------- | -------------- |
+| 0.1     | Jun 2026 | Initial draft. |


### PR DESCRIPTION
Two **draft design RFCs** — no implementation, no SRS or code changes (everything is deferred to each RFC's "Impact when accepted"). Both follow the existing RFC template and name no real plugin.

## RFC 0003 — Plugin monetization
`docs/rfcs/0003-plugin-monetization.md`

Per-plugin paid access: a plugin declares its model (`free | one_time | recurring{interval} | pay_what_you_want`) with optional tiers.
- **Plugin author is the merchant** and **fixes the price** in the manifest.
- Access is granted by an **author-issued signed license**, verified **offline** against the author's public key → works self-hosted with **no mandatory central service**; **manual/bank transfer** is first-class.
- **Payment-provider adapter** abstraction: manual/bank, Stripe, PayPal (hosted checkout only — no card data on the instance); extensible.
- **Enforcement:** middleware route-gate by entitlement (paywall / `402`) + a reserved `sdk.billing` surface for in-plugin tier gating.
- Reconciles the "no public marketplace" non-goal (this is licensing plumbing, not a hosted store); central marketplace (Stripe Connect) documented as the alternative.

## RFC 0004 — Per-plugin database
`docs/rfcs/0004-per-plugin-database.md`

Designs the already-reserved `database: "isolated"` manifest option; **`shared` stays the default**.
- **SQLite** → a dedicated file `data/plugins/<id>.db`; **Postgres** → schema-per-plugin (recommended) vs database-per-plugin (the open fork).
- **Routing** reuses the existing `createClient({ url })` seam via `sdk.db.getClient()` + a lazy per-plugin client registry; per-plugin migrations extend the `plugins/[id]/migrations/` model with a per-store tracking table.
- Benefits: clean data lifecycle / right-to-be-forgotten, per-plugin backup/export, blast-radius isolation, schema freedom. Reinforces the SDK boundary (no cross-DB joins → cross-plugin reads go via RFC 0002's `sdk.data`).
- **BYO external DB** deferred to a future open question.

Docs-only → no package version bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)