### PR TITLE
Postgres support for the auth server (apps/auth)

### DIFF
--- a/apps/auth/app/api/admin/invites/route.ts
+++ b/apps/auth/app/api/admin/invites/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { checkAdminKey } from '@/src/admin-guard';
-import { getDb } from '@/src/db';
+import { authRun } from '@/src/db';
 
 interface InviteBody {
   email: string;
@@ -16,17 +16,16 @@ export async function POST(request: Request): Promise<Response> {
     return NextResponse.json({ error: 'email is required' }, { status: 400 });
   }
 
-  const db = getDb();
   const token = crypto.randomUUID();
   const createdAt = Math.floor(Date.now() / 1000);
   const expiresAt = body.expiresInDays != null ? createdAt + body.expiresInDays * 86400 : null;
 
-  db.prepare('INSERT INTO invites (token, email, created_at, expires_at) VALUES (?, ?, ?, ?)').run(
+  await authRun('INSERT INTO invites (token, email, created_at, expires_at) VALUES (?, ?, ?, ?)', [
     token,
     body.email,
     createdAt,
     expiresAt,
-  );
+  ]);
 
   return NextResponse.json({ token, email: body.email }, { status: 201 });
 }

--- a/apps/auth/app/api/admin/settings/route.ts
+++ b/apps/auth/app/api/admin/settings/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from 'next/server';
 import { checkAdminKey } from '@/src/admin-guard';
-import { getDb } from '@/src/db';
 import { getEnv } from '@/src/env';
 import { readInviteOnlySetting, resolveInviteOnly, writeInviteOnlySetting } from '@/src/settings';
 
@@ -8,7 +7,7 @@ export async function GET(request: Request): Promise<Response> {
   const denied = checkAdminKey(request);
   if (denied) return denied;
 
-  const inviteOnly = resolveInviteOnly(readInviteOnlySetting(getDb()), getEnv().inviteOnly);
+  const inviteOnly = resolveInviteOnly(await readInviteOnlySetting(), getEnv().inviteOnly);
   return NextResponse.json({ inviteOnly });
 }
 
@@ -21,6 +20,6 @@ export async function PATCH(request: Request): Promise<Response> {
     return NextResponse.json({ error: 'inviteOnly (boolean) is required' }, { status: 400 });
   }
 
-  writeInviteOnlySetting(getDb(), body.inviteOnly);
+  await writeInviteOnlySetting(body.inviteOnly);
   return NextResponse.json({ inviteOnly: body.inviteOnly });
 }

--- a/apps/auth/app/api/admin/users/[id]/route.ts
+++ b/apps/auth/app/api/admin/users/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { checkAdminKey } from '@/src/admin-guard';
-import { getDb } from '@/src/db';
+import { authGet, authRun } from '@/src/db';
 
 interface PatchBody {
   role?: string;
@@ -17,33 +17,31 @@ export async function PATCH(
   const { id } = await params;
   const body = (await request.json()) as PatchBody;
 
-  const db = getDb();
-  const now = new Date().toISOString(); // better-auth stores dates as ISO strings
+  const now = new Date().toISOString(); // better-auth stores dates as ISO/timestamp
 
+  // `user` is a reserved word in Postgres and the date columns are camelCase, so
+  // both are quoted to keep the SQL portable. `active` is bound as a boolean and
+  // mapped to 0/1 for SQLite by the query layer.
   if ('role' in body) {
-    db.prepare('UPDATE user SET role = ?, updatedAt = ? WHERE id = ?').run(body.role, now, id);
+    await authRun('UPDATE "user" SET role = ?, "updatedAt" = ? WHERE id = ?', [body.role, now, id]);
   }
 
   if ('active' in body) {
-    db.prepare('UPDATE user SET active = ?, updatedAt = ? WHERE id = ?').run(
-      body.active ? 1 : 0,
+    await authRun('UPDATE "user" SET active = ?, "updatedAt" = ? WHERE id = ?', [
+      body.active,
       now,
       id,
-    );
+    ]);
   }
 
-  const updated = db
-    .prepare('SELECT id, email, name, role, active, createdAt FROM user WHERE id = ?')
-    .get(id) as
-    | {
-        id: string;
-        email: string;
-        name: string | null;
-        role: string;
-        active: number | null;
-        createdAt: string; // ISO 8601 string from better-auth
-      }
-    | undefined;
+  const updated = await authGet<{
+    id: string;
+    email: string;
+    name: string | null;
+    role: string;
+    active: number | boolean | null;
+    createdAt: string | Date;
+  }>('SELECT id, email, name, role, active, "createdAt" FROM "user" WHERE id = ?', [id]);
 
   if (!updated) {
     return NextResponse.json({ error: 'not found' }, { status: 404 });
@@ -54,7 +52,8 @@ export async function PATCH(
     email: updated.email,
     name: updated.name,
     role: updated.role,
-    active: updated.active !== 0,
-    createdAt: updated.createdAt,
+    active: updated.active !== 0 && updated.active !== false,
+    createdAt:
+      updated.createdAt instanceof Date ? updated.createdAt.toISOString() : updated.createdAt,
   });
 }

--- a/apps/auth/app/api/admin/users/route.ts
+++ b/apps/auth/app/api/admin/users/route.ts
@@ -1,30 +1,50 @@
 import { NextResponse } from 'next/server';
 import { checkAdminKey } from '@/src/admin-guard';
-import { getDb } from '@/src/db';
+import { authAll } from '@/src/db';
 import { buildMemberList, type AuthUserRow, type PendingInviteRow } from '@/src/member-list';
+
+/** Normalise a better-auth date (ISO string on SQLite, Date on Postgres) to ISO. */
+function toIso(value: string | Date): string {
+  return value instanceof Date ? value.toISOString() : String(value);
+}
 
 export async function GET(request: Request): Promise<Response> {
   const denied = checkAdminKey(request);
   if (denied) return denied;
 
-  const db = getDb();
-
-  const users = db
-    .prepare('SELECT id, email, name, role, active, createdAt FROM user ORDER BY createdAt ASC')
-    .all() as AuthUserRow[];
+  // Quote the `user` table (reserved word in Postgres) and camelCase columns so
+  // the query is portable across SQLite and Postgres.
+  const userRows = await authAll<{
+    id: string;
+    email: string;
+    name: string | null;
+    role: string;
+    active: number | boolean | null;
+    createdAt: string | Date;
+  }>('SELECT id, email, name, role, active, "createdAt" FROM "user" ORDER BY "createdAt" ASC');
+  const users: AuthUserRow[] = userRows.map((u) => ({ ...u, createdAt: toIso(u.createdAt) }));
 
   const now = Math.floor(Date.now() / 1000);
 
   // Pending invites only: not consumed, not expired. Ascending order so the
   // merge's last-write-wins dedup keeps the most recent invite per email.
-  const invites = db
-    .prepare(
-      `SELECT email, created_at, expires_at FROM invites
+  const inviteRows = await authAll<{
+    email: string;
+    created_at: number | string;
+    expires_at: number | string | null;
+  }>(
+    `SELECT email, created_at, expires_at FROM invites
        WHERE consumed_at IS NULL
          AND (expires_at IS NULL OR expires_at > ?)
        ORDER BY created_at ASC`,
-    )
-    .all(now) as PendingInviteRow[];
+    [now],
+  );
+  // created_at/expires_at are BIGINT on Postgres, returned as strings — coerce.
+  const invites: PendingInviteRow[] = inviteRows.map((i) => ({
+    email: i.email,
+    created_at: Number(i.created_at),
+    expires_at: i.expires_at == null ? null : Number(i.expires_at),
+  }));
 
   return NextResponse.json(buildMemberList(users, invites));
 }

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sovereignfs/auth",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -15,12 +15,14 @@
     "better-auth": "^1.6.16",
     "better-sqlite3": "^12.10.0",
     "next": "catalog:",
+    "pg": "^8.21.0",
     "react": "catalog:",
     "react-dom": "catalog:"
   },
   "devDependencies": {
     "@sovereignfs/tsconfig": "workspace:*",
     "@types/better-sqlite3": "^7.6.13",
+    "@types/pg": "^8.20.0",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "typescript": "catalog:"

--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -1,18 +1,17 @@
 import { betterAuth, type BetterAuthOptions } from 'better-auth';
 import { APIError } from 'better-auth/api';
 import { nextCookies } from 'better-auth/next-js';
-import { getDb } from './db';
+import { authGet, authRun, getAuthDatabase } from './db';
 import { getEnv } from './env';
 import { readInviteOnlySetting, resolveInviteOnly } from './settings';
 
 function buildOptions(): BetterAuthOptions {
   const env = getEnv();
-  const db = getDb();
 
   return {
     secret: env.secret,
     baseURL: env.baseUrl,
-    database: db,
+    database: getAuthDatabase(),
     session: {
       // Disable better-auth's "fresh session" gate. By default sensitive
       // endpoints guarded by freshSessionMiddleware (e.g. GET /list-sessions,
@@ -48,26 +47,31 @@ function buildOptions(): BetterAuthOptions {
       user: {
         create: {
           before: async (user) => {
-            const isFirst =
-              (db.prepare('SELECT COUNT(*) AS c FROM user').get() as { c: number }).c === 0;
+            const countRow = await authGet<{ c: number | string }>(
+              'SELECT COUNT(*) AS c FROM "user"',
+            );
+            // COUNT is a number on SQLite, a bigint-as-string on Postgres.
+            const isFirst = Number(countRow?.c ?? 0) === 0;
 
             // Invite-only gate (first user bootstraps and is exempt). The
             // Console toggle (stored setting) overrides the env default, so
             // this is resolved per registration — no restart needed (CON-10).
-            const inviteOnly = resolveInviteOnly(readInviteOnlySetting(db), env.inviteOnly);
+            const inviteOnly = resolveInviteOnly(await readInviteOnlySetting(), env.inviteOnly);
             if (!isFirst && inviteOnly) {
               const now = Math.floor(Date.now() / 1000);
-              const invite = db
-                .prepare(
-                  'SELECT token FROM invites WHERE email = ? AND consumed_at IS NULL AND (expires_at IS NULL OR expires_at > ?)',
-                )
-                .get(user.email, now);
+              const invite = await authGet(
+                'SELECT token FROM invites WHERE email = ? AND consumed_at IS NULL AND (expires_at IS NULL OR expires_at > ?)',
+                [user.email, now],
+              );
               if (!invite) {
                 throw new APIError('FORBIDDEN', {
                   message: 'Registration is invite-only; no valid invite was found for this email.',
                 });
               }
-              db.prepare('UPDATE invites SET consumed_at = ? WHERE email = ?').run(now, user.email);
+              await authRun('UPDATE invites SET consumed_at = ? WHERE email = ?', [
+                now,
+                user.email,
+              ]);
             }
 
             // First user becomes the platform admin.

--- a/apps/auth/src/db.ts
+++ b/apps/auth/src/db.ts
@@ -1,17 +1,36 @@
 import { existsSync, mkdirSync } from 'node:fs';
 import { dirname, isAbsolute, join, resolve } from 'node:path';
 import Database from 'better-sqlite3';
+import { Pool } from 'pg';
 import { getEnv } from './env';
 
-let db: Database.Database | undefined;
+/**
+ * The auth server's database, dialect-agnostic like the platform DB (NFR-03).
+ * The dialect is inferred from the connection URL: a `postgres(ql)://` URL uses
+ * node-postgres, anything else a local SQLite file.
+ *
+ * better-auth manages its own user/session/account/verification tables (created
+ * by its migrator, see ./migrate); we add an `invites` table (invite-only gate)
+ * and an `auth_settings` table (the Console invite-only toggle). better-auth
+ * receives the raw driver via `getAuthDatabase()`; the app's own queries go
+ * through the async `authGet`/`authAll`/`authRun` helpers, which paper over the
+ * better-sqlite3 (sync) vs node-postgres (async) split.
+ */
+
+type AuthDb =
+  | { dialect: 'sqlite'; sqlite: Database.Database }
+  | { dialect: 'postgres'; pool: Pool };
+
+function isPostgresUrl(url: string): boolean {
+  return url.startsWith('postgres://') || url.startsWith('postgresql://');
+}
 
 /**
- * Convert a `file:` URL to a filesystem path. Relative paths resolve against
- * the workspace root (nearest ancestor with pnpm-workspace.yaml), not the
- * process cwd — the auth server runs from apps/auth/, and all SQLite files
- * should land in the single root-level data/ directory. Mirrors the
- * resolution in packages/db (not imported: the auth server intentionally
- * does not depend on packages/db).
+ * Convert a `file:` URL to a filesystem path. Relative paths resolve against the
+ * workspace root (nearest ancestor with pnpm-workspace.yaml), not the process
+ * cwd — the auth server runs from apps/auth/, and all SQLite files should land
+ * in the single root-level data/ directory. (Mirrors packages/db; not imported,
+ * as the auth server intentionally does not depend on packages/db.)
  */
 function toPath(url: string): string {
   if (url === ':memory:') return url;
@@ -30,35 +49,104 @@ function findWorkspaceRoot(): string {
   }
 }
 
-/**
- * The auth server's own SQLite database. better-auth manages the
- * user/session/account/verification tables; we add an `invites` table for the
- * invite-only gate (invite creation is a Console feature, Task 0.4.02).
- */
-export function getDb(): Database.Database {
-  if (!db) {
-    const path = toPath(getEnv().databaseUrl);
-    if (path !== ':memory:') {
-      mkdirSync(dirname(path), { recursive: true });
-    }
-    const conn = new Database(path);
-    conn.pragma('journal_mode = WAL');
-    conn.pragma('foreign_keys = ON');
-    conn.exec(`
-      CREATE TABLE IF NOT EXISTS invites (
-        token TEXT PRIMARY KEY,
-        email TEXT NOT NULL,
-        created_at INTEGER NOT NULL,
-        expires_at INTEGER,
-        consumed_at INTEGER
-      );
-      CREATE TABLE IF NOT EXISTS auth_settings (
-        key TEXT PRIMARY KEY,
-        value TEXT NOT NULL,
-        updated_at INTEGER NOT NULL
-      );
-    `);
-    db = conn;
+let _db: AuthDb | undefined;
+
+function getAuthDb(): AuthDb {
+  if (_db) return _db;
+  const url = getEnv().databaseUrl;
+
+  if (isPostgresUrl(url)) {
+    _db = { dialect: 'postgres', pool: new Pool({ connectionString: url }) };
+    return _db;
   }
-  return db;
+
+  const path = toPath(url);
+  if (path !== ':memory:') {
+    mkdirSync(dirname(path), { recursive: true });
+  }
+  const sqlite = new Database(path);
+  sqlite.pragma('journal_mode = WAL');
+  sqlite.pragma('foreign_keys = ON');
+  _db = { dialect: 'sqlite', sqlite };
+  return _db;
+}
+
+/** The dialect of the auth database. */
+export function getAuthDialect(): 'sqlite' | 'postgres' {
+  return getAuthDb().dialect;
+}
+
+/**
+ * The raw driver better-auth manages directly (a better-sqlite3 `Database` for
+ * SQLite, a node-postgres `Pool` for Postgres). better-auth detects the dialect
+ * from the instance.
+ */
+export function getAuthDatabase(): Database.Database | Pool {
+  const db = getAuthDb();
+  return db.dialect === 'sqlite' ? db.sqlite : db.pool;
+}
+
+/** Create the auth server's own tables (invites, auth_settings). Idempotent. */
+export async function ensureAuthTables(): Promise<void> {
+  const ts = getAuthDialect() === 'postgres' ? 'BIGINT' : 'INTEGER';
+  await authRun(
+    `CREATE TABLE IF NOT EXISTS invites (
+      token TEXT PRIMARY KEY,
+      email TEXT NOT NULL,
+      created_at ${ts} NOT NULL,
+      expires_at ${ts},
+      consumed_at ${ts}
+    )`,
+  );
+  await authRun(
+    `CREATE TABLE IF NOT EXISTS auth_settings (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL,
+      updated_at ${ts} NOT NULL
+    )`,
+  );
+}
+
+/** Rewrite `?` positional placeholders to Postgres `$1, $2, …`. */
+function toPgPlaceholders(sql: string): string {
+  let i = 0;
+  return sql.replace(/\?/g, () => `$${++i}`);
+}
+
+/** better-sqlite3 cannot bind booleans; map them to 0/1. Postgres binds natively. */
+function sqliteParams(params: readonly unknown[]): unknown[] {
+  return params.map((p) => (typeof p === 'boolean' ? (p ? 1 : 0) : p));
+}
+
+/** Run a query returning at most one row. */
+export async function authGet<T>(
+  sql: string,
+  params: readonly unknown[] = [],
+): Promise<T | undefined> {
+  const db = getAuthDb();
+  if (db.dialect === 'sqlite') {
+    return db.sqlite.prepare(sql).get(...sqliteParams(params)) as T | undefined;
+  }
+  const res = await db.pool.query(toPgPlaceholders(sql), params as unknown[]);
+  return res.rows[0] as T | undefined;
+}
+
+/** Run a query returning all rows. */
+export async function authAll<T>(sql: string, params: readonly unknown[] = []): Promise<T[]> {
+  const db = getAuthDb();
+  if (db.dialect === 'sqlite') {
+    return db.sqlite.prepare(sql).all(...sqliteParams(params)) as T[];
+  }
+  const res = await db.pool.query(toPgPlaceholders(sql), params as unknown[]);
+  return res.rows as T[];
+}
+
+/** Run a statement for its side effects (INSERT/UPDATE/DDL). */
+export async function authRun(sql: string, params: readonly unknown[] = []): Promise<void> {
+  const db = getAuthDb();
+  if (db.dialect === 'sqlite') {
+    db.sqlite.prepare(sql).run(...sqliteParams(params));
+    return;
+  }
+  await db.pool.query(toPgPlaceholders(sql), params as unknown[]);
 }

--- a/apps/auth/src/member-list.test.ts
+++ b/apps/auth/src/member-list.test.ts
@@ -23,7 +23,7 @@ function invite(overrides: Partial<PendingInviteRow> = {}): PendingInviteRow {
 }
 
 describe('buildMemberList', () => {
-  it('maps active 1 and NULL to active, 0 to deactivated', () => {
+  it('maps active 1 and NULL to active, 0 to deactivated (SQLite shape)', () => {
     const rows = buildMemberList(
       [
         user({ id: 'u1', email: 'a@x.com', active: 1 }),
@@ -33,6 +33,17 @@ describe('buildMemberList', () => {
       [],
     );
     expect(rows.map((r) => r.status)).toEqual(['active', 'active', 'deactivated']);
+  });
+
+  it('maps active true to active, false to deactivated (Postgres shape)', () => {
+    const rows = buildMemberList(
+      [
+        user({ id: 'u1', email: 'a@x.com', active: true }),
+        user({ id: 'u2', email: 'b@x.com', active: false }),
+      ],
+      [],
+    );
+    expect(rows.map((r) => r.status)).toEqual(['active', 'deactivated']);
   });
 
   it('appends pending invites as invited rows with null id and role', () => {

--- a/apps/auth/src/member-list.ts
+++ b/apps/auth/src/member-list.ts
@@ -3,13 +3,16 @@ export interface AuthUserRow {
   email: string;
   name: string | null;
   role: string;
-  active: number | null; // SQLite boolean: 0 | 1 | NULL (NULL = active, same as default)
-  createdAt: string; // better-auth stores dates as ISO 8601 strings in SQLite
+  // better-auth's `active` boolean reads back as 0/1 on SQLite and true/false on
+  // Postgres; NULL means active (the default). The route passes whichever the
+  // driver returns — `buildMemberList` treats 0 and false as deactivated.
+  active: number | boolean | null;
+  createdAt: string; // normalised to an ISO 8601 string by the caller (Date on pg)
 }
 
 export interface PendingInviteRow {
   email: string;
-  created_at: number; // Unix timestamp (seconds)
+  created_at: number; // Unix timestamp (seconds) — caller normalises pg bigint strings
   expires_at: number | null;
 }
 
@@ -46,7 +49,7 @@ export function buildMemberList(users: AuthUserRow[], invites: PendingInviteRow[
     email: u.email,
     name: u.name,
     role: u.role,
-    status: u.active === 0 ? 'deactivated' : 'active',
+    status: u.active === 0 || u.active === false ? 'deactivated' : 'active',
     createdAt: u.createdAt,
     expiresAt: null,
   }));

--- a/apps/auth/src/migrate.ts
+++ b/apps/auth/src/migrate.ts
@@ -1,11 +1,14 @@
 import { getMigrations } from 'better-auth/db/migration';
 import { getAuthOptions } from './auth';
+import { ensureAuthTables } from './db';
 
 /**
- * Apply better-auth's schema migrations (user/session/account/verification) to
- * the auth database. Idempotent — safe to run on every startup.
+ * Apply better-auth's schema migrations (user/session/account/verification) and
+ * create the auth server's own tables (invites, auth_settings). Both are
+ * dialect-aware and idempotent — safe to run on every startup.
  */
 export async function runAuthMigrations(): Promise<void> {
   const { runMigrations } = await getMigrations(getAuthOptions());
   await runMigrations();
+  await ensureAuthTables();
 }

--- a/apps/auth/src/settings.ts
+++ b/apps/auth/src/settings.ts
@@ -1,4 +1,4 @@
-import type Database from 'better-sqlite3';
+import { authGet, authRun } from './db';
 
 /**
  * Resolve the effective invite-only flag: a stored Console setting overrides
@@ -15,18 +15,19 @@ export function resolveInviteOnly(
 }
 
 /** Read the stored invite-only setting; null when never toggled. */
-export function readInviteOnlySetting(db: Database.Database): string | null {
-  const row = db.prepare("SELECT value FROM auth_settings WHERE key = 'invite_only'").get() as
-    | { value: string }
-    | undefined;
+export async function readInviteOnlySetting(): Promise<string | null> {
+  const row = await authGet<{ value: string }>(
+    "SELECT value FROM auth_settings WHERE key = 'invite_only'",
+  );
   return row?.value ?? null;
 }
 
 /** Persist the invite-only setting (upsert). */
-export function writeInviteOnlySetting(db: Database.Database, inviteOnly: boolean): void {
+export async function writeInviteOnlySetting(inviteOnly: boolean): Promise<void> {
   const now = Math.floor(Date.now() / 1000);
-  db.prepare(
+  await authRun(
     `INSERT INTO auth_settings (key, value, updated_at) VALUES ('invite_only', ?, ?)
-     ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
-  ).run(String(inviteOnly), now);
+     ON CONFLICT (key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+    [String(inviteOnly), now],
+  );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,13 +94,16 @@ importers:
         version: link:../../packages/ui
       better-auth:
         specifier: ^1.6.16
-        version: 1.6.16(better-sqlite3@12.10.0)(drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.10.0)(kysely@0.29.2)(pg@8.21.0))(next@15.5.19(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8(@types/node@22.19.20)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))
+        version: 1.6.16(better-sqlite3@12.10.0)(drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.10.0)(kysely@0.29.2)(pg@8.21.0))(next@15.5.19(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8(@types/node@22.19.20)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))
       better-sqlite3:
         specifier: ^12.10.0
         version: 12.10.0
       next:
         specifier: 'catalog:'
         version: 15.5.19(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      pg:
+        specifier: ^8.21.0
+        version: 8.21.0
       react:
         specifier: 'catalog:'
         version: 19.2.7
@@ -114,6 +117,9 @@ importers:
       '@types/better-sqlite3':
         specifier: ^7.6.13
         version: 7.6.13
+      '@types/pg':
+        specifier: ^8.20.0
+        version: 8.20.0
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.17
@@ -6439,7 +6445,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.37: {}
 
-  better-auth@1.6.16(better-sqlite3@12.10.0)(drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.10.0)(kysely@0.29.2)(pg@8.21.0))(next@15.5.19(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8(@types/node@22.19.20)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))):
+  better-auth@1.6.16(better-sqlite3@12.10.0)(drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.10.0)(kysely@0.29.2)(pg@8.21.0))(next@15.5.19(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8(@types/node@22.19.20)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))):
     dependencies:
       '@better-auth/core': 1.6.16(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.2.2)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.6.16(@better-auth/core@1.6.16(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.2.2)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.10.0)(kysely@0.29.2)(pg@8.21.0))


### PR DESCRIPTION
**Phase 2 of Task 0.5.03 (Postgres validation).** Makes `apps/auth` dialect-agnostic (NFR-03), completing platform Postgres parity alongside `packages/db` (#33). **SQLite stays the default and behaves identically.**

## Changes
- **`db.ts`** — dialect inferred from `AUTH_DATABASE_URL` (`postgres://` → node-postgres `Pool`, else a `better-sqlite3` file). better-auth gets the raw driver via `getAuthDatabase()` (it auto-detects the dialect); the app's own queries go through async `authGet`/`authAll`/`authRun` helpers that translate `?`→`$N` and bind booleans as `0/1` for SQLite. `ensureAuthTables()` creates `invites`/`auth_settings` with dialect-aware DDL (`INTEGER` vs `BIGINT`).
- **`auth.ts`** — `database: getAuthDatabase()`; the create-hook is async via the helpers. The **`user` table (reserved word in Postgres)** and its camelCase columns are quoted for portability, and `COUNT` is read via `Number(...)` to handle Postgres's bigint-as-string.
- **`settings.ts`** — async via the helpers. **`migrate.ts`** — runs `ensureAuthTables()` after better-auth's own migrations.
- **Admin routes** (users, users/[id], invites, settings) — raw `better-sqlite3` calls replaced with the helpers, so `.prepare()` is confined to the `db.ts` data layer.
- **`member-list.ts`** — normalizes better-auth's cross-dialect divergence: `active` reads back as `0/1` (SQLite) vs `true/false` (Postgres) and `createdAt` as an ISO string vs a `Date`; both mapped to a consistent shape (new test for the pg boolean shape).

## Validation
- Build, lint, typecheck, **147 tests** pass.
- **Live-validated on Postgres 16 and SQLite** (throwaway Docker): better-auth migrate, first user → `platform:admin` (second → `platform:user`), the quoted user-list query, and the settings upsert all behave correctly on both dialects.
- `.prepare()` is confined to the data layer.

## Deps / version
`pg` + `@types/pg`; `@sovereignfs/auth` 0.3.1 → **0.4.0**.

## Context
Third of 4 PRs for Task 0.5.03: PR1a async (#32) → PR1b Postgres `packages/db` (#33) → **PR2 auth Postgres (this)** → PR3 compose Postgres variant + docs + full cross-container end-to-end validation. **No Docker config changes here** — the compose Postgres service and `docs/self-hosting.md` land in PR3 (the existing `AUTH_DATABASE_URL` env already selects the dialect; `pg` is pure-JS so no Dockerfile build change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)