### PR TITLE
docs: update GitHub org references to sovereignfs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       value: |
         Please search existing issues before filing to avoid duplicates.
-        For security vulnerabilities, use [GitHub Security Advisories](https://github.com/CommonsEngine/Sovereign/security/advisories/new) — do not open a public issue.
+        For security vulnerabilities, use [GitHub Security Advisories](https://github.com/sovereignfs/sovereign/security/advisories/new) — do not open a public issue.
 
   - type: input
     id: version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ you need to get started.
 recommended for running the full stack locally.
 
 ```bash
-git clone https://github.com/CommonsEngine/Sovereign.git
+git clone https://github.com/sovereignfs/sovereign.git
 cd Sovereign
 pnpm install
 cp .env.example .env   # fill in required values
@@ -198,7 +198,7 @@ try to commit or track it.
    manifest `id` as the directory name:
 
    ```bash
-   git clone https://github.com/CommonsEngine/Sovereign.git
+   git clone https://github.com/sovereignfs/sovereign.git
    cd Sovereign
    mkdir -p plugins/fs.example.splitify
    ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@
 Report vulnerabilities privately using GitHub Security Advisories — only
 repository maintainers can see your report:
 
-### [Report a vulnerability →](https://github.com/CommonsEngine/Sovereign/security/advisories/new)
+### [Report a vulnerability →](https://github.com/sovereignfs/sovereign/security/advisories/new)
 
 You will need a GitHub account. Your report remains private until we
 coordinate disclosure together.

--- a/docs/plugins/api-composer.md
+++ b/docs/plugins/api-composer.md
@@ -48,19 +48,19 @@ endpoints under the platform's `/api` namespace (PLT-16).
 
 ## Identity and manifest
 
-| Property                           | Value                                                           |
-| ---------------------------------- | --------------------------------------------------------------- |
-| `id`                               | `io.openfs.sovereign.apicomposer`                               |
-| `name`                             | `API Composer`                                                  |
-| `type`                             | `sovereign`                                                     |
-| `runtime`                          | `native`                                                        |
-| `routePrefix`                      | `/api-composer`                                                 |
-| `shell`                            | `default`                                                       |
-| `adminOnly`                        | omitted (`false`)                                               |
-| `icon`                             | `icon.svg`                                                      |
-| `permissions`                      | `auth:session`, `db:readWrite`                                  |
-| `repository`                       | `https://github.com/CommonsEngine/sovereign-plugin-apicomposer` |
-| `compatibility.minPlatformVersion` | `0.5.0`                                                         |
+| Property                           | Value                                                         |
+| ---------------------------------- | ------------------------------------------------------------- |
+| `id`                               | `io.openfs.sovereign.apicomposer`                             |
+| `name`                             | `API Composer`                                                |
+| `type`                             | `sovereign`                                                   |
+| `runtime`                          | `native`                                                      |
+| `routePrefix`                      | `/api-composer`                                               |
+| `shell`                            | `default`                                                     |
+| `adminOnly`                        | omitted (`false`)                                             |
+| `icon`                             | `icon.svg`                                                    |
+| `permissions`                      | `auth:session`, `db:readWrite`                                |
+| `repository`                       | `https://github.com/sovereignfs/sovereign-plugin-apicomposer` |
+| `compatibility.minPlatformVersion` | `0.5.0`                                                       |
 
 Proposed `manifest.json`:
 
@@ -77,7 +77,7 @@ Proposed `manifest.json`:
   "shell": "default",
   "icon": "icon.svg",
   "permissions": ["auth:session", "db:readWrite"],
-  "repository": "https://github.com/CommonsEngine/sovereign-plugin-apicomposer",
+  "repository": "https://github.com/sovereignfs/sovereign-plugin-apicomposer",
   "compatibility": {
     "minPlatformVersion": "0.5.0"
   }

--- a/docs/plugins/plainwrite.md
+++ b/docs/plugins/plainwrite.md
@@ -46,19 +46,19 @@ third-party API integration from within a Sovereign plugin.
 
 ## Identity and manifest
 
-| Property                           | Value                                                          |
-| ---------------------------------- | -------------------------------------------------------------- |
-| `id`                               | `io.openfs.sovereign.plainwrite`                               |
-| `name`                             | `Plainwrite`                                                   |
-| `type`                             | `sovereign`                                                    |
-| `runtime`                          | `native`                                                       |
-| `routePrefix`                      | `/plainwrite`                                                  |
-| `shell`                            | `default`                                                      |
-| `adminOnly`                        | omitted (`false`)                                              |
-| `icon`                             | `icon.svg`                                                     |
-| `permissions`                      | `auth:session`, `db:readWrite`                                 |
-| `repository`                       | `https://github.com/CommonsEngine/sovereign-plugin-plainwrite` |
-| `compatibility.minPlatformVersion` | `0.4.0`                                                        |
+| Property                           | Value                                                        |
+| ---------------------------------- | ------------------------------------------------------------ |
+| `id`                               | `io.openfs.sovereign.plainwrite`                             |
+| `name`                             | `Plainwrite`                                                 |
+| `type`                             | `sovereign`                                                  |
+| `runtime`                          | `native`                                                     |
+| `routePrefix`                      | `/plainwrite`                                                |
+| `shell`                            | `default`                                                    |
+| `adminOnly`                        | omitted (`false`)                                            |
+| `icon`                             | `icon.svg`                                                   |
+| `permissions`                      | `auth:session`, `db:readWrite`                               |
+| `repository`                       | `https://github.com/sovereignfs/sovereign-plugin-plainwrite` |
+| `compatibility.minPlatformVersion` | `0.4.0`                                                      |
 
 Proposed `manifest.json`:
 
@@ -75,7 +75,7 @@ Proposed `manifest.json`:
   "shell": "default",
   "icon": "icon.svg",
   "permissions": ["auth:session", "db:readWrite"],
-  "repository": "https://github.com/CommonsEngine/sovereign-plugin-plainwrite",
+  "repository": "https://github.com/sovereignfs/sovereign-plugin-plainwrite",
   "compatibility": {
     "minPlatformVersion": "0.4.0"
   }

--- a/docs/plugins/splitify.md
+++ b/docs/plugins/splitify.md
@@ -35,19 +35,19 @@ exercises `sdk.mailer`.
 
 ## Identity and manifest
 
-| Property                           | Value                                                        |
-| ---------------------------------- | ------------------------------------------------------------ |
-| `id`                               | `io.openfs.sovereign.splitify`                               |
-| `name`                             | `Splitify`                                                   |
-| `type`                             | `sovereign`                                                  |
-| `runtime`                          | `native`                                                     |
-| `routePrefix`                      | `/splitify`                                                  |
-| `shell`                            | `default`                                                    |
-| `adminOnly`                        | omitted (`false`)                                            |
-| `icon`                             | `icon.svg`                                                   |
-| `permissions`                      | `auth:session`, `db:readWrite`, `mailer:send`                |
-| `repository`                       | `https://github.com/CommonsEngine/sovereign-plugin-splitify` |
-| `compatibility.minPlatformVersion` | `0.4.0`                                                      |
+| Property                           | Value                                                      |
+| ---------------------------------- | ---------------------------------------------------------- |
+| `id`                               | `io.openfs.sovereign.splitify`                             |
+| `name`                             | `Splitify`                                                 |
+| `type`                             | `sovereign`                                                |
+| `runtime`                          | `native`                                                   |
+| `routePrefix`                      | `/splitify`                                                |
+| `shell`                            | `default`                                                  |
+| `adminOnly`                        | omitted (`false`)                                          |
+| `icon`                             | `icon.svg`                                                 |
+| `permissions`                      | `auth:session`, `db:readWrite`, `mailer:send`              |
+| `repository`                       | `https://github.com/sovereignfs/sovereign-plugin-splitify` |
+| `compatibility.minPlatformVersion` | `0.4.0`                                                    |
 
 Proposed `manifest.json`:
 
@@ -64,7 +64,7 @@ Proposed `manifest.json`:
   "shell": "default",
   "icon": "icon.svg",
   "permissions": ["auth:session", "db:readWrite", "mailer:send"],
-  "repository": "https://github.com/CommonsEngine/sovereign-plugin-splitify",
+  "repository": "https://github.com/sovereignfs/sovereign-plugin-splitify",
   "compatibility": {
     "minPlatformVersion": "0.4.0"
   }

--- a/docs/plugins/tasks.md
+++ b/docs/plugins/tasks.md
@@ -34,19 +34,19 @@ externally-maintained plugin integrates with the Sovereign SDK.
 
 ## Identity and manifest
 
-| Property                           | Value                                                     |
-| ---------------------------------- | --------------------------------------------------------- |
-| `id`                               | `io.openfs.sovereign.tasks`                               |
-| `name`                             | `Tasks`                                                   |
-| `type`                             | `sovereign`                                               |
-| `runtime`                          | `native`                                                  |
-| `routePrefix`                      | `/tasks`                                                  |
-| `shell`                            | `default`                                                 |
-| `adminOnly`                        | omitted (`false`)                                         |
-| `icon`                             | `icon.svg`                                                |
-| `permissions`                      | `auth:session`, `db:readWrite`                            |
-| `repository`                       | `https://github.com/CommonsEngine/sovereign-plugin-tasks` |
-| `compatibility.minPlatformVersion` | `0.4.0`                                                   |
+| Property                           | Value                                                   |
+| ---------------------------------- | ------------------------------------------------------- |
+| `id`                               | `io.openfs.sovereign.tasks`                             |
+| `name`                             | `Tasks`                                                 |
+| `type`                             | `sovereign`                                             |
+| `runtime`                          | `native`                                                |
+| `routePrefix`                      | `/tasks`                                                |
+| `shell`                            | `default`                                               |
+| `adminOnly`                        | omitted (`false`)                                       |
+| `icon`                             | `icon.svg`                                              |
+| `permissions`                      | `auth:session`, `db:readWrite`                          |
+| `repository`                       | `https://github.com/sovereignfs/sovereign-plugin-tasks` |
+| `compatibility.minPlatformVersion` | `0.4.0`                                                 |
 
 Proposed `manifest.json`:
 
@@ -63,7 +63,7 @@ Proposed `manifest.json`:
   "shell": "default",
   "icon": "icon.svg",
   "permissions": ["auth:session", "db:readWrite"],
-  "repository": "https://github.com/CommonsEngine/sovereign-plugin-tasks",
+  "repository": "https://github.com/sovereignfs/sovereign-plugin-tasks",
   "compatibility": {
     "minPlatformVersion": "0.4.0"
   }

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -18,7 +18,7 @@ internal network, with the runtime exposed as the single public entry point.
 
 ```bash
 # 1. Clone
-git clone https://github.com/CommonsEngine/Sovereign.git
+git clone https://github.com/sovereignfs/sovereign.git
 cd Sovereign
 
 # 2. Configure environment

--- a/docs/sovereign-implementation-tasks.md
+++ b/docs/sovereign-implementation-tasks.md
@@ -688,11 +688,11 @@ Deferred: password reset (AUTH-07) — revisited in a later auth task.
     "plugins": [
       {
         "id": "io.openfs.sovereign.tasks",
-        "repository": "https://github.com/CommonsEngine/sovereign-plugin-tasks"
+        "repository": "https://github.com/sovereignfs/sovereign-plugin-tasks"
       },
       {
         "id": "io.openfs.sovereign.splitify",
-        "repository": "https://github.com/CommonsEngine/sovereign-plugin-splitify"
+        "repository": "https://github.com/sovereignfs/sovereign-plugin-splitify"
       }
     ]
   }

--- a/docs/sovereign-proposal-plan-srs.md
+++ b/docs/sovereign-proposal-plan-srs.md
@@ -543,7 +543,7 @@ Every plugin contains a `manifest.json` at its root. The `packages/manifest` pac
   "compatibility": {
     "minPlatformVersion": "0.1.0"
   },
-  "repository": "https://github.com/CommonsEngine/sovereign-plugin-tasks"
+  "repository": "https://github.com/sovereignfs/sovereign-plugin-tasks"
 }
 ```
 

--- a/packages/manifest/src/validate.test.ts
+++ b/packages/manifest/src/validate.test.ts
@@ -49,7 +49,7 @@ describe('validateManifest', () => {
     const res = validateManifest({
       ...base,
       type: 'sovereign',
-      repository: 'https://github.com/CommonsEngine/sovereign-plugin-tasks',
+      repository: 'https://github.com/sovereignfs/sovereign-plugin-tasks',
     });
     expect(res.valid).toBe(true);
   });


### PR DESCRIPTION
## What

The GitHub organization moved from `CommonsEngine` to `sovereignfs`. This updates all repository references across the codebase:

- **Main-repo URLs** — clone commands and security-advisory links now point to `github.com/sovereignfs/sovereign`. Also normalized the old `Sovereign` capitalization to the canonical lowercase `sovereign` to match the actual remote (`git@github.com:sovereignfs/sovereign.git`).
  - `CONTRIBUTING.md`, `SECURITY.md`, `docs/self-hosting.md`, `.github/ISSUE_TEMPLATE/bug_report.yml`
- **Plugin repository URLs** (`sovereign-plugin-*`) in plugin docs, the implementation-tasks/SRS examples, and the manifest validation test.
  - `docs/plugins/{tasks,splitify,plainwrite,api-composer}.md`, `docs/sovereign-implementation-tasks.md`, `docs/sovereign-proposal-plan-srs.md`, `packages/manifest/src/validate.test.ts`

## Notes

- The plugin-doc diffs are larger than the content change because Prettier re-padded the Markdown table columns after the URL length changed — no content was altered.
- Left the historical `@commonsengine/sovereign-*` npm-scope mention in the decision log (`docs/sovereign-proposal-plan-srs.md`) untouched: it records a *considered-and-rejected* scope name, not a live org reference.
- Docs/test-data only — no version bump (per repo conventions). `packages/manifest` tests pass (10/10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)