### PR TITLE
Make the platform data layer async (Postgres prerequisite)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,12 @@ pnpm lint:fix        # run ESLint with auto-fix
   multi-tenancy), even though no multi-tenant logic exists in v1.
 - **DB is dialect-agnostic** (Drizzle): SQLite default, Postgres via env only.
   No SQLite-specific SQL in app code.
+- **The platform data layer is async** (Task 0.5.03). Postgres (node-postgres)
+  has no synchronous query, so `getPlatformDb()` and every `packages/db` platform
+  helper (`getPlatformSetting`, `setAccountPrefs`, …) and `sdk.platform.getConfig()`
+  return promises — always `await` them. (On SQLite the underlying better-sqlite3
+  calls still run synchronously; the async signature is the dialect-agnostic
+  contract.) Never reintroduce a synchronous platform-DB read.
 - **Relative SQLite paths resolve against the workspace root** (nearest
   ancestor with `pnpm-workspace.yaml`), not the process cwd — all SQLite files
   land in the single root-level `data/` directory regardless of which app

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -1,0 +1,31 @@
+# Upgrade guide
+
+Migration notes for breaking changes. Per NFR-04, any breaking change to a
+published package (`@sovereignfs/sdk`, `@sovereignfs/ui`) ships with at least a
+minor version bump and an entry here.
+
+## `@sovereignfs/sdk` 0.5.0 → 0.6.0
+
+### `sdk.platform.getConfig()` is now async
+
+To make the platform database **dialect-agnostic** (SQLite and Postgres — Task
+0.5.03), the platform data layer can no longer assume synchronous queries:
+node-postgres has no synchronous API. `sdk.platform.getConfig()` therefore now
+returns a `Promise<PlatformConfig>` instead of `PlatformConfig`.
+
+**Before:**
+
+```ts
+const config = sdk.platform.getConfig();
+console.log(config.tenantName);
+```
+
+**After:**
+
+```ts
+const config = await sdk.platform.getConfig();
+console.log(config.tenantName);
+```
+
+The caller must be in an async context (server components, route handlers, and
+server actions all qualify). The returned `PlatformConfig` shape is unchanged.

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sovereignfs/db",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "description": "Drizzle client factory, platform schema, and migration runner for Sovereign.",

--- a/packages/db/src/platform-db.test.ts
+++ b/packages/db/src/platform-db.test.ts
@@ -12,84 +12,92 @@ import {
   type PlatformDb,
 } from './platform-db';
 
-function freshDb(): PlatformDb {
+async function freshDb(): Promise<PlatformDb> {
   const db = createClient({ url: ':memory:' });
-  bootstrapPlatformDb(db);
+  await bootstrapPlatformDb(db);
   return db;
 }
 
 describe('bootstrapPlatformDb', () => {
-  it('seeds the default tenant', () => {
-    const tenant = getDefaultTenant(freshDb());
+  it('seeds the default tenant', async () => {
+    const tenant = await getDefaultTenant(await freshDb());
     expect(tenant.id).toBe('default');
     expect(tenant.name).toBe('Sovereign');
   });
 
-  it('seeds root_plugin_id with the Launcher default', () => {
-    expect(getPlatformSetting(freshDb(), 'root_plugin_id')).toBe(DEFAULT_ROOT_PLUGIN_ID);
+  it('seeds root_plugin_id with the Launcher default', async () => {
+    expect(await getPlatformSetting(await freshDb(), 'root_plugin_id')).toBe(
+      DEFAULT_ROOT_PLUGIN_ID,
+    );
   });
 
-  it('is idempotent and does not overwrite existing values', () => {
-    const db = freshDb();
-    setTenantName(db, 'Acme');
-    setPlatformSetting(db, 'root_plugin_id', 'fs.example.tasks');
+  it('is idempotent and does not overwrite existing values', async () => {
+    const db = await freshDb();
+    await setTenantName(db, 'Acme');
+    await setPlatformSetting(db, 'root_plugin_id', 'fs.example.tasks');
 
-    bootstrapPlatformDb(db); // simulate a second startup
+    await bootstrapPlatformDb(db); // simulate a second startup
 
-    expect(getDefaultTenant(db).name).toBe('Acme');
-    expect(getPlatformSetting(db, 'root_plugin_id')).toBe('fs.example.tasks');
+    expect((await getDefaultTenant(db)).name).toBe('Acme');
+    expect(await getPlatformSetting(db, 'root_plugin_id')).toBe('fs.example.tasks');
   });
 });
 
 describe('platform settings helpers', () => {
-  it('returns null for an unset key', () => {
-    expect(getPlatformSetting(freshDb(), 'no_such_key')).toBeNull();
+  it('returns null for an unset key', async () => {
+    expect(await getPlatformSetting(await freshDb(), 'no_such_key')).toBeNull();
   });
 
-  it('round-trips a new setting', () => {
-    const db = freshDb();
-    setPlatformSetting(db, 'invite_only', 'true');
-    expect(getPlatformSetting(db, 'invite_only')).toBe('true');
+  it('round-trips a new setting', async () => {
+    const db = await freshDb();
+    await setPlatformSetting(db, 'invite_only', 'true');
+    expect(await getPlatformSetting(db, 'invite_only')).toBe('true');
   });
 
-  it('upserts an existing setting', () => {
-    const db = freshDb();
-    setPlatformSetting(db, 'invite_only', 'true');
-    setPlatformSetting(db, 'invite_only', 'false');
-    expect(getPlatformSetting(db, 'invite_only')).toBe('false');
+  it('upserts an existing setting', async () => {
+    const db = await freshDb();
+    await setPlatformSetting(db, 'invite_only', 'true');
+    await setPlatformSetting(db, 'invite_only', 'false');
+    expect(await getPlatformSetting(db, 'invite_only')).toBe('false');
   });
 });
 
 describe('tenant helpers', () => {
-  it('renames the default tenant', () => {
-    const db = freshDb();
-    setTenantName(db, 'My Workspace');
-    expect(getDefaultTenant(db).name).toBe('My Workspace');
+  it('renames the default tenant', async () => {
+    const db = await freshDb();
+    await setTenantName(db, 'My Workspace');
+    expect((await getDefaultTenant(db)).name).toBe('My Workspace');
   });
 });
 
 describe('account preferences helpers', () => {
-  it('returns UTC + system defaults when no row exists', () => {
-    expect(getAccountPrefs(freshDb(), 'u1')).toEqual({ timezone: 'UTC', theme: 'system' });
+  it('returns UTC + system defaults when no row exists', async () => {
+    expect(await getAccountPrefs(await freshDb(), 'u1')).toEqual({
+      timezone: 'UTC',
+      theme: 'system',
+    });
   });
 
-  it('inserts a row on first set and round-trips it', () => {
-    const db = freshDb();
-    const next = setAccountPrefs(db, 'u1', { timezone: 'America/New_York', theme: 'dark' });
+  it('inserts a row on first set and round-trips it', async () => {
+    const db = await freshDb();
+    const next = await setAccountPrefs(db, 'u1', { timezone: 'America/New_York', theme: 'dark' });
     expect(next).toEqual({ timezone: 'America/New_York', theme: 'dark' });
-    expect(getAccountPrefs(db, 'u1')).toEqual({ timezone: 'America/New_York', theme: 'dark' });
+    expect(await getAccountPrefs(db, 'u1')).toEqual({
+      timezone: 'America/New_York',
+      theme: 'dark',
+    });
   });
 
-  it('merges a partial update, leaving other fields intact', () => {
-    const db = freshDb();
-    setAccountPrefs(db, 'u1', { timezone: 'Europe/Berlin', theme: 'light' });
-    setAccountPrefs(db, 'u1', { theme: 'dark' });
-    expect(getAccountPrefs(db, 'u1')).toEqual({ timezone: 'Europe/Berlin', theme: 'dark' });
+  it('merges a partial update, leaving other fields intact', async () => {
+    const db = await freshDb();
+    await setAccountPrefs(db, 'u1', { timezone: 'Europe/Berlin', theme: 'light' });
+    await setAccountPrefs(db, 'u1', { theme: 'dark' });
+    expect(await getAccountPrefs(db, 'u1')).toEqual({ timezone: 'Europe/Berlin', theme: 'dark' });
   });
 
-  it('keeps preferences isolated per user', () => {
-    const db = freshDb();
-    setAccountPrefs(db, 'u1', { theme: 'dark' });
-    expect(getAccountPrefs(db, 'u2')).toEqual({ timezone: 'UTC', theme: 'system' });
+  it('keeps preferences isolated per user', async () => {
+    const db = await freshDb();
+    await setAccountPrefs(db, 'u1', { theme: 'dark' });
+    expect(await getAccountPrefs(db, 'u2')).toEqual({ timezone: 'UTC', theme: 'system' });
   });
 });

--- a/packages/db/src/platform-db.ts
+++ b/packages/db/src/platform-db.ts
@@ -18,8 +18,13 @@ const DEFAULT_TENANT_NAME = 'Sovereign';
  * Apply the interim DDL bootstrap and seed rows to a client. Idempotent —
  * CREATE TABLE IF NOT EXISTS plus conflict-ignoring inserts. Exported
  * separately from the singleton so tests can run it against :memory:.
+ *
+ * Async by contract: Postgres (node-postgres) has no synchronous query, so the
+ * whole platform data layer is async. On SQLite (better-sqlite3) the underlying
+ * calls run synchronously and resolve immediately. Postgres execution lands in
+ * the next change (Task 0.5.03 driver wiring); the bodies here stay SQLite.
  */
-export function bootstrapPlatformDb(db: PlatformDb): void {
+export async function bootstrapPlatformDb(db: PlatformDb): Promise<void> {
   for (const statement of PLATFORM_BOOTSTRAP_SQL) {
     db.run(sql.raw(statement));
   }
@@ -42,21 +47,27 @@ export function bootstrapPlatformDb(db: PlatformDb): void {
     .run();
 }
 
-let _db: PlatformDb | null = null;
+let _dbPromise: Promise<PlatformDb> | null = null;
 
 /**
  * The platform database, initialised once per process from the environment
  * (DATABASE_URL / DB_DIALECT) with tables bootstrapped and seed rows present.
+ * The initialisation promise is memoised so bootstrap runs exactly once even
+ * under concurrent first calls.
  */
-export function getPlatformDb(): PlatformDb {
-  if (_db) return _db;
-  _db = createClient();
-  bootstrapPlatformDb(_db);
-  return _db;
+export function getPlatformDb(): Promise<PlatformDb> {
+  if (!_dbPromise) {
+    _dbPromise = (async () => {
+      const db = createClient();
+      await bootstrapPlatformDb(db);
+      return db;
+    })();
+  }
+  return _dbPromise;
 }
 
 /** Read a platform setting for the default tenant. Returns null when unset. */
-export function getPlatformSetting(db: PlatformDb, key: string): string | null {
+export async function getPlatformSetting(db: PlatformDb, key: string): Promise<string | null> {
   const row = db
     .select({ value: schema.platformSettings.value })
     .from(schema.platformSettings)
@@ -71,7 +82,11 @@ export function getPlatformSetting(db: PlatformDb, key: string): string | null {
 }
 
 /** Upsert a platform setting for the default tenant. */
-export function setPlatformSetting(db: PlatformDb, key: string, value: string): void {
+export async function setPlatformSetting(
+  db: PlatformDb,
+  key: string,
+  value: string,
+): Promise<void> {
   const now = Math.floor(Date.now() / 1000);
   db.insert(schema.platformSettings)
     .values({ key, tenantId: DEFAULT_TENANT_ID, value, updatedAt: now })
@@ -83,7 +98,7 @@ export function setPlatformSetting(db: PlatformDb, key: string, value: string): 
 }
 
 /** The default tenant row. Always present after bootstrap. */
-export function getDefaultTenant(db: PlatformDb): schema.Tenant {
+export async function getDefaultTenant(db: PlatformDb): Promise<schema.Tenant> {
   const tenant = db
     .select()
     .from(schema.tenants)
@@ -96,7 +111,7 @@ export function getDefaultTenant(db: PlatformDb): schema.Tenant {
 }
 
 /** Rename the default tenant (CON-08). */
-export function setTenantName(db: PlatformDb, name: string): void {
+export async function setTenantName(db: PlatformDb, name: string): Promise<void> {
   const now = Math.floor(Date.now() / 1000);
   db.update(schema.tenants)
     .set({ name, updatedAt: now })
@@ -113,7 +128,7 @@ export interface AccountPrefsValue {
 const DEFAULT_ACCOUNT_PREFS: AccountPrefsValue = { timezone: 'UTC', theme: 'system' };
 
 /** A user's Account preferences, falling back to defaults when no row exists. */
-export function getAccountPrefs(db: PlatformDb, userId: string): AccountPrefsValue {
+export async function getAccountPrefs(db: PlatformDb, userId: string): Promise<AccountPrefsValue> {
   const row = db
     .select({ timezone: schema.accountPrefs.timezone, theme: schema.accountPrefs.theme })
     .from(schema.accountPrefs)
@@ -123,12 +138,12 @@ export function getAccountPrefs(db: PlatformDb, userId: string): AccountPrefsVal
 }
 
 /** Upsert a user's Account preferences (one row per user). */
-export function setAccountPrefs(
+export async function setAccountPrefs(
   db: PlatformDb,
   userId: string,
   prefs: Partial<AccountPrefsValue>,
-): AccountPrefsValue {
-  const current = getAccountPrefs(db, userId);
+): Promise<AccountPrefsValue> {
+  const current = await getAccountPrefs(db, userId);
   const next = { ...current, ...prefs };
   const now = Math.floor(Date.now() / 1000);
   db.insert(schema.accountPrefs)

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sovereignfs/sdk",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "description": "Sovereign SDK — the plugin↔platform contract (types and interfaces).",
   "license": "AGPL-3.0",

--- a/packages/sdk/src/platform.ts
+++ b/packages/sdk/src/platform.ts
@@ -28,13 +28,19 @@ function getPlatformVersion(): string {
 
 /**
  * Returns the platform runtime configuration (SRS PLT-06). Reads the platform
- * database directly — synchronous by contract, which better-sqlite3 supports.
+ * database directly. Async by contract: the platform DB is dialect-agnostic and
+ * Postgres (node-postgres) has no synchronous query, so this resolves a promise
+ * (on SQLite the underlying reads complete synchronously).
  */
-export function getConfig(): PlatformConfig {
-  const db = getPlatformDb();
+export async function getConfig(): Promise<PlatformConfig> {
+  const db = await getPlatformDb();
+  const [tenant, inviteOnly] = await Promise.all([
+    getDefaultTenant(db),
+    getPlatformSetting(db, 'invite_only'),
+  ]);
   return {
-    tenantName: getDefaultTenant(db).name,
-    inviteOnly: getPlatformSetting(db, 'invite_only') === 'true',
+    tenantName: tenant.name,
+    inviteOnly: inviteOnly === 'true',
     version: getPlatformVersion(),
   };
 }

--- a/packages/sdk/src/sdk.test.ts
+++ b/packages/sdk/src/sdk.test.ts
@@ -30,8 +30,8 @@ describe('sdk', () => {
     expect(() => sdk.db.getClient()).toThrow(NotImplementedError);
   });
 
-  it('platform.getConfig returns tenant name, invite flag, and platform version', () => {
-    const config = sdk.platform.getConfig();
+  it('platform.getConfig returns tenant name, invite flag, and platform version', async () => {
+    const config = await sdk.platform.getConfig();
     expect(config.tenantName).toBe('Sovereign');
     expect(config.inviteOnly).toBe(false);
     expect(config.version).toMatch(/^\d+\.\d+\.\d+/);

--- a/runtime/app/(platform)/page.tsx
+++ b/runtime/app/(platform)/page.tsx
@@ -8,9 +8,9 @@ import styles from './page.module.css';
 // Force dynamic so a root-plugin change in Console takes effect immediately.
 export const dynamic = 'force-dynamic';
 
-export default function Home() {
+export default async function Home() {
   const rootPluginId =
-    getPlatformSetting(getPlatformDb(), 'root_plugin_id') ?? DEFAULT_ROOT_PLUGIN_ID;
+    (await getPlatformSetting(await getPlatformDb(), 'root_plugin_id')) ?? DEFAULT_ROOT_PLUGIN_ID;
   const rootPlugin = getInstalledPlugins().find((plugin) => plugin.id === rootPluginId);
 
   if (rootPlugin) {

--- a/runtime/app/api/account/prefs/route.ts
+++ b/runtime/app/api/account/prefs/route.ts
@@ -16,7 +16,7 @@ function currentUserId(request: Request): string | null {
 export async function GET(request: Request): Promise<Response> {
   const userId = currentUserId(request);
   if (!userId) return NextResponse.json({ error: 'unauthenticated' }, { status: 401 });
-  return NextResponse.json(getAccountPrefs(getPlatformDb(), userId));
+  return NextResponse.json(await getAccountPrefs(await getPlatformDb(), userId));
 }
 
 export async function PATCH(request: Request): Promise<Response> {
@@ -39,7 +39,7 @@ export async function PATCH(request: Request): Promise<Response> {
     patch.theme = body.theme;
   }
 
-  const next = setAccountPrefs(getPlatformDb(), userId, patch);
+  const next = await setAccountPrefs(await getPlatformDb(), userId, patch);
   const res = NextResponse.json(next);
 
   // Mirror the theme to a cookie so the shell can resolve it before first paint

--- a/runtime/app/api/admin/health/route.ts
+++ b/runtime/app/api/admin/health/route.ts
@@ -28,7 +28,7 @@ export async function GET(request: Request): Promise<Response> {
 
   let dbStatus: 'ok' | 'error' = 'ok';
   try {
-    getPlatformDb().get(sql`SELECT 1`);
+    (await getPlatformDb()).get(sql`SELECT 1`);
   } catch {
     dbStatus = 'error';
   }
@@ -52,7 +52,7 @@ export async function GET(request: Request): Promise<Response> {
   }
 
   const report: HealthReport = {
-    platformVersion: sdk.platform.getConfig().version,
+    platformVersion: (await sdk.platform.getConfig()).version,
     database: { dialect: resolved.dialect, status: dbStatus, sizeBytes },
     auth: { status: authStatus },
     uptimeSeconds: Math.floor(process.uptime()),

--- a/runtime/app/api/admin/plugins/[id]/route.ts
+++ b/runtime/app/api/admin/plugins/[id]/route.ts
@@ -23,7 +23,7 @@ export async function PATCH(request: Request, { params }: RouteParams): Promise<
     return NextResponse.json({ error: 'enabled (boolean) is required' }, { status: 400 });
   }
 
-  const db = getPlatformDb();
+  const db = await getPlatformDb();
   const now = Math.floor(Date.now() / 1000);
 
   db.insert(schema.pluginStatus)

--- a/runtime/app/api/admin/plugins/disabled/route.ts
+++ b/runtime/app/api/admin/plugins/disabled/route.ts
@@ -14,7 +14,7 @@ export async function GET(request: Request): Promise<Response> {
   const denied = checkAdminKey(request);
   if (denied) return denied;
 
-  const db = getPlatformDb();
+  const db = await getPlatformDb();
   const rows = db
     .select({ pluginId: schema.pluginStatus.pluginId })
     .from(schema.pluginStatus)

--- a/runtime/app/api/admin/plugins/route.ts
+++ b/runtime/app/api/admin/plugins/route.ts
@@ -8,7 +8,7 @@ export async function GET(request: Request): Promise<Response> {
   const denied = checkAdminKey(request);
   if (denied) return denied;
 
-  const db = getPlatformDb();
+  const db = await getPlatformDb();
   const statusRows = db.select().from(schema.pluginStatus).all();
   const statusMap = new Map(statusRows.map((r) => [r.pluginId, r.enabled]));
 

--- a/runtime/app/api/admin/root-plugin/route.ts
+++ b/runtime/app/api/admin/root-plugin/route.ts
@@ -16,8 +16,8 @@ export async function GET(request: Request): Promise<Response> {
   const denied = checkAdminKey(request);
   if (denied) return denied;
 
-  const db = getPlatformDb();
-  const rootPluginId = getPlatformSetting(db, 'root_plugin_id') ?? DEFAULT_ROOT_PLUGIN_ID;
+  const db = await getPlatformDb();
+  const rootPluginId = (await getPlatformSetting(db, 'root_plugin_id')) ?? DEFAULT_ROOT_PLUGIN_ID;
   const disabledIds = new Set(
     db
       .select({ pluginId: schema.pluginStatus.pluginId })

--- a/runtime/app/api/admin/settings/route.ts
+++ b/runtime/app/api/admin/settings/route.ts
@@ -15,19 +15,24 @@ import { validateRootPlugin } from '@/src/root-plugin';
 
 const AUTH_URL = process.env.SOVEREIGN_AUTH_URL ?? 'http://localhost:3001';
 
-function readSettings() {
-  const db = getPlatformDb();
+async function readSettings() {
+  const db = await getPlatformDb();
+  const [tenant, inviteOnly, rootPluginId] = await Promise.all([
+    getDefaultTenant(db),
+    getPlatformSetting(db, 'invite_only'),
+    getPlatformSetting(db, 'root_plugin_id'),
+  ]);
   return {
-    tenantName: getDefaultTenant(db).name,
-    inviteOnly: getPlatformSetting(db, 'invite_only') === 'true',
-    rootPluginId: getPlatformSetting(db, 'root_plugin_id') ?? DEFAULT_ROOT_PLUGIN_ID,
+    tenantName: tenant.name,
+    inviteOnly: inviteOnly === 'true',
+    rootPluginId: rootPluginId ?? DEFAULT_ROOT_PLUGIN_ID,
   };
 }
 
 export async function GET(request: Request): Promise<Response> {
   const denied = checkAdminKey(request);
   if (denied) return denied;
-  return NextResponse.json(readSettings());
+  return NextResponse.json(await readSettings());
 }
 
 export async function PATCH(request: Request): Promise<Response> {
@@ -39,14 +44,14 @@ export async function PATCH(request: Request): Promise<Response> {
     inviteOnly?: boolean;
     rootPluginId?: string;
   };
-  const db = getPlatformDb();
+  const db = await getPlatformDb();
 
   if (body.tenantName !== undefined) {
     const name = body.tenantName.trim();
     if (name.length === 0) {
       return NextResponse.json({ error: 'tenantName must not be empty' }, { status: 400 });
     }
-    setTenantName(db, name);
+    await setTenantName(db, name);
   }
 
   if (body.rootPluginId !== undefined) {
@@ -65,7 +70,7 @@ export async function PATCH(request: Request): Promise<Response> {
         { status: 400 },
       );
     }
-    setPlatformSetting(db, 'root_plugin_id', body.rootPluginId);
+    await setPlatformSetting(db, 'root_plugin_id', body.rootPluginId);
   }
 
   if (body.inviteOnly !== undefined) {
@@ -88,8 +93,8 @@ export async function PATCH(request: Request): Promise<Response> {
         { status: 502 },
       );
     }
-    setPlatformSetting(db, 'invite_only', String(body.inviteOnly));
+    await setPlatformSetting(db, 'invite_only', String(body.inviteOnly));
   }
 
-  return NextResponse.json(readSettings());
+  return NextResponse.json(await readSettings());
 }

--- a/runtime/app/api/plugins/route.ts
+++ b/runtime/app/api/plugins/route.ts
@@ -14,7 +14,7 @@ import { selectLauncherPlugins } from '@/src/launcher-plugins';
 export async function GET(request: Request): Promise<Response> {
   const role = request.headers.get('x-sovereign-user-role') ?? 'platform:user';
 
-  const db = getPlatformDb();
+  const db = await getPlatformDb();
   const disabledIds = new Set(
     db
       .select({ pluginId: schema.pluginStatus.pluginId })


### PR DESCRIPTION
**Phase 1a of Task 0.5.03 (Postgres validation).** Postgres (node-postgres) has no synchronous query, but the platform data layer was *synchronous by contract* (better-sqlite3's sync API). This converts it to **async** so it can be made dialect-agnostic. The actual Postgres driver/schema/bootstrap land in the next PR (1b) — this is a **behaviour-preserving sync→async refactor on SQLite**, isolated so the async ripple is proven before any Postgres code.

## Changes
- **`packages/db/platform-db.ts`** — `bootstrapPlatformDb` + every platform helper (`getPlatformSetting`, `setPlatformSetting`, `getDefaultTenant`, `setTenantName`, `getAccountPrefs`, `setAccountPrefs`) are now `async`; `getPlatformDb()` returns a `Promise` and **memoizes the init promise** (bootstrap runs exactly once under concurrent first calls). SQLite query bodies unchanged.
- **`sdk.platform.getConfig()`** is now `async`.
- **Runtime** — all call sites `await` `getPlatformDb()` and the helpers (the `page.tsx` server component, account-prefs, health, the admin plugin/settings/root-plugin routes, gated `/api/plugins`). Direct inline Drizzle `.all()/.get()/.run()` terminals stay synchronous until PR1b makes them dialect-aware.
- Tests updated to async.

## Breaking change (NFR-04)
`sdk.platform.getConfig()` now returns `Promise<PlatformConfig>`. Migration note added in **`docs/upgrade.md`**. Version bumps: `@sovereignfs/sdk` 0.5.0 → **0.6.0** (breaking), `@sovereignfs/db` 0.4.0 → **0.5.0**.

## Verification
`format:check`, `lint`, `typecheck` (12/12), `build` (8/8), `test` (144) all pass. SQLite behaviour is identical.

## Context
First of 4 PRs for Task 0.5.03: **1a async (this)** → 1b Postgres driver/schema/bootstrap → 2 apps/auth Postgres → 3 compose + docs + end-to-end validation. CLAUDE.md gains a load-bearing note: the platform data layer is async — always `await`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)