### PR TITLE
PostgreSQL Docker variant, docs, and end-to-end validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,11 +30,18 @@ SOVEREIGN_ADMIN_KEY=
 
 # --- Database ---
 # SQLite by default (zero-config). Relative paths resolve against the repo
-# root — all SQLite files land in the root-level data/ directory. For
-# Postgres, set a postgres:// URL and DB_DIALECT=postgres (Postgres support
-# lands in Task 0.5.03).
+# root — all SQLite files land in the root-level data/ directory.
 DATABASE_URL=file:./data/sovereign.db
 DB_DIALECT=sqlite
+
+# PostgreSQL: point DATABASE_URL + AUTH_DATABASE_URL at a postgres:// URL and set
+# DB_DIALECT=postgres. With the Docker stack, layer docker-compose.postgres.yml
+# over docker-compose.prod.yml (it provisions a postgres service and wires both
+# apps to it) — then only POSTGRES_PASSWORD below is required. See
+# docs/self-hosting.md.
+# POSTGRES_USER=sovereign
+# POSTGRES_PASSWORD=
+# POSTGRES_DB=sovereign
 
 # --- Email (SMTP) ---
 # Off by default: with SMTP_HOST unset the mailer no-ops and the app still runs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,9 +185,11 @@ pnpm lint:fix        # run ESLint with auto-fix
   pattern as `/api/admin/plugins/disabled`). `(platform)/page.tsx` keeps a
   `redirect()` as a fallback for when that resolution fetch fails. Platform
   tables (`tenants`, `plugin_status`, `platform_settings`) are bootstrapped with
-  CREATE-TABLE-IF-NOT-EXISTS + seed rows in `packages/db`'s `getPlatformDb()`
-  until drizzle-kit migrations land in Task 0.5.03; the DDL there must stay in
-  sync with the Drizzle schema.
+  **dialect-aware** CREATE-TABLE-IF-NOT-EXISTS + seed rows in `packages/db`'s
+  `getPlatformDb()` (`packages/db/src/bootstrap.ts`, `INTEGER`/`BIGINT` +
+  `INTEGER`/`BOOLEAN` per dialect); the DDL must stay in sync with the Drizzle
+  schemas (`schema/sqlite` + `schema/postgres`, guarded by a parity test).
+  drizzle-kit migrations replace this later (0.5.05+).
 - **Chrome plugins** (`fs.sovereign.launcher`, `fs.sovereign.account`,
   `fs.sovereign.console`) are reached through the sidebar chrome (home `/`,
   Console ⚙, Account avatar), never via the Launcher grid or the sidebar's
@@ -497,8 +499,9 @@ pnpm install:plugins    # clone sovereign/community plugins declared in sovereig
 - ✅ Task 0.4.06 — Account plugin (Profile + Preferences + Security): display name + avatar, IANA timezone + Light/Dark/System theme, password change, active-session list/revoke; `account_prefs` table; `sdk.auth` gained `changePassword`/`listSessions`/`revokeSession`; `freshAge: 0` so session listing isn't gated by session age. Completes the v0.4 chrome-plugin trio (Console, Launcher, Account) (merged to `main`).
 - ✅ Task 0.5.00 — `scripts/install-plugins.ts` (platform → 0.5.0, enters v0.5): reads `sovereign.plugins.json`, shallow-clones declared plugins into `plugins/<id>/` (skips existing), then runs `pnpm generate`; cloned plugins gitignored (allowlist keeps the three committed platform plugins) (merged to `main`).
 - ✅ Task 0.5.01 — PWA configuration (`runtime` → 0.5.0): `@ducanh2912/next-pwa` wraps `runtime/next.config.ts` (disabled in dev), `runtime/public/manifest.json` + generated PNG icons (192/512/maskable + apple-touch), manifest/theme-colour linked via root-layout metadata/viewport, `/offline` fallback page; service worker generated into `runtime/public/` at build (gitignored + eslint/prettier-ignored). SRS §3.11, PLT-09 (merged to `main`).
-- ▶️ In review: Task 0.5.02 — Production Docker image: `Dockerfile` (runtime) + `apps/auth/Dockerfile` rewritten as three-stage (`deps`/`builder`/`runner`) builds from Next.js standalone output (`output: 'standalone'` + `outputFileTracingRoot` = monorepo root in both `next.config.ts`); non-root `nextjs` runner, `HEALTHCHECK` against the new public `runtime/app/api/health` liveness route (auth already had `/api/health`); `docker-compose.prod.yml` adds healthchecks, `depends_on: condition: service_healthy`, and switches prod data to a **named volume** (non-root + bind mount breaks SQLite writes on Linux). ~264 MB true image size (≈7× smaller than the old dev image). SRS NFR-01, §3.1.
-- ⏳ Next: Task 0.5.03 — Postgres validation: confirm full SQLite↔Postgres parity (drizzle-kit migrations, both dialects exercised). Branch from an up-to-date `main` once the production-Docker PR merges.
+- ✅ Task 0.5.02 — Production Docker image: three-stage (`deps`/`builder`/`runner`) builds from Next.js standalone output (`output: 'standalone'` + `outputFileTracingRoot`); non-root `nextjs` runner, `HEALTHCHECK` against the public `runtime/app/api/health` route; `docker-compose.prod.yml` healthchecks, `depends_on: service_healthy`, and a **named volume** for prod data. ~264 MB image. SRS NFR-01, §3.1 (merged to `main`).
+- ✅ Task 0.5.03 — Postgres validation (SQLite↔Postgres parity, NFR-03; delivered in 4 PRs). The platform data layer is **async** (Postgres has no sync query) and `sdk.platform.getConfig()` is now async; `packages/db` wires the pg driver + a dialect-tagged `PlatformDb` wrapper + `schema/postgres` (bigint timestamps) + dialect-aware bootstrap DDL; `apps/auth` runs better-auth on a pg `Pool` with dialect-agnostic query helpers (quoted `"user"`, boolean/date normalisation). Postgres opt-in via the **`docker-compose.postgres.yml` overlay** (adds a `postgres` service, wires both apps). Env-gated `*.pg.test.ts` parity tests (`TEST_DATABASE_URL`). **Live-validated** end-to-end on Postgres 16: register → admin role → authenticated request → plugin toggle, all on a fresh pg. `docs/self-hosting.md` documents the Postgres setup + switch procedure (merged to `main`).
+- ⏳ Next: Task 0.5.04 — `sv` CLI core commands. Branch from an up-to-date `main`.
 - ⏳ Spec complete: Shell sidebar three-section architecture (PLT-11–PLT-15, SRS updated).
 - ⏳ Spec complete: Plainwrite sovereign plugin (`docs/plugins/plainwrite.md`, v0.2 — provider + SSG adapters).
 - ⏳ Spec complete: API Composer sovereign plugin (`docs/plugins/api-composer.md`) — GUI API builder, `/api` namespace (PLT-16, Task 0.5.08).

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -1,0 +1,48 @@
+# PostgreSQL overlay for the production stack.
+#
+# The base docker-compose.prod.yml runs on SQLite by default. Layer this file on
+# top to run the whole stack on PostgreSQL instead — it adds a `postgres`
+# service and points both the runtime and the auth server at it. No application
+# code changes (NFR-03): only the database connection differs.
+#
+# Usage:
+#   cp .env.example .env            # set AUTH_SECRET, SOVEREIGN_ADMIN_KEY,
+#                                   # POSTGRES_PASSWORD, NEXT_PUBLIC_RUNTIME_URL …
+#   docker compose -f docker-compose.prod.yml -f docker-compose.postgres.yml up --build -d
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: sovereign-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: '${POSTGRES_USER:-sovereign}'
+      POSTGRES_PASSWORD: '${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}'
+      POSTGRES_DB: '${POSTGRES_DB:-sovereign}'
+    volumes:
+      - sovereign_pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U ${POSTGRES_USER:-sovereign} -d ${POSTGRES_DB:-sovereign}']
+      interval: 10s
+      timeout: 5s
+      start_period: 10s
+      retries: 5
+    networks:
+      - sovereign_net
+
+  auth:
+    environment:
+      AUTH_DATABASE_URL: 'postgres://${POSTGRES_USER:-sovereign}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-sovereign}'
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  runtime:
+    environment:
+      DB_DIALECT: 'postgres'
+      DATABASE_URL: 'postgres://${POSTGRES_USER:-sovereign}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-sovereign}'
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+volumes:
+  sovereign_pgdata:

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -148,6 +148,67 @@ Caddy automatically.
 
 ---
 
+## PostgreSQL
+
+SQLite is the zero-config default and is fine for personal and small-group use.
+For larger or higher-concurrency deployments, run the whole stack on PostgreSQL
+instead — the only change is the database connection (NFR-03), no application
+code differs.
+
+### With Docker (recommended)
+
+Layer the `docker-compose.postgres.yml` overlay on top of the production file. It
+provisions a `postgres` service and points both the runtime and the auth server
+at it:
+
+```bash
+cp .env.example .env
+# Set AUTH_SECRET, SOVEREIGN_ADMIN_KEY, NEXT_PUBLIC_RUNTIME_URL, and at minimum
+# POSTGRES_PASSWORD. POSTGRES_USER / POSTGRES_DB default to "sovereign".
+
+docker compose -f docker-compose.prod.yml -f docker-compose.postgres.yml up --build -d
+```
+
+The runtime and auth server wait for Postgres to be healthy, then create their
+tables on first start (better-auth's identity tables and the platform tables).
+Postgres data lives in the `sovereign_pgdata` named volume; back it up with
+`pg_dump`:
+
+```bash
+docker exec sovereign-postgres pg_dump -U sovereign sovereign > backup.sql
+```
+
+### Without Docker
+
+Point all three database variables at your Postgres instance in `.env`:
+
+```bash
+DB_DIALECT=postgres
+DATABASE_URL=postgres://user:pass@host:5432/sovereign
+AUTH_DATABASE_URL=postgres://user:pass@host:5432/sovereign
+```
+
+The runtime and auth server can share one database (their table names don't
+collide) or use separate ones.
+
+### Switching SQLite → PostgreSQL
+
+There is no automatic data migration. To move an existing instance:
+
+1. Stop the stack (`docker compose ... down`, keeping volumes).
+2. Stand up PostgreSQL and start the stack with the Postgres overlay once so the
+   schema is created on the new database.
+3. Copy your data across with a tool such as
+   [pgloader](https://pgloader.io/) (pointed at the SQLite files under the
+   `sovereign_data` volume), or re-enter it. Timestamps are stored as integers
+   and booleans/`active` flags map directly, so a straight table copy works.
+4. Verify login, Console access, and your plugins, then retire the SQLite files.
+
+Uploaded files (avatars under `/app/data`) are independent of the database and
+stay on the `sovereign_data` volume regardless of dialect.
+
+---
+
 ## Email in development
 
 The dev Compose file includes [Mailpit](https://mailpit.axllent.org/) — a


### PR DESCRIPTION
**Final PR for Task 0.5.03 (Postgres validation, NFR-03).** Completes the SQLite↔Postgres parity work with the deployment variant, docs, and a live end-to-end validation. SQLite stays the zero-config default; Postgres is opt-in with **no application code change**.

## Changes
- **`docker-compose.postgres.yml`** (new) — an overlay for `docker-compose.prod.yml` that adds a `postgres` service (healthcheck + `sovereign_pgdata` named volume) and points both the runtime and auth server at it (`DB_DIALECT=postgres` + `postgres://` URLs, `depends_on: postgres healthy`):
  ```bash
  docker compose -f docker-compose.prod.yml -f docker-compose.postgres.yml up --build -d
  ```
- **`docs/self-hosting.md`** — a PostgreSQL section (Docker overlay + non-Docker env + `pg_dump` backup) and a **SQLite → Postgres switch procedure**.
- **`.env.example`** — documents `POSTGRES_USER`/`PASSWORD`/`DB`; removed the stale "Postgres lands in 0.5.03" note.
- **`CLAUDE.md`** — 0.5.03 marked done; bootstrap note corrected (dialect-aware DDL; drizzle-kit deferred to 0.5.05+); next is 0.5.04.

## Live validation (Postgres 16, full prod stack via the overlay)
Every review-checklist item from the task:
- ✅ Switching is **env-only** (`DB_DIALECT` + `DATABASE_URL`/`AUTH_DATABASE_URL`) — no code change.
- ✅ Migrations apply cleanly to a **fresh** Postgres (better-auth identity tables + platform tables + invites/auth_settings all created).
- ✅ **Register → first user becomes `platform:admin` → session verified across containers (runtime → auth over the internal network) → authenticated runtime request `200` → plugin enable/disable round-trips.** Health reports `dialect: postgres`.
- ✅ No SQLite-specific SQL in app code; the SQLite path is unchanged.

No version bumps (deployment + docs only).

## Task 0.5.03 — complete (4 PRs)
PR1a async (#32) · PR1b db Postgres (#33) · PR2 auth Postgres (#34) · test coverage (#35) · **this** (compose + docs + validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)