### PR TITLE
Postgres test coverage (parity integration tests + dialect-helper units)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,26 @@ sends mail. For a zero-install option, nodemailer's
 [Ethereal](https://ethereal.email/) test accounts print a preview URL per
 message instead of using a local inbox.
 
+### Running the tests
+
+`pnpm test` runs the whole suite on **SQLite** with no external services — this
+is what CI runs by default and what you should run before a PR.
+
+The platform is dialect-agnostic (SQLite or Postgres, NFR-03), so there are also
+**Postgres parity tests** (files named `*.pg.test.ts`). They are **skipped
+unless** `TEST_DATABASE_URL` points at a Postgres instance, so the default run
+stays Docker-free. To run them against a throwaway Postgres:
+
+```bash
+docker run -d --name sov-test-pg -e POSTGRES_PASSWORD=pw -e POSTGRES_DB=sov \
+  -p 5432:5432 postgres:16-alpine
+TEST_DATABASE_URL=postgres://postgres:pw@127.0.0.1:5432/sov pnpm test
+docker rm -f sov-test-pg
+```
+
+These tests drop and recreate their own tables, so point them only at a
+disposable database. CI gains a Postgres service that runs them in Task 0.5.07.
+
 ---
 
 ## Branching and commits

--- a/apps/auth/src/db.pg.test.ts
+++ b/apps/auth/src/db.pg.test.ts
@@ -1,0 +1,79 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+/**
+ * Live Postgres parity for the auth server. Skipped unless TEST_DATABASE_URL
+ * points at a Postgres instance (the default `pnpm test` stays Docker-free).
+ * CI wires a Postgres service in Task 0.5.07.
+ *
+ *   TEST_DATABASE_URL=postgres://user:pass@localhost:5432/db pnpm test
+ *
+ * Exercises the riskiest dialect divergences: better-auth migrating + signing
+ * up against Postgres, the quoted `"user"` query (reserved word + camelCase
+ * columns), the bigint-as-string COUNT in the create hook, and our own
+ * invites/auth_settings tables via the query helpers.
+ */
+const PG_URL = process.env.TEST_DATABASE_URL;
+
+describe.skipIf(!PG_URL)('auth server on Postgres', () => {
+  beforeAll(async () => {
+    process.env.AUTH_DATABASE_URL = PG_URL;
+    process.env.AUTH_SECRET ??= 'test-secret-test-secret-test-secret';
+    process.env.SOVEREIGN_ADMIN_KEY ??= 'test-admin-key';
+    process.env.AUTH_INVITE_ONLY = 'false';
+
+    const { authRun } = await import('./db');
+    // Clean slate: better-auth's tables + our own.
+    await authRun(
+      'DROP TABLE IF EXISTS "user", session, account, verification, invites, auth_settings CASCADE',
+    );
+
+    const { runAuthMigrations } = await import('./migrate');
+    await runAuthMigrations();
+  });
+
+  it('infers the postgres dialect from the URL', async () => {
+    const { getAuthDialect } = await import('./db');
+    expect(getAuthDialect()).toBe('postgres');
+  });
+
+  it('makes the first registered user a platform admin (create hook)', async () => {
+    const { getAuth } = await import('./auth');
+    const auth = getAuth();
+    await auth.api.signUpEmail({
+      body: { email: 'admin@example.com', password: 'sup3rsecret!', name: 'Admin' },
+    });
+    await auth.api.signUpEmail({
+      body: { email: 'bob@example.com', password: 'sup3rsecret!', name: 'Bob' },
+    });
+
+    // The quoted "user" query (reserved word + camelCase column) must work, and
+    // `active`/`createdAt` come back as boolean/Date on Postgres.
+    const { authAll } = await import('./db');
+    const rows = await authAll<{ email: string; role: string; active: unknown }>(
+      'SELECT id, email, name, role, active, "createdAt" FROM "user" ORDER BY "createdAt" ASC',
+    );
+    expect(rows.map((r) => [r.email, r.role])).toEqual([
+      ['admin@example.com', 'platform:admin'],
+      ['bob@example.com', 'platform:user'],
+    ]);
+    expect(typeof rows[0]?.active).toBe('boolean');
+  });
+
+  it('round-trips the invite-only setting and an invite', async () => {
+    const { readInviteOnlySetting, writeInviteOnlySetting } = await import('./settings');
+    expect(await readInviteOnlySetting()).toBeNull();
+    await writeInviteOnlySetting(true);
+    await writeInviteOnlySetting(false);
+    expect(await readInviteOnlySetting()).toBe('false');
+
+    const { authRun, authGet } = await import('./db');
+    await authRun(
+      'INSERT INTO invites (token, email, created_at, expires_at) VALUES (?, ?, ?, ?)',
+      ['tok-1', 'carol@example.com', Math.floor(Date.now() / 1000), null],
+    );
+    const invite = await authGet<{ email: string }>('SELECT email FROM invites WHERE token = ?', [
+      'tok-1',
+    ]);
+    expect(invite?.email).toBe('carol@example.com');
+  });
+});

--- a/apps/auth/src/db.test.ts
+++ b/apps/auth/src/db.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { sqliteParams, toPgPlaceholders } from './db';
+
+describe('toPgPlaceholders', () => {
+  it('rewrites ? to $1, $2, … in order', () => {
+    expect(toPgPlaceholders('SELECT * FROM t WHERE a = ? AND b = ?')).toBe(
+      'SELECT * FROM t WHERE a = $1 AND b = $2',
+    );
+  });
+
+  it('leaves a parameterless query unchanged', () => {
+    expect(toPgPlaceholders('SELECT 1')).toBe('SELECT 1');
+  });
+
+  it('numbers every placeholder, including repeats', () => {
+    expect(toPgPlaceholders('VALUES (?, ?, ?)')).toBe('VALUES ($1, $2, $3)');
+  });
+});
+
+describe('sqliteParams', () => {
+  it('maps booleans to 1/0 (better-sqlite3 cannot bind booleans)', () => {
+    expect(sqliteParams([true, false])).toEqual([1, 0]);
+  });
+
+  it('leaves non-boolean params untouched', () => {
+    expect(sqliteParams(['x', 5, null, undefined])).toEqual(['x', 5, null, undefined]);
+  });
+});

--- a/apps/auth/src/db.ts
+++ b/apps/auth/src/db.ts
@@ -107,14 +107,17 @@ export async function ensureAuthTables(): Promise<void> {
   );
 }
 
-/** Rewrite `?` positional placeholders to Postgres `$1, $2, …`. */
-function toPgPlaceholders(sql: string): string {
+/** Rewrite `?` positional placeholders to Postgres `$1, $2, …`. Exported for testing. */
+export function toPgPlaceholders(sql: string): string {
   let i = 0;
   return sql.replace(/\?/g, () => `$${++i}`);
 }
 
-/** better-sqlite3 cannot bind booleans; map them to 0/1. Postgres binds natively. */
-function sqliteParams(params: readonly unknown[]): unknown[] {
+/**
+ * better-sqlite3 cannot bind booleans; map them to 0/1. Postgres binds natively.
+ * Exported for testing.
+ */
+export function sqliteParams(params: readonly unknown[]): unknown[] {
   return params.map((p) => (typeof p === 'boolean' ? (p ? 1 : 0) : p));
 }
 

--- a/packages/db/src/exec.test.ts
+++ b/packages/db/src/exec.test.ts
@@ -1,0 +1,37 @@
+import { sql } from 'drizzle-orm';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { type PlatformDb, createClient } from './client';
+import { dbAll, dbGet, dbRun } from './exec';
+
+describe('exec helpers (sqlite)', () => {
+  let pdb: PlatformDb;
+
+  beforeAll(async () => {
+    pdb = createClient({ url: ':memory:' });
+    await dbRun(pdb, sql.raw('CREATE TABLE t (id TEXT PRIMARY KEY, n INTEGER NOT NULL)'));
+    await dbRun(pdb, sql`INSERT INTO t (id, n) VALUES (${'a'}, ${1})`);
+    await dbRun(pdb, sql`INSERT INTO t (id, n) VALUES (${'b'}, ${2})`);
+  });
+
+  it('dbGet returns a single parameterised row', async () => {
+    const row = await dbGet<{ id: string; n: number }>(
+      pdb,
+      sql`SELECT id, n FROM t WHERE id = ${'a'}`,
+    );
+    expect(row).toEqual({ id: 'a', n: 1 });
+  });
+
+  it('dbGet returns undefined when no row matches', async () => {
+    expect(await dbGet(pdb, sql`SELECT id FROM t WHERE id = ${'missing'}`)).toBeUndefined();
+  });
+
+  it('dbAll returns every matching row', async () => {
+    const rows = await dbAll<{ id: string }>(pdb, sql`SELECT id FROM t ORDER BY id`);
+    expect(rows.map((r) => r.id)).toEqual(['a', 'b']);
+  });
+
+  it('dbRun executes a statement for its side effects', async () => {
+    await dbRun(pdb, sql`DELETE FROM t WHERE id = ${'b'}`);
+    expect(await dbAll(pdb, sql`SELECT id FROM t`)).toHaveLength(1);
+  });
+});

--- a/packages/db/src/postgres.pg.test.ts
+++ b/packages/db/src/postgres.pg.test.ts
@@ -1,0 +1,83 @@
+import { sql } from 'drizzle-orm';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { type PlatformDb, createClient } from './client';
+import { dbRun } from './exec';
+import {
+  DEFAULT_ROOT_PLUGIN_ID,
+  bootstrapPlatformDb,
+  getAccountPrefs,
+  getDefaultTenant,
+  getPlatformSetting,
+  listDisabledPluginIds,
+  listPluginStatus,
+  pingDb,
+  setAccountPrefs,
+  setPlatformSetting,
+  setPluginEnabled,
+  setTenantName,
+} from './platform-db';
+
+/**
+ * Live Postgres parity for the platform data layer. Skipped unless
+ * TEST_DATABASE_URL points at a Postgres instance, so the default `pnpm test`
+ * stays Docker-free. CI wires a Postgres service in Task 0.5.07.
+ *
+ *   TEST_DATABASE_URL=postgres://user:pass@localhost:5432/db pnpm test
+ *
+ * Asserts the dialect-divergence traps the query builder normalises: `enabled`
+ * comes back as a real JS boolean (not 0/1) and the seeds/upserts behave the
+ * same as on SQLite.
+ */
+const PG_URL = process.env.TEST_DATABASE_URL;
+
+describe.skipIf(!PG_URL)('platform-db on Postgres', () => {
+  let pdb: PlatformDb;
+
+  beforeAll(async () => {
+    pdb = createClient({ url: PG_URL });
+    // Clean slate — the platform tables only (auth tables live elsewhere).
+    for (const table of ['account_prefs', 'platform_settings', 'plugin_status', 'tenants']) {
+      await dbRun(pdb, sql.raw(`DROP TABLE IF EXISTS ${table} CASCADE`));
+    }
+    await bootstrapPlatformDb(pdb);
+  });
+
+  it('connects with the postgres dialect', () => {
+    expect(pdb.dialect).toBe('postgres');
+  });
+
+  it('pings without error', async () => {
+    await expect(pingDb(pdb)).resolves.toBeUndefined();
+  });
+
+  it('seeds the default tenant and root plugin', async () => {
+    expect((await getDefaultTenant(pdb)).name).toBe('Sovereign');
+    expect(await getPlatformSetting(pdb, 'root_plugin_id')).toBe(DEFAULT_ROOT_PLUGIN_ID);
+  });
+
+  it('renames the tenant and upserts settings', async () => {
+    await setTenantName(pdb, 'Acme');
+    expect((await getDefaultTenant(pdb)).name).toBe('Acme');
+    await setPlatformSetting(pdb, 'invite_only', 'true');
+    await setPlatformSetting(pdb, 'invite_only', 'false');
+    expect(await getPlatformSetting(pdb, 'invite_only')).toBe('false');
+  });
+
+  it('maps the plugin_status boolean to a JS boolean and upserts', async () => {
+    await setPluginEnabled(pdb, 'fs.test.alpha', false);
+    await setPluginEnabled(pdb, 'fs.test.alpha', false); // upsert, not a duplicate
+    const rows = await listPluginStatus(pdb);
+    expect(rows).toContainEqual({ pluginId: 'fs.test.alpha', enabled: false });
+    expect(rows.every((r) => typeof r.enabled === 'boolean')).toBe(true);
+    expect(await listDisabledPluginIds(pdb)).toContain('fs.test.alpha');
+
+    await setPluginEnabled(pdb, 'fs.test.alpha', true);
+    expect(await listDisabledPluginIds(pdb)).not.toContain('fs.test.alpha');
+  });
+
+  it('round-trips account preferences', async () => {
+    expect(await getAccountPrefs(pdb, 'u1')).toEqual({ timezone: 'UTC', theme: 'system' });
+    await setAccountPrefs(pdb, 'u1', { theme: 'dark' });
+    expect(await getAccountPrefs(pdb, 'u1')).toEqual({ timezone: 'UTC', theme: 'dark' });
+  });
+});


### PR DESCRIPTION
Closes the test gap left by the Postgres work (#33, #34): the suite was **SQLite-only**, the pure dialect-translation helpers were untested, and the pg paths had only been validated by throwaway scripts. This commits that coverage.

## Unit tests (always run, no DB)
- **`packages/db/src/exec.test.ts`** — `dbGet`/`dbAll`/`dbRun` against in-memory SQLite (parameterised get, empty result, all, side-effecting run).
- **`apps/auth`** — export and unit-test `toPgPlaceholders` (`?`→`$N` in order) and `sqliteParams` (boolean→`0/1`, others untouched) — the subtle dialect-translation logic.

## Env-gated Postgres integration tests
Skipped unless `TEST_DATABASE_URL` is set, so the default `pnpm test` stays Docker-free (the CI Postgres service lands in **Task 0.5.07**):
- **`packages/db/src/postgres.pg.test.ts`** — `createClient` + bootstrap + every platform helper on real Postgres, asserting the divergence traps the query builder normalizes (`enabled` is a JS boolean; settings/tenant/prefs round-trip).
- **`apps/auth/src/db.pg.test.ts`** — better-auth migrate + signup (first user → `platform:admin`), the quoted `"user"` query (reserved word + camelCase columns), and invites/auth_settings via the query helpers.

## Verification
- `pnpm test` → **156 passed, 9 skipped**.
- `TEST_DATABASE_URL=… pnpm test` against **Postgres 16** → **165 passed** (the 9 gated tests run and pass).
- `CONTRIBUTING.md` documents how to run the Postgres tests.

No version bumps (tests only; the two exported helpers are internal to the private `apps/auth`).

## Context
A dedicated test PR for Task 0.5.03, after PR1a (#32) / PR1b (#33) / PR2 (#34). Next and last: **PR3** — `docker-compose.prod.yml` Postgres service variant + `docs/self-hosting.md` + full cross-container end-to-end validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)