### PR TITLE
Wire Postgres in packages/db (driver, dialect schema, dialect-aware execution)

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sovereignfs/db",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "description": "Drizzle client factory, platform schema, and migration runner for Sovereign.",

--- a/packages/db/src/bootstrap.ts
+++ b/packages/db/src/bootstrap.ts
@@ -1,57 +1,51 @@
+import type { Dialect } from './dialect';
+
 /**
  * Interim DDL bootstrap for platform tables, applied with
- * CREATE TABLE IF NOT EXISTS by `getPlatformDb()` at startup. Replaced by
- * drizzle-kit migrations in Task 0.5.03.
+ * CREATE TABLE IF NOT EXISTS by `bootstrapPlatformDb()` at startup. Replaced by
+ * drizzle-kit migrations later (0.5.05+).
  *
- * Must stay in sync with ./schema/sqlite/platform.ts — the Drizzle schema is
- * the source of truth for shape; this DDL only exists because migrations are
- * not wired yet. Statements are pure DDL (no seeding) so they stay
- * dialect-portable; seed rows are inserted via Drizzle in platform-db.ts with
+ * Must stay in sync with ./schema/{sqlite,postgres}/platform.ts — the Drizzle
+ * schemas are the source of truth for shape (a parity test guards that the two
+ * dialects match); this DDL only exists because migrations are not wired yet.
+ * Statements are pure DDL (no seeding); seed rows are inserted separately with
  * caller-supplied timestamps.
+ *
+ * Dialect differences: timestamps are `INTEGER` (SQLite) vs `BIGINT` (Postgres,
+ * to avoid the 2038 32-bit overflow); booleans are `INTEGER` 0/1 (SQLite) vs
+ * native `BOOLEAN` (Postgres).
  */
+export function platformBootstrapStatements(dialect: Dialect): readonly string[] {
+  const ts = dialect === 'postgres' ? 'BIGINT' : 'INTEGER';
+  const bool = dialect === 'postgres' ? 'BOOLEAN' : 'INTEGER';
+  const boolTrue = dialect === 'postgres' ? 'TRUE' : '1';
 
-export const TENANTS_BOOTSTRAP_SQL = `
-  CREATE TABLE IF NOT EXISTS tenants (
-    id TEXT PRIMARY KEY,
-    name TEXT NOT NULL,
-    created_at INTEGER NOT NULL,
-    updated_at INTEGER NOT NULL
-  )
-`;
-
-export const PLUGIN_STATUS_BOOTSTRAP_SQL = `
-  CREATE TABLE IF NOT EXISTS plugin_status (
-    plugin_id TEXT PRIMARY KEY,
-    tenant_id TEXT NOT NULL,
-    enabled INTEGER NOT NULL DEFAULT 1,
-    updated_at INTEGER NOT NULL
-  )
-`;
-
-export const PLATFORM_SETTINGS_BOOTSTRAP_SQL = `
-  CREATE TABLE IF NOT EXISTS platform_settings (
-    key TEXT NOT NULL,
-    tenant_id TEXT NOT NULL,
-    value TEXT NOT NULL,
-    updated_at INTEGER NOT NULL,
-    PRIMARY KEY (key, tenant_id)
-  )
-`;
-
-export const ACCOUNT_PREFS_BOOTSTRAP_SQL = `
-  CREATE TABLE IF NOT EXISTS account_prefs (
-    user_id TEXT PRIMARY KEY,
-    tenant_id TEXT NOT NULL,
-    timezone TEXT NOT NULL DEFAULT 'UTC',
-    theme TEXT NOT NULL DEFAULT 'system',
-    updated_at INTEGER NOT NULL
-  )
-`;
-
-/** All platform DDL statements, in dependency order. */
-export const PLATFORM_BOOTSTRAP_SQL: readonly string[] = [
-  TENANTS_BOOTSTRAP_SQL,
-  PLUGIN_STATUS_BOOTSTRAP_SQL,
-  PLATFORM_SETTINGS_BOOTSTRAP_SQL,
-  ACCOUNT_PREFS_BOOTSTRAP_SQL,
-];
+  return [
+    `CREATE TABLE IF NOT EXISTS tenants (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      created_at ${ts} NOT NULL,
+      updated_at ${ts} NOT NULL
+    )`,
+    `CREATE TABLE IF NOT EXISTS plugin_status (
+      plugin_id TEXT PRIMARY KEY,
+      tenant_id TEXT NOT NULL,
+      enabled ${bool} NOT NULL DEFAULT ${boolTrue},
+      updated_at ${ts} NOT NULL
+    )`,
+    `CREATE TABLE IF NOT EXISTS platform_settings (
+      key TEXT NOT NULL,
+      tenant_id TEXT NOT NULL,
+      value TEXT NOT NULL,
+      updated_at ${ts} NOT NULL,
+      PRIMARY KEY (key, tenant_id)
+    )`,
+    `CREATE TABLE IF NOT EXISTS account_prefs (
+      user_id TEXT PRIMARY KEY,
+      tenant_id TEXT NOT NULL,
+      timezone TEXT NOT NULL DEFAULT 'UTC',
+      theme TEXT NOT NULL DEFAULT 'system',
+      updated_at ${ts} NOT NULL
+    )`,
+  ];
+}

--- a/packages/db/src/client.test.ts
+++ b/packages/db/src/client.test.ts
@@ -1,9 +1,7 @@
 import { isAbsolute, resolve } from 'node:path';
 import { sql } from 'drizzle-orm';
 import { describe, expect, it } from 'vitest';
-import { PLUGIN_STATUS_BOOTSTRAP_SQL } from './bootstrap';
 import { createClient, resolveSqlitePath } from './client';
-import * as schema from './schema/sqlite';
 
 describe('resolveSqlitePath', () => {
   it('passes :memory: through untouched', () => {
@@ -27,57 +25,19 @@ describe('resolveSqlitePath', () => {
   });
 });
 
-describe('createClient (sqlite, in-memory)', () => {
-  it('opens an in-memory database and applies pragmas', () => {
-    const db = createClient({ url: ':memory:' });
-    const row = db.get<{ foreign_keys: number }>(sql`PRAGMA foreign_keys`);
+describe('createClient', () => {
+  it('opens an in-memory SQLite database with pragmas and tags the dialect', () => {
+    const client = createClient({ url: ':memory:' });
+    expect(client.dialect).toBe('sqlite');
+    if (client.dialect !== 'sqlite') throw new Error('expected sqlite');
+    const row = client.db.get<{ foreign_keys: number }>(sql`PRAGMA foreign_keys`);
     expect(row?.foreign_keys).toBe(1);
   });
 
-  it('round-trips plugin_status rows through the Drizzle schema', () => {
-    const db = createClient({ url: ':memory:' });
-    db.run(sql.raw(PLUGIN_STATUS_BOOTSTRAP_SQL));
-
-    db.insert(schema.pluginStatus)
-      .values({ pluginId: 'fs.test.alpha', tenantId: 'default', enabled: false, updatedAt: 100 })
-      .run();
-
-    const rows = db.select().from(schema.pluginStatus).all();
-    expect(rows).toHaveLength(1);
-    expect(rows[0]).toEqual({
-      pluginId: 'fs.test.alpha',
-      tenantId: 'default',
-      enabled: false,
-      updatedAt: 100,
-    });
-  });
-
-  it('upserts on plugin_id conflict (the toggle pattern)', () => {
-    const db = createClient({ url: ':memory:' });
-    db.run(sql.raw(PLUGIN_STATUS_BOOTSTRAP_SQL));
-
-    const upsert = (enabled: boolean, updatedAt: number) =>
-      db
-        .insert(schema.pluginStatus)
-        .values({ pluginId: 'fs.test.alpha', tenantId: 'default', enabled, updatedAt })
-        .onConflictDoUpdate({
-          target: schema.pluginStatus.pluginId,
-          set: { enabled, updatedAt },
-        })
-        .run();
-
-    upsert(false, 100);
-    upsert(true, 200);
-
-    const rows = db.select().from(schema.pluginStatus).all();
-    expect(rows).toHaveLength(1);
-    expect(rows[0]?.enabled).toBe(true);
-    expect(rows[0]?.updatedAt).toBe(200);
-  });
-
-  it('throws a clear error for the unwired postgres dialect', () => {
-    expect(() => createClient({ dialect: 'postgres', url: 'postgres://u:p@host/db' })).toThrow(
-      /Postgres support is not yet implemented/,
-    );
+  it('constructs a Postgres client (lazy pool) without connecting', () => {
+    // node-postgres connects lazily, so building the client must not throw even
+    // with an unreachable host — the first query would be what connects.
+    const client = createClient({ dialect: 'postgres', url: 'postgres://u:p@127.0.0.1:1/db' });
+    expect(client.dialect).toBe('postgres');
   });
 });

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -1,9 +1,12 @@
 import { existsSync, mkdirSync } from 'node:fs';
 import { dirname, isAbsolute, join, resolve } from 'node:path';
 import Database from 'better-sqlite3';
-import { drizzle as drizzleSqlite } from 'drizzle-orm/better-sqlite3';
-import { resolveDialect, type Dialect } from './dialect';
-import * as schema from './schema/sqlite';
+import { type BetterSQLite3Database, drizzle as drizzleSqlite } from 'drizzle-orm/better-sqlite3';
+import { type NodePgDatabase, drizzle as drizzlePg } from 'drizzle-orm/node-postgres';
+import { Pool } from 'pg';
+import { type Dialect, resolveDialect } from './dialect';
+import * as pgSchema from './schema/postgres';
+import * as sqliteSchema from './schema/sqlite';
 
 export interface DbConfig {
   /** Override the resolved dialect. Defaults to the environment resolution. */
@@ -13,13 +16,22 @@ export interface DbConfig {
 }
 
 /**
- * Create a Drizzle client for the configured dialect.
- *
- * SQLite is fully supported. Postgres is recognised but not yet wired — the
- * driver and Postgres schema land in Task 0.5.03; until then this throws a
- * clear error rather than silently misbehaving.
+ * A dialect-tagged platform database client. The `dialect` tag drives portable
+ * execution (see ./exec) so the same query runs on SQLite (better-sqlite3,
+ * synchronous) and Postgres (node-postgres, async). Both dialects expose the
+ * same logical schema (see ./schema/{sqlite,postgres}).
  */
-export function createClient(config: DbConfig = {}) {
+export type PlatformDb =
+  | { dialect: 'sqlite'; db: BetterSQLite3Database<typeof sqliteSchema> }
+  | { dialect: 'postgres'; db: NodePgDatabase<typeof pgSchema> };
+
+/**
+ * Create a Drizzle client for the configured dialect. SQLite opens a
+ * better-sqlite3 file (WAL, foreign keys on); Postgres opens a node-postgres
+ * connection pool. The dialect is resolved from the environment unless
+ * overridden via `config`.
+ */
+export function createClient(config: DbConfig = {}): PlatformDb {
   const resolved = resolveDialect({
     ...process.env,
     ...(config.dialect ? { DB_DIALECT: config.dialect } : {}),
@@ -34,13 +46,13 @@ export function createClient(config: DbConfig = {}) {
     const sqlite = new Database(path);
     sqlite.pragma('journal_mode = WAL');
     sqlite.pragma('foreign_keys = ON');
-    return drizzleSqlite(sqlite, { schema });
+    return { dialect: 'sqlite', db: drizzleSqlite(sqlite, { schema: sqliteSchema }) };
   }
 
-  throw new Error(
-    'Postgres support is not yet implemented (Task 0.5.03). ' +
-      'Set DB_DIALECT=sqlite (or leave it unset) for now.',
-  );
+  // node-postgres: the pool connects lazily, so constructing it never blocks or
+  // throws here — the first query establishes the connection.
+  const pool = new Pool({ connectionString: resolved.url });
+  return { dialect: 'postgres', db: drizzlePg(pool, { schema: pgSchema }) };
 }
 
 /**

--- a/packages/db/src/exec.ts
+++ b/packages/db/src/exec.ts
@@ -1,0 +1,45 @@
+import type { SQL } from 'drizzle-orm';
+import type { PlatformDb } from './client';
+
+/**
+ * Dialect-aware execution for raw `sql` queries against the platform database.
+ *
+ * better-sqlite3 is synchronous (`db.get`/`db.all`/`db.run`); node-postgres is
+ * asynchronous (`db.execute(...).rows`). These helpers paper over that split so
+ * platform queries are written once and run on both dialects. The queries
+ * themselves use only standard SQL (no SQLite- or Postgres-specific idioms), so
+ * the same `sql` template is portable; `ON CONFLICT ... DO UPDATE/NOTHING` is
+ * supported identically by both engines.
+ *
+ * Column casing: raw SQL returns the database column names, so callers that
+ * need camelCase alias explicitly (e.g. `plugin_id AS "pluginId"`). Booleans
+ * read back as 0/1 on SQLite and `true/false` on Postgres — normalise with a
+ * cast where it matters.
+ */
+
+/** Run a query for at most one row. */
+export async function dbGet<T>(pdb: PlatformDb, query: SQL): Promise<T | undefined> {
+  if (pdb.dialect === 'sqlite') {
+    return (pdb.db.get<T>(query) as T | undefined) ?? undefined;
+  }
+  const result = await pdb.db.execute(query);
+  return (result.rows[0] as T | undefined) ?? undefined;
+}
+
+/** Run a query returning all rows. */
+export async function dbAll<T>(pdb: PlatformDb, query: SQL): Promise<T[]> {
+  if (pdb.dialect === 'sqlite') {
+    return pdb.db.all<T>(query);
+  }
+  const result = await pdb.db.execute(query);
+  return result.rows as T[];
+}
+
+/** Run a statement for its side effects (INSERT/UPDATE/DDL). */
+export async function dbRun(pdb: PlatformDb, query: SQL): Promise<void> {
+  if (pdb.dialect === 'sqlite') {
+    pdb.db.run(query);
+    return;
+  }
+  await pdb.db.execute(query);
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,11 +1,5 @@
 export { createClient, findWorkspaceRoot, resolveSqlitePath, type DbConfig } from './client';
-export {
-  ACCOUNT_PREFS_BOOTSTRAP_SQL,
-  PLATFORM_BOOTSTRAP_SQL,
-  PLATFORM_SETTINGS_BOOTSTRAP_SQL,
-  PLUGIN_STATUS_BOOTSTRAP_SQL,
-  TENANTS_BOOTSTRAP_SQL,
-} from './bootstrap';
+export { platformBootstrapStatements } from './bootstrap';
 export {
   DEFAULT_ROOT_PLUGIN_ID,
   DEFAULT_TENANT_ID,
@@ -14,8 +8,12 @@ export {
   getDefaultTenant,
   getPlatformDb,
   getPlatformSetting,
+  listDisabledPluginIds,
+  listPluginStatus,
+  pingDb,
   setAccountPrefs,
   setPlatformSetting,
+  setPluginEnabled,
   setTenantName,
   type AccountPrefsValue,
   type PlatformDb,

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -1,20 +1,22 @@
-import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import { migrate as migrateSqlite } from 'drizzle-orm/better-sqlite3/migrator';
+import { migrate as migratePg } from 'drizzle-orm/node-postgres/migrator';
+import type { PlatformDb } from './client';
 
 /**
- * Apply pending migrations against a SQLite Drizzle client.
+ * Apply pending migrations against a platform client, dispatching on dialect.
  *
  * `migrationsFolder` is a directory of Drizzle-generated migrations (`.sql`
  * files plus a `_journal.json`). Drizzle applies them in journal order and
  * records what has run, so calling this repeatedly is safe (idempotent).
  *
- * Note: this uses Drizzle's standard folder+journal migrator rather than a raw
- * array of file paths — the journal is what gives ordering and idempotency.
- * Postgres migrations arrive with the Postgres driver in Task 0.5.03.
+ * Not yet load-bearing: platform tables are still created via the
+ * CREATE-TABLE-IF-NOT-EXISTS bootstrap (see ./platform-db); this runner is in
+ * place for when drizzle-kit migrations land (0.5.05+).
  */
-export function runMigrations<TSchema extends Record<string, unknown>>(
-  db: BetterSQLite3Database<TSchema>,
-  migrationsFolder: string,
-): void {
-  migrateSqlite(db, { migrationsFolder });
+export async function runMigrations(pdb: PlatformDb, migrationsFolder: string): Promise<void> {
+  if (pdb.dialect === 'sqlite') {
+    migrateSqlite(pdb.db, { migrationsFolder });
+    return;
+  }
+  await migratePg(pdb.db, { migrationsFolder });
 }

--- a/packages/db/src/platform-db.test.ts
+++ b/packages/db/src/platform-db.test.ts
@@ -6,8 +6,11 @@ import {
   getAccountPrefs,
   getDefaultTenant,
   getPlatformSetting,
+  listDisabledPluginIds,
+  listPluginStatus,
   setAccountPrefs,
   setPlatformSetting,
+  setPluginEnabled,
   setTenantName,
   type PlatformDb,
 } from './platform-db';
@@ -21,7 +24,6 @@ async function freshDb(): Promise<PlatformDb> {
 describe('bootstrapPlatformDb', () => {
   it('seeds the default tenant', async () => {
     const tenant = await getDefaultTenant(await freshDb());
-    expect(tenant.id).toBe('default');
     expect(tenant.name).toBe('Sovereign');
   });
 
@@ -99,5 +101,26 @@ describe('account preferences helpers', () => {
     const db = await freshDb();
     await setAccountPrefs(db, 'u1', { theme: 'dark' });
     expect(await getAccountPrefs(db, 'u2')).toEqual({ timezone: 'UTC', theme: 'system' });
+  });
+});
+
+describe('plugin status helpers', () => {
+  it('returns no status rows on a fresh database (absence = enabled)', async () => {
+    expect(await listPluginStatus(await freshDb())).toEqual([]);
+    expect(await listDisabledPluginIds(await freshDb())).toEqual([]);
+  });
+
+  it('upserts enable/disable state and maps the boolean correctly', async () => {
+    const db = await freshDb();
+    await setPluginEnabled(db, 'fs.test.alpha', false);
+
+    const rows = await listPluginStatus(db);
+    expect(rows).toEqual([{ pluginId: 'fs.test.alpha', enabled: false }]);
+    expect(await listDisabledPluginIds(db)).toEqual(['fs.test.alpha']);
+
+    // re-enabling upserts the same row, not a duplicate
+    await setPluginEnabled(db, 'fs.test.alpha', true);
+    expect(await listPluginStatus(db)).toEqual([{ pluginId: 'fs.test.alpha', enabled: true }]);
+    expect(await listDisabledPluginIds(db)).toEqual([]);
   });
 });

--- a/packages/db/src/platform-db.ts
+++ b/packages/db/src/platform-db.ts
@@ -1,10 +1,11 @@
-import { and, eq } from 'drizzle-orm';
-import { sql } from 'drizzle-orm';
-import { PLATFORM_BOOTSTRAP_SQL } from './bootstrap';
-import { createClient } from './client';
-import * as schema from './schema/sqlite';
+import { eq, sql } from 'drizzle-orm';
+import { platformBootstrapStatements } from './bootstrap';
+import { type PlatformDb, createClient } from './client';
+import { dbGet, dbRun } from './exec';
+import * as pg from './schema/postgres';
+import * as sqlite from './schema/sqlite';
 
-export type PlatformDb = ReturnType<typeof createClient>;
+export type { PlatformDb };
 
 /** v1 is single-tenant; every tenant-scoped row uses this id (SRS §3.1). */
 export const DEFAULT_TENANT_ID = 'default';
@@ -15,36 +16,31 @@ export const DEFAULT_ROOT_PLUGIN_ID = 'fs.sovereign.launcher';
 const DEFAULT_TENANT_NAME = 'Sovereign';
 
 /**
- * Apply the interim DDL bootstrap and seed rows to a client. Idempotent —
- * CREATE TABLE IF NOT EXISTS plus conflict-ignoring inserts. Exported
- * separately from the singleton so tests can run it against :memory:.
- *
- * Async by contract: Postgres (node-postgres) has no synchronous query, so the
- * whole platform data layer is async. On SQLite (better-sqlite3) the underlying
- * calls run synchronously and resolve immediately. Postgres execution lands in
- * the next change (Task 0.5.03 driver wiring); the bodies here stay SQLite.
+ * Apply the interim DDL bootstrap and seed rows. Idempotent — CREATE TABLE IF
+ * NOT EXISTS plus conflict-ignoring inserts. Dialect-agnostic: the DDL is
+ * dialect-aware (see ./bootstrap) and the seeds are standard `INSERT … ON
+ * CONFLICT DO NOTHING`, supported identically by SQLite and Postgres. Exported
+ * separately from the singleton so tests can run it against `:memory:`.
  */
-export async function bootstrapPlatformDb(db: PlatformDb): Promise<void> {
-  for (const statement of PLATFORM_BOOTSTRAP_SQL) {
-    db.run(sql.raw(statement));
+export async function bootstrapPlatformDb(pdb: PlatformDb): Promise<void> {
+  for (const statement of platformBootstrapStatements(pdb.dialect)) {
+    await dbRun(pdb, sql.raw(statement));
   }
 
   const now = Math.floor(Date.now() / 1000);
 
-  db.insert(schema.tenants)
-    .values({ id: DEFAULT_TENANT_ID, name: DEFAULT_TENANT_NAME, createdAt: now, updatedAt: now })
-    .onConflictDoNothing()
-    .run();
-
-  db.insert(schema.platformSettings)
-    .values({
-      key: 'root_plugin_id',
-      tenantId: DEFAULT_TENANT_ID,
-      value: DEFAULT_ROOT_PLUGIN_ID,
-      updatedAt: now,
-    })
-    .onConflictDoNothing()
-    .run();
+  await dbRun(
+    pdb,
+    sql`INSERT INTO tenants (id, name, created_at, updated_at)
+        VALUES (${DEFAULT_TENANT_ID}, ${DEFAULT_TENANT_NAME}, ${now}, ${now})
+        ON CONFLICT (id) DO NOTHING`,
+  );
+  await dbRun(
+    pdb,
+    sql`INSERT INTO platform_settings (key, tenant_id, value, updated_at)
+        VALUES ('root_plugin_id', ${DEFAULT_TENANT_ID}, ${DEFAULT_ROOT_PLUGIN_ID}, ${now})
+        ON CONFLICT (key, tenant_id) DO NOTHING`,
+  );
 }
 
 let _dbPromise: Promise<PlatformDb> | null = null;
@@ -58,65 +54,124 @@ let _dbPromise: Promise<PlatformDb> | null = null;
 export function getPlatformDb(): Promise<PlatformDb> {
   if (!_dbPromise) {
     _dbPromise = (async () => {
-      const db = createClient();
-      await bootstrapPlatformDb(db);
-      return db;
+      const pdb = createClient();
+      await bootstrapPlatformDb(pdb);
+      return pdb;
     })();
   }
   return _dbPromise;
 }
 
+/** Liveness check — throws if the database is unreachable. */
+export async function pingDb(pdb: PlatformDb): Promise<void> {
+  await dbGet(pdb, sql`SELECT 1`);
+}
+
 /** Read a platform setting for the default tenant. Returns null when unset. */
-export async function getPlatformSetting(db: PlatformDb, key: string): Promise<string | null> {
-  const row = db
-    .select({ value: schema.platformSettings.value })
-    .from(schema.platformSettings)
-    .where(
-      and(
-        eq(schema.platformSettings.key, key),
-        eq(schema.platformSettings.tenantId, DEFAULT_TENANT_ID),
-      ),
-    )
-    .get();
+export async function getPlatformSetting(pdb: PlatformDb, key: string): Promise<string | null> {
+  const row = await dbGet<{ value: string }>(
+    pdb,
+    sql`SELECT value FROM platform_settings WHERE key = ${key} AND tenant_id = ${DEFAULT_TENANT_ID}`,
+  );
   return row?.value ?? null;
 }
 
 /** Upsert a platform setting for the default tenant. */
 export async function setPlatformSetting(
-  db: PlatformDb,
+  pdb: PlatformDb,
   key: string,
   value: string,
 ): Promise<void> {
   const now = Math.floor(Date.now() / 1000);
-  db.insert(schema.platformSettings)
-    .values({ key, tenantId: DEFAULT_TENANT_ID, value, updatedAt: now })
-    .onConflictDoUpdate({
-      target: [schema.platformSettings.key, schema.platformSettings.tenantId],
-      set: { value, updatedAt: now },
-    })
-    .run();
+  await dbRun(
+    pdb,
+    sql`INSERT INTO platform_settings (key, tenant_id, value, updated_at)
+        VALUES (${key}, ${DEFAULT_TENANT_ID}, ${value}, ${now})
+        ON CONFLICT (key, tenant_id)
+        DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+  );
 }
 
-/** The default tenant row. Always present after bootstrap. */
-export async function getDefaultTenant(db: PlatformDb): Promise<schema.Tenant> {
-  const tenant = db
-    .select()
-    .from(schema.tenants)
-    .where(eq(schema.tenants.id, DEFAULT_TENANT_ID))
-    .get();
-  if (!tenant) {
+/** The default tenant's name. Always present after bootstrap. */
+export async function getDefaultTenant(pdb: PlatformDb): Promise<{ name: string }> {
+  const row = await dbGet<{ name: string }>(
+    pdb,
+    sql`SELECT name FROM tenants WHERE id = ${DEFAULT_TENANT_ID}`,
+  );
+  if (!row) {
     throw new Error('Default tenant missing — was bootstrapPlatformDb() run?');
   }
-  return tenant;
+  return row;
 }
 
 /** Rename the default tenant (CON-08). */
-export async function setTenantName(db: PlatformDb, name: string): Promise<void> {
+export async function setTenantName(pdb: PlatformDb, name: string): Promise<void> {
   const now = Math.floor(Date.now() / 1000);
-  db.update(schema.tenants)
-    .set({ name, updatedAt: now })
-    .where(eq(schema.tenants.id, DEFAULT_TENANT_ID))
-    .run();
+  await dbRun(
+    pdb,
+    sql`UPDATE tenants SET name = ${name}, updated_at = ${now} WHERE id = ${DEFAULT_TENANT_ID}`,
+  );
+}
+
+/**
+ * Per-plugin enable/disable state (absence of a row = enabled). The `enabled`
+ * column is a boolean, which SQLite stores as 0/1 and Postgres natively — so
+ * these go through the Drizzle query builder (which maps both to a JS boolean)
+ * rather than raw SQL.
+ */
+export async function listPluginStatus(
+  pdb: PlatformDb,
+): Promise<{ pluginId: string; enabled: boolean }[]> {
+  if (pdb.dialect === 'sqlite') {
+    return pdb.db
+      .select({ pluginId: sqlite.pluginStatus.pluginId, enabled: sqlite.pluginStatus.enabled })
+      .from(sqlite.pluginStatus)
+      .all();
+  }
+  return pdb.db
+    .select({ pluginId: pg.pluginStatus.pluginId, enabled: pg.pluginStatus.enabled })
+    .from(pg.pluginStatus);
+}
+
+/** IDs of explicitly-disabled plugins (consumed by the middleware gate). */
+export async function listDisabledPluginIds(pdb: PlatformDb): Promise<string[]> {
+  if (pdb.dialect === 'sqlite') {
+    const rows = pdb.db
+      .select({ pluginId: sqlite.pluginStatus.pluginId })
+      .from(sqlite.pluginStatus)
+      .where(eq(sqlite.pluginStatus.enabled, false))
+      .all();
+    return rows.map((r) => r.pluginId);
+  }
+  const rows = await pdb.db
+    .select({ pluginId: pg.pluginStatus.pluginId })
+    .from(pg.pluginStatus)
+    .where(eq(pg.pluginStatus.enabled, false));
+  return rows.map((r) => r.pluginId);
+}
+
+/** Enable or disable a plugin (upsert on plugin_id) — CON-07. */
+export async function setPluginEnabled(
+  pdb: PlatformDb,
+  pluginId: string,
+  enabled: boolean,
+): Promise<void> {
+  const now = Math.floor(Date.now() / 1000);
+  if (pdb.dialect === 'sqlite') {
+    pdb.db
+      .insert(sqlite.pluginStatus)
+      .values({ pluginId, tenantId: DEFAULT_TENANT_ID, enabled, updatedAt: now })
+      .onConflictDoUpdate({
+        target: sqlite.pluginStatus.pluginId,
+        set: { enabled, updatedAt: now },
+      })
+      .run();
+    return;
+  }
+  await pdb.db
+    .insert(pg.pluginStatus)
+    .values({ pluginId, tenantId: DEFAULT_TENANT_ID, enabled, updatedAt: now })
+    .onConflictDoUpdate({ target: pg.pluginStatus.pluginId, set: { enabled, updatedAt: now } });
 }
 
 /** Account-plugin preferences with their defaults (SRS ACC-07/08). */
@@ -128,30 +183,29 @@ export interface AccountPrefsValue {
 const DEFAULT_ACCOUNT_PREFS: AccountPrefsValue = { timezone: 'UTC', theme: 'system' };
 
 /** A user's Account preferences, falling back to defaults when no row exists. */
-export async function getAccountPrefs(db: PlatformDb, userId: string): Promise<AccountPrefsValue> {
-  const row = db
-    .select({ timezone: schema.accountPrefs.timezone, theme: schema.accountPrefs.theme })
-    .from(schema.accountPrefs)
-    .where(eq(schema.accountPrefs.userId, userId))
-    .get();
+export async function getAccountPrefs(pdb: PlatformDb, userId: string): Promise<AccountPrefsValue> {
+  const row = await dbGet<AccountPrefsValue>(
+    pdb,
+    sql`SELECT timezone, theme FROM account_prefs WHERE user_id = ${userId}`,
+  );
   return row ?? DEFAULT_ACCOUNT_PREFS;
 }
 
 /** Upsert a user's Account preferences (one row per user). */
 export async function setAccountPrefs(
-  db: PlatformDb,
+  pdb: PlatformDb,
   userId: string,
   prefs: Partial<AccountPrefsValue>,
 ): Promise<AccountPrefsValue> {
-  const current = await getAccountPrefs(db, userId);
+  const current = await getAccountPrefs(pdb, userId);
   const next = { ...current, ...prefs };
   const now = Math.floor(Date.now() / 1000);
-  db.insert(schema.accountPrefs)
-    .values({ userId, tenantId: DEFAULT_TENANT_ID, ...next, updatedAt: now })
-    .onConflictDoUpdate({
-      target: schema.accountPrefs.userId,
-      set: { ...next, updatedAt: now },
-    })
-    .run();
+  await dbRun(
+    pdb,
+    sql`INSERT INTO account_prefs (user_id, tenant_id, timezone, theme, updated_at)
+        VALUES (${userId}, ${DEFAULT_TENANT_ID}, ${next.timezone}, ${next.theme}, ${now})
+        ON CONFLICT (user_id)
+        DO UPDATE SET timezone = excluded.timezone, theme = excluded.theme, updated_at = excluded.updated_at`,
+  );
   return next;
 }

--- a/packages/db/src/schema/parity.test.ts
+++ b/packages/db/src/schema/parity.test.ts
@@ -1,0 +1,46 @@
+import { getTableColumns, getTableName, isTable } from 'drizzle-orm';
+import { describe, expect, it } from 'vitest';
+import * as pg from './postgres';
+import * as sqlite from './sqlite';
+
+/**
+ * The SQLite and Postgres platform schemas must stay structurally identical so
+ * the platform data layer is dialect-agnostic (SRS §3.7, NFR-03). This guards
+ * against drift: same set of tables, and for each table the same column set
+ * mapped to the same database column names.
+ */
+
+function tableMap(mod: Record<string, unknown>): Map<string, Record<string, { name: string }>> {
+  const map = new Map<string, Record<string, { name: string }>>();
+  for (const value of Object.values(mod)) {
+    if (isTable(value)) {
+      map.set(getTableName(value), getTableColumns(value));
+    }
+  }
+  return map;
+}
+
+describe('schema parity (sqlite ↔ postgres)', () => {
+  const sqliteTables = tableMap(sqlite);
+  const pgTables = tableMap(pg);
+
+  it('defines the same set of tables in both dialects', () => {
+    expect([...pgTables.keys()].sort()).toEqual([...sqliteTables.keys()].sort());
+  });
+
+  it('defines the same columns (and DB column names) per table', () => {
+    for (const [table, sqliteCols] of sqliteTables) {
+      const pgCols = pgTables.get(table);
+      expect(pgCols, `postgres missing table ${table}`).toBeDefined();
+      if (!pgCols) continue;
+
+      const sqliteNames = Object.values(sqliteCols)
+        .map((c) => c.name)
+        .sort();
+      const pgNames = Object.values(pgCols)
+        .map((c) => c.name)
+        .sort();
+      expect(pgNames, `column mismatch on ${table}`).toEqual(sqliteNames);
+    }
+  });
+});

--- a/packages/db/src/schema/postgres/index.ts
+++ b/packages/db/src/schema/postgres/index.ts
@@ -1,0 +1,1 @@
+export * from './platform';

--- a/packages/db/src/schema/postgres/platform.ts
+++ b/packages/db/src/schema/postgres/platform.ts
@@ -1,0 +1,77 @@
+import { bigint, boolean, pgTable, primaryKey, text } from 'drizzle-orm/pg-core';
+
+/**
+ * Platform schema (Postgres dialect). A 1:1 mirror of `../sqlite/platform.ts` —
+ * same table and column names — so the platform data layer is dialect-agnostic
+ * (SRS §3.7, NFR-03). A parity test (`./schema-parity.test.ts`) asserts the two
+ * dialect schemas stay structurally identical.
+ *
+ * Dialect mapping vs SQLite:
+ * - Timestamps are Unix epoch **seconds** stored as `bigint` (SQLite uses
+ *   `integer`). Postgres `INTEGER` is 32-bit and overflows in 2038; `bigint`
+ *   avoids the Y2038 cliff. `mode: 'number'` keeps the JS-side type a `number`,
+ *   matching SQLite (seconds fit safely within 2^53).
+ * - Booleans are native `boolean` (SQLite stores 0/1 via `mode: 'boolean'`).
+ *
+ * Defaults stay dialect-portable literals; callers supply timestamps.
+ */
+
+export const tenants = pgTable('tenants', {
+  id: text('id').primaryKey(),
+  name: text('name').notNull(),
+  createdAt: bigint('created_at', { mode: 'number' }).notNull(),
+  updatedAt: bigint('updated_at', { mode: 'number' }).notNull(),
+});
+
+export const users = pgTable('users', {
+  id: text('id').primaryKey(),
+  tenantId: text('tenant_id')
+    .notNull()
+    .references(() => tenants.id),
+  email: text('email').notNull().unique(),
+  emailVerified: boolean('email_verified').notNull().default(false),
+  name: text('name'),
+  image: text('image'),
+  role: text('role').notNull().default('platform:user'),
+  createdAt: bigint('created_at', { mode: 'number' }).notNull(),
+  updatedAt: bigint('updated_at', { mode: 'number' }).notNull(),
+});
+
+export const sessions = pgTable('sessions', {
+  id: text('id').primaryKey(),
+  userId: text('user_id')
+    .notNull()
+    .references(() => users.id),
+  token: text('token').notNull().unique(),
+  expiresAt: bigint('expires_at', { mode: 'number' }).notNull(),
+  ipAddress: text('ip_address'),
+  userAgent: text('user_agent'),
+  createdAt: bigint('created_at', { mode: 'number' }).notNull(),
+  updatedAt: bigint('updated_at', { mode: 'number' }).notNull(),
+});
+
+export const pluginStatus = pgTable('plugin_status', {
+  pluginId: text('plugin_id').primaryKey(),
+  tenantId: text('tenant_id').notNull(),
+  enabled: boolean('enabled').notNull().default(true),
+  updatedAt: bigint('updated_at', { mode: 'number' }).notNull(),
+});
+
+export const platformSettings = pgTable(
+  'platform_settings',
+  {
+    key: text('key').notNull(),
+    tenantId: text('tenant_id').notNull(),
+    value: text('value').notNull(),
+    updatedAt: bigint('updated_at', { mode: 'number' }).notNull(),
+  },
+  (table) => [primaryKey({ columns: [table.key, table.tenantId] })],
+);
+
+export const accountPrefs = pgTable('account_prefs', {
+  userId: text('user_id').primaryKey(),
+  tenantId: text('tenant_id').notNull(),
+  timezone: text('timezone').notNull().default('UTC'),
+  theme: text('theme').notNull().default('system'), // 'system' | 'light' | 'dark'
+  updatedAt: bigint('updated_at', { mode: 'number' }).notNull(),
+});

--- a/runtime/app/api/admin/health/route.ts
+++ b/runtime/app/api/admin/health/route.ts
@@ -1,7 +1,6 @@
 import { statSync } from 'node:fs';
 import { NextResponse } from 'next/server';
-import { sql } from 'drizzle-orm';
-import { resolveDialect, resolveSqlitePath } from '@sovereignfs/db';
+import { pingDb, resolveDialect, resolveSqlitePath } from '@sovereignfs/db';
 import { sdk } from '@sovereignfs/sdk';
 import { checkAdminKey } from '@/src/admin-guard';
 import { getPlatformDb } from '@/src/db';
@@ -28,7 +27,7 @@ export async function GET(request: Request): Promise<Response> {
 
   let dbStatus: 'ok' | 'error' = 'ok';
   try {
-    (await getPlatformDb()).get(sql`SELECT 1`);
+    await pingDb(await getPlatformDb());
   } catch {
     dbStatus = 'error';
   }

--- a/runtime/app/api/admin/plugins/[id]/route.ts
+++ b/runtime/app/api/admin/plugins/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { schema } from '@sovereignfs/db';
+import { setPluginEnabled } from '@sovereignfs/db';
 import { checkAdminKey } from '@/src/admin-guard';
 import { getPlatformDb } from '@/src/db';
 import { getInstalledPlugins } from '@/src/registry';
@@ -23,16 +23,7 @@ export async function PATCH(request: Request, { params }: RouteParams): Promise<
     return NextResponse.json({ error: 'enabled (boolean) is required' }, { status: 400 });
   }
 
-  const db = await getPlatformDb();
-  const now = Math.floor(Date.now() / 1000);
-
-  db.insert(schema.pluginStatus)
-    .values({ pluginId: id, tenantId: 'default', enabled: body.enabled, updatedAt: now })
-    .onConflictDoUpdate({
-      target: schema.pluginStatus.pluginId,
-      set: { enabled: body.enabled, updatedAt: now },
-    })
-    .run();
+  await setPluginEnabled(await getPlatformDb(), id, body.enabled);
 
   return NextResponse.json({ id, enabled: body.enabled });
 }

--- a/runtime/app/api/admin/plugins/disabled/route.ts
+++ b/runtime/app/api/admin/plugins/disabled/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from 'next/server';
-import { eq } from 'drizzle-orm';
-import { schema } from '@sovereignfs/db';
+import { listDisabledPluginIds } from '@sovereignfs/db';
 import { checkAdminKey } from '@/src/admin-guard';
 import { getPlatformDb } from '@/src/db';
 
@@ -14,12 +13,7 @@ export async function GET(request: Request): Promise<Response> {
   const denied = checkAdminKey(request);
   if (denied) return denied;
 
-  const db = await getPlatformDb();
-  const rows = db
-    .select({ pluginId: schema.pluginStatus.pluginId })
-    .from(schema.pluginStatus)
-    .where(eq(schema.pluginStatus.enabled, false))
-    .all();
+  const disabled = await listDisabledPluginIds(await getPlatformDb());
 
-  return NextResponse.json({ disabled: rows.map((r) => r.pluginId) });
+  return NextResponse.json({ disabled });
 }

--- a/runtime/app/api/admin/plugins/route.ts
+++ b/runtime/app/api/admin/plugins/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { schema } from '@sovereignfs/db';
+import { listPluginStatus } from '@sovereignfs/db';
 import { checkAdminKey } from '@/src/admin-guard';
 import { getPlatformDb } from '@/src/db';
 import { getInstalledPlugins } from '@/src/registry';
@@ -8,8 +8,7 @@ export async function GET(request: Request): Promise<Response> {
   const denied = checkAdminKey(request);
   if (denied) return denied;
 
-  const db = await getPlatformDb();
-  const statusRows = db.select().from(schema.pluginStatus).all();
+  const statusRows = await listPluginStatus(await getPlatformDb());
   const statusMap = new Map(statusRows.map((r) => [r.pluginId, r.enabled]));
 
   const plugins = getInstalledPlugins().map((manifest) => ({

--- a/runtime/app/api/admin/root-plugin/route.ts
+++ b/runtime/app/api/admin/root-plugin/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from 'next/server';
-import { eq } from 'drizzle-orm';
-import { DEFAULT_ROOT_PLUGIN_ID, getPlatformSetting, schema } from '@sovereignfs/db';
+import { DEFAULT_ROOT_PLUGIN_ID, getPlatformSetting, listDisabledPluginIds } from '@sovereignfs/db';
 import { checkAdminKey } from '@/src/admin-guard';
 import { getPlatformDb } from '@/src/db';
 import { getInstalledPlugins } from '@/src/registry';
@@ -18,14 +17,7 @@ export async function GET(request: Request): Promise<Response> {
 
   const db = await getPlatformDb();
   const rootPluginId = (await getPlatformSetting(db, 'root_plugin_id')) ?? DEFAULT_ROOT_PLUGIN_ID;
-  const disabledIds = new Set(
-    db
-      .select({ pluginId: schema.pluginStatus.pluginId })
-      .from(schema.pluginStatus)
-      .where(eq(schema.pluginStatus.enabled, false))
-      .all()
-      .map((r) => r.pluginId),
-  );
+  const disabledIds = new Set(await listDisabledPluginIds(db));
 
   const routePrefix = resolveRootRoutePrefix(rootPluginId, getInstalledPlugins(), disabledIds);
   return NextResponse.json({ routePrefix });

--- a/runtime/app/api/admin/settings/route.ts
+++ b/runtime/app/api/admin/settings/route.ts
@@ -1,10 +1,9 @@
 import { NextResponse } from 'next/server';
-import { eq } from 'drizzle-orm';
 import {
   DEFAULT_ROOT_PLUGIN_ID,
   getDefaultTenant,
   getPlatformSetting,
-  schema,
+  listDisabledPluginIds,
   setPlatformSetting,
   setTenantName,
 } from '@sovereignfs/db';
@@ -55,14 +54,7 @@ export async function PATCH(request: Request): Promise<Response> {
   }
 
   if (body.rootPluginId !== undefined) {
-    const disabledIds = new Set(
-      db
-        .select({ pluginId: schema.pluginStatus.pluginId })
-        .from(schema.pluginStatus)
-        .where(eq(schema.pluginStatus.enabled, false))
-        .all()
-        .map((r) => r.pluginId),
-    );
+    const disabledIds = new Set(await listDisabledPluginIds(db));
     const result = validateRootPlugin(body.rootPluginId, getInstalledPlugins(), disabledIds);
     if (!result.ok) {
       return NextResponse.json(

--- a/runtime/app/api/plugins/route.ts
+++ b/runtime/app/api/plugins/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from 'next/server';
-import { eq } from 'drizzle-orm';
-import { schema } from '@sovereignfs/db';
+import { listDisabledPluginIds } from '@sovereignfs/db';
 import { getPlatformDb } from '@/src/db';
 import { getInstalledPlugins } from '@/src/registry';
 import { selectLauncherPlugins } from '@/src/launcher-plugins';
@@ -14,15 +13,7 @@ import { selectLauncherPlugins } from '@/src/launcher-plugins';
 export async function GET(request: Request): Promise<Response> {
   const role = request.headers.get('x-sovereign-user-role') ?? 'platform:user';
 
-  const db = await getPlatformDb();
-  const disabledIds = new Set(
-    db
-      .select({ pluginId: schema.pluginStatus.pluginId })
-      .from(schema.pluginStatus)
-      .where(eq(schema.pluginStatus.enabled, false))
-      .all()
-      .map((r) => r.pluginId),
-  );
+  const disabledIds = new Set(await listDisabledPluginIds(await getPlatformDb()));
 
   const plugins = selectLauncherPlugins(getInstalledPlugins(), disabledIds, role);
   return NextResponse.json({ plugins });


### PR DESCRIPTION
**Phase 1b of Task 0.5.03 (Postgres validation).** Implements the Postgres half of the dialect-agnostic platform database (NFR-03, SRS §3.7), building on the async platform data layer (PR #32). **SQLite stays the default and behaves identically.**

## Changes
- **`client.ts`** — `createClient` returns a dialect-tagged wrapper `{ dialect, db }`. Postgres opens a `pg.Pool` via `drizzle-orm/node-postgres` (lazy connect); SQLite branch unchanged.
- **`schema/postgres/platform.ts`** (new) — pg-core mirror of the SQLite schema: identical table/column names, native `boolean`, and **`bigint` timestamps** (Postgres `INTEGER` overflows in 2038). `schema/parity.test.ts` guards against drift.
- **`exec.ts`** (new) — `dbGet`/`dbAll`/`dbRun`: portable raw-`sql` execution papering over better-sqlite3 (sync) vs node-postgres (async). Used for text/DDL/ping.
- **`platform-db.ts`** — dialect-agnostic. Text/settings/prefs via portable raw SQL; the **boolean** `plugin_status` helpers via the Drizzle query builder (which maps `0/1` ↔ `true/false`). New helpers `listPluginStatus` / `listDisabledPluginIds` / `setPluginEnabled` / `pingDb` absorb the runtime's former inline queries.
- **`bootstrap.ts`** — dialect-aware DDL (`BIGINT`/`BOOLEAN` for Postgres). **`migrate.ts`** — node-postgres migrator branch (not yet load-bearing).
- **Runtime routes** (7) — inline Drizzle queries replaced with the `packages/db` helpers, so **no DB-dialect code remains in app code** (review-checklist item).

## Validation
- Build, lint, typecheck, and **146 tests** pass (incl. the new schema-parity + plugin-status helper tests).
- **Live-validated against Postgres 16** (throwaway Docker): bootstrap + idempotent re-bootstrap, settings/tenant/prefs upserts, and plugin enable/disable with correct boolean mapping. SQLite path unchanged.
- Grep gate: no `better-sqlite3`/sqlite-specific SQL in `runtime/`/`plugins/` app code (only the webpack `serverExternalPackages` config + the dependency).

## Version
`@sovereignfs/db` 0.5.0 → **0.6.0**.

## Context
Second of 4 PRs for Task 0.5.03: PR1a async (#32, merged) → **1b Postgres (this)** → 2 apps/auth Postgres → 3 compose + docs + end-to-end validation. The auth server is still SQLite-only until PR2; full live cross-container validation lands in PR3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)