### PR TITLE
feat(runtime): verify sessions locally in middleware (AUTH-05)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,8 +24,11 @@ NEXT_PUBLIC_RUNTIME_URL=http://localhost:3000
 # No default — the auth server and runtime both refuse to start without it.
 # Generate one with:  openssl rand -base64 32
 SOVEREIGN_ADMIN_KEY=
-# Shared secret for local JWT verification — used from v0.5 (SRS AUTH-05); the
-# runtime currently verifies via the /api/verify round-trip.
+# Secret for local session verification (SRS AUTH-05). The runtime verifies the
+# auth server's signed session cookie offline using this secret — no /api/verify
+# round-trip per request — falling back to /api/verify when absent. It MUST equal
+# the auth server's signing secret, so it defaults to AUTH_SECRET above; set it
+# only if you deliberately run a distinct value.
 # SOVEREIGN_AUTH_SECRET=
 
 # --- Database ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -457,9 +457,31 @@ pnpm install:plugins    # clone sovereign/community plugins declared in sovereig
   orchestrator, which composes plugins (writes the registry, copies plugin
   `app/` trees), then runs the generate watcher + `next dev` on `:3000`. Both
   apps load the single root `.env` via `loadEnvConfig`. The runtime middleware
-  verifies each request against the auth server's `/api/verify`
-  (`SOVEREIGN_AUTH_URL`) and injects `x-sovereign-user-*` headers;
-  `SOVEREIGN_AUTH_SECRET` (local JWT verify) is a v0.5 concern.
+  injects `x-sovereign-user-*` headers from the verified session.
+- **Middleware verifies sessions locally, then falls back to `/api/verify`**
+  (AUTH-05, Task 0.5.05b). The auth server enables better-auth's **signed cookie
+  cache** (`session.cookieCache`, `maxAge` 300s) — a `better-auth.session_data`
+  cookie holding session+user, HMAC-signed with `AUTH_SECRET`. The middleware
+  verifies it offline via `getCookieCache` from `better-auth/cookies` (Edge-safe;
+  pure logic in `runtime/src/session-verify.ts`, `verifiedUserFromCache`), using
+  `resolveAuthSecret()` = `SOVEREIGN_AUTH_SECRET ?? AUTH_SECRET` (must equal the
+  auth signing secret; if neither is set, local verify is skipped — never a
+  default). On a cache miss it falls back to `/api/verify` (`SOVEREIGN_AUTH_URL`,
+  AUTH-06) and **forwards better-auth's `Set-Cookie`** so the cache self-refreshes.
+  Trade-off: role/active changes are stale up to `maxAge` (then the cache cookie
+  expires → fallback). `/api/verify` returns the same payload shape; the runtime
+  service now needs `AUTH_SECRET` in every compose file.
+- **Profile self-mutations must invalidate the `session_data` cache cookie.**
+  The chrome and Account page render the user's name/avatar from the cached
+  session snapshot (`x-sovereign-user-*` headers), so a self-change would
+  otherwise not appear until `maxAge` elapses. Any path that updates the current
+  user's session-visible fields clears both `better-auth.session_data` and
+  `__Secure-better-auth.session_data` (`maxAge: 0`, the secure variant with
+  `Secure`) so the next request re-verifies fresh via `/api/verify` — done in the
+  avatar upload route (`runtime/app/api/account/avatar/route.ts`) and the
+  display-name action (`plugins/account/app/actions.ts`). The session token is
+  untouched (no logout). Admin-driven changes to _other_ users (role/deactivate)
+  remain bounded by `maxAge`.
 
 ## Environment notes
 
@@ -503,7 +525,8 @@ pnpm install:plugins    # clone sovereign/community plugins declared in sovereig
 - ✅ Task 0.5.03 — Postgres validation (SQLite↔Postgres parity, NFR-03; delivered in 4 PRs). The platform data layer is **async** (Postgres has no sync query) and `sdk.platform.getConfig()` is now async; `packages/db` wires the pg driver + a dialect-tagged `PlatformDb` wrapper + `schema/postgres` (bigint timestamps) + dialect-aware bootstrap DDL; `apps/auth` runs better-auth on a pg `Pool` with dialect-agnostic query helpers (quoted `"user"`, boolean/date normalisation). Postgres opt-in via the **`docker-compose.postgres.yml` overlay** (adds a `postgres` service, wires both apps). Env-gated `*.pg.test.ts` parity tests (`TEST_DATABASE_URL`). **Live-validated** end-to-end on Postgres 16: register → admin role → authenticated request → plugin toggle, all on a fresh pg. `docs/self-hosting.md` documents the Postgres setup + switch procedure (merged to `main`).
 - ✅ Task 0.5.04 — `sv` CLI core commands (platform → 0.6.0): `bin/sv.ts` (`citty` + `consola`, run via `tsx`; `pnpm sv <cmd>` or the `./bin/sv` shim). A **thin orchestrator** — commands delegate to the existing scripts and `pnpm`/`turbo` (one source of truth per operation): `install`/`generate`/`build`/`dev` shell out, `serve` orchestrates both `next start` processes with mutual teardown (Docker stays canonical for prod), `plugin add <repo>` shallow-clones into a temp dir under `plugins/`, derives the destination from the manifest `id` (`validateManifest`), then composes, and `plugin remove <id>` guards the built-in platform plugins (`account`/`console`/`launcher`) before deleting + re-composing. Pure logic in `bin/helpers.ts` (unit-tested). Vitest `include` extended to `bin/**`. SRS §2.2 (merged to `main`).
 - ✅ Task 0.5.05 (SDK surface) — `sdk.db.getClient()` implemented (`@sovereignfs/sdk` → 0.7.0). Last v1 SDK stub is gone: `getClient()` now returns the live platform Drizzle instance from `getPlatformDb()` — **async** (`Promise<DrizzleClient>`, same dialect-agnostic reason as `getConfig()`); `DrizzleClient` stays opaque (`unknown`) so the published SDK takes no dialect dependency. `sdk.auth.getSession()` now populates `tenantId` with `DEFAULT_TENANT_ID` (v1 single-tenant). `sdk.platform`/`sdk.mailer` were already implemented directly in `packages/sdk` (the doc's "runtime injects impls / SDK re-exports" model is obsolete — `packages/sdk/src/*.ts` import `@sovereignfs/db`/`@sovereignfs/mailer` directly). Migration note in `docs/upgrade.md`. SRS §3.6 (merged to `main`).
-- ⏳ Next: Task 0.5.05b — **local JWT middleware (AUTH-05)**, split out from 0.5.05 as its own security-sensitive task: replace the runtime middleware's `/api/verify` round-trip with local JWT verification using `SOVEREIGN_AUTH_SECRET`. Needs auth-side JWT issuance (better-auth currently uses DB-backed session cookies — no JWT/cookie-cache configured) + Edge-compatible (`jose`) verification on the runtime. Branch from an up-to-date `main`.
+- ✅ Task 0.5.05b — local session verification in middleware (AUTH-05; `runtime` → 0.6.0). Auth server enables better-auth's signed cookie cache (`session.cookieCache`, 300s); the runtime middleware verifies the `session_data` cookie offline via `getCookieCache` (`better-auth/cookies`, Edge-safe) + the pure `verifiedUserFromCache`/`resolveAuthSecret` in `runtime/src/session-verify.ts`, falling back to `/api/verify` (which now re-emits better-auth's `Set-Cookie`, forwarded by the middleware so the cache self-refreshes). Secret = `SOVEREIGN_AUTH_SECRET ?? AUTH_SECRET`; runtime services in all compose files get `AUTH_SECRET`. `better-auth` added as a runtime dep. SRS AUTH-05/06 (merged to `main`).
+- ⏳ Next: Task 0.5.06 — Documentation. Branch from an up-to-date `main`.
 - ⏳ Spec complete: Shell sidebar three-section architecture (PLT-11–PLT-15, SRS updated).
 - ⏳ Spec complete: Plainwrite sovereign plugin (`docs/plugins/plainwrite.md`, v0.2 — provider + SSG adapters).
 - ⏳ Spec complete: API Composer sovereign plugin (`docs/plugins/api-composer.md`) — GUI API builder, `/api` namespace (PLT-16, Task 0.5.08).

--- a/apps/auth/app/api/verify/route.ts
+++ b/apps/auth/app/api/verify/route.ts
@@ -3,10 +3,18 @@ import { getAuth } from '@/src/auth';
 
 /**
  * Session verification for the runtime. Returns the authenticated user or 401.
- * Consumed by the runtime middleware (SRS AUTH-05/06).
+ * Consumed by the runtime middleware as the fallback when local cookie-cache
+ * verification has no cookie to read (SRS AUTH-05/06).
+ *
+ * `returnHeaders` surfaces better-auth's Set-Cookie — with the cookie cache
+ * enabled, `getSession` (re)issues the signed `session_data` cookie here, and we
+ * forward it so the runtime installs/refreshes it and verifies locally next time.
  */
 export async function GET(request: Request): Promise<Response> {
-  const session = await getAuth().api.getSession({ headers: request.headers });
+  const { headers, response: session } = await getAuth().api.getSession({
+    headers: request.headers,
+    returnHeaders: true,
+  });
   if (!session) {
     return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
   }
@@ -23,14 +31,18 @@ export async function GET(request: Request): Promise<Response> {
     return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
   }
 
-  return NextResponse.json({
-    user: {
-      id: user.id,
-      email: user.email,
-      name: user.name ?? null,
-      image: user.image ?? null,
-      role: user.role ?? 'platform:user',
+  const setCookie = headers.get('set-cookie');
+  return NextResponse.json(
+    {
+      user: {
+        id: user.id,
+        email: user.email,
+        name: user.name ?? null,
+        image: user.image ?? null,
+        role: user.role ?? 'platform:user',
+      },
+      expiresAt: Math.floor(new Date(session.session.expiresAt).getTime() / 1000),
     },
-    expiresAt: Math.floor(new Date(session.session.expiresAt).getTime() / 1000),
-  });
+    setCookie ? { headers: { 'set-cookie': setCookie } } : undefined,
+  );
 }

--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -20,6 +20,12 @@ function buildOptions(): BetterAuthOptions {
       // 1 day). In a self-hosted workspace users stay signed in for weeks, so
       // viewing/managing your own sessions must not require recent re-auth.
       freshAge: 0,
+      // Sign a short-lived snapshot of the session+user into a `session_data`
+      // cookie so the runtime middleware can verify requests locally (HMAC,
+      // shared secret) without a /api/verify round-trip per request (SRS
+      // AUTH-05). maxAge bounds how stale a role change / deactivation can be
+      // before the runtime falls back to /api/verify.
+      cookieCache: { enabled: true, maxAge: 300 },
     },
     emailAndPassword: {
       enabled: true,

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -54,6 +54,9 @@ services:
     environment:
       SOVEREIGN_AUTH_URL: 'http://auth:3001'
       SOVEREIGN_ADMIN_KEY: '${SOVEREIGN_ADMIN_KEY}'
+      # Shared signing secret — the runtime verifies the auth server's session
+      # cookie locally with it (SRS AUTH-05); must match the auth service.
+      AUTH_SECRET: '${AUTH_SECRET}'
       NEXT_PUBLIC_RUNTIME_URL: '${NEXT_PUBLIC_RUNTIME_URL}'
       DATABASE_URL: '${DATABASE_URL:-file:./data/sovereign.db}'
       DB_DIALECT: '${DB_DIALECT:-sqlite}'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,9 @@ services:
       # Inside Docker, the runtime reaches auth via the internal service name.
       SOVEREIGN_AUTH_URL: 'http://auth:3001'
       SOVEREIGN_ADMIN_KEY: '${SOVEREIGN_ADMIN_KEY}'
+      # Shared signing secret — the runtime verifies the auth server's session
+      # cookie locally with it (SRS AUTH-05); must match the auth service.
+      AUTH_SECRET: '${AUTH_SECRET}'
       NEXT_PUBLIC_RUNTIME_URL: '${NEXT_PUBLIC_RUNTIME_URL:-http://localhost:3000}'
       DATABASE_URL: '${DATABASE_URL:-file:./data/sovereign.db}'
       DB_DIALECT: '${DB_DIALECT:-sqlite}'

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -69,22 +69,22 @@ runtime container.
 All variables live in a single `.env` at the repo root. Copy `.env.example`
 to get started — every variable is documented there.
 
-| Variable                  | Required | Default                      | Description                                                                                                                        |
-| ------------------------- | -------- | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `AUTH_SECRET`             | **yes**  | —                            | Secret key for the auth server. Generate with `openssl rand -base64 32`. Never share or commit.                                    |
-| `SOVEREIGN_ADMIN_KEY`     | **yes**  | —                            | Shared secret for runtime↔auth internal admin API calls (Console user/plugin management). Generate with `openssl rand -base64 32`. |
-| `NEXT_PUBLIC_RUNTIME_URL` | **yes**  | `http://localhost:3000`      | Public URL of the runtime — used by the auth server to redirect users after login.                                                 |
-| `AUTH_INVITE_ONLY`        | no       | `false`                      | When `true`, registration requires a valid invite token. The first user is exempt.                                                 |
-| `AUTH_DATABASE_URL`       | no       | `file:./data/auth.db`        | Auth server database. SQLite file path (relative paths resolve against the repo root) or a `postgres://` URL.                      |
-| `DATABASE_URL`            | no       | `file:./data/sovereign.db`   | Runtime database. SQLite file path (relative paths resolve against the repo root) or a `postgres://` URL.                          |
-| `DB_DIALECT`              | no       | `sqlite`                     | Set to `postgres` when using PostgreSQL.                                                                                           |
-| `SMTP_HOST`               | no       | —                            | SMTP server host. Leave unset to disable email (the app still runs).                                                               |
-| `SMTP_PORT`               | no       | `587`                        | SMTP port.                                                                                                                         |
-| `SMTP_USER`               | no       | —                            | SMTP username.                                                                                                                     |
-| `SMTP_PASS`               | no       | —                            | SMTP password.                                                                                                                     |
-| `SMTP_FROM`               | no       | —                            | Sender address, e.g. `Sovereign <noreply@example.com>`.                                                                            |
-| `RUNTIME_PORT`            | no       | `3000` (dev) / `4000` (prod) | Host port the runtime container is mapped to.                                                                                      |
-| `SOVEREIGN_AUTH_SECRET`   | no       | —                            | Shared JWT secret for local session verification (v0.5+). Leave unset for now.                                                     |
+| Variable                  | Required | Default                      | Description                                                                                                                                                                       |
+| ------------------------- | -------- | ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `AUTH_SECRET`             | **yes**  | —                            | Signing secret for the auth server. The runtime also reads it to verify the session cookie locally (AUTH-05). Generate with `openssl rand -base64 32`. Never share or commit.     |
+| `SOVEREIGN_ADMIN_KEY`     | **yes**  | —                            | Shared secret for runtime↔auth internal admin API calls (Console user/plugin management). Generate with `openssl rand -base64 32`.                                                |
+| `NEXT_PUBLIC_RUNTIME_URL` | **yes**  | `http://localhost:3000`      | Public URL of the runtime — used by the auth server to redirect users after login.                                                                                                |
+| `AUTH_INVITE_ONLY`        | no       | `false`                      | When `true`, registration requires a valid invite token. The first user is exempt.                                                                                                |
+| `AUTH_DATABASE_URL`       | no       | `file:./data/auth.db`        | Auth server database. SQLite file path (relative paths resolve against the repo root) or a `postgres://` URL.                                                                     |
+| `DATABASE_URL`            | no       | `file:./data/sovereign.db`   | Runtime database. SQLite file path (relative paths resolve against the repo root) or a `postgres://` URL.                                                                         |
+| `DB_DIALECT`              | no       | `sqlite`                     | Set to `postgres` when using PostgreSQL.                                                                                                                                          |
+| `SMTP_HOST`               | no       | —                            | SMTP server host. Leave unset to disable email (the app still runs).                                                                                                              |
+| `SMTP_PORT`               | no       | `587`                        | SMTP port.                                                                                                                                                                        |
+| `SMTP_USER`               | no       | —                            | SMTP username.                                                                                                                                                                    |
+| `SMTP_PASS`               | no       | —                            | SMTP password.                                                                                                                                                                    |
+| `SMTP_FROM`               | no       | —                            | Sender address, e.g. `Sovereign <noreply@example.com>`.                                                                                                                           |
+| `RUNTIME_PORT`            | no       | `3000` (dev) / `4000` (prod) | Host port the runtime container is mapped to.                                                                                                                                     |
+| `SOVEREIGN_AUTH_SECRET`   | no       | `AUTH_SECRET`                | Secret for local session verification (AUTH-05). Must equal the auth server's signing secret, so it defaults to `AUTH_SECRET` — set it only to run a deliberately distinct value. |
 
 ---
 

--- a/docs/sovereign-implementation-tasks.md
+++ b/docs/sovereign-implementation-tasks.md
@@ -849,11 +849,11 @@ consistent info/success/warn/error formatting. CLI is monorepo-internal in v1
 
 ---
 
-### Task 0.5.05b — Local JWT middleware (AUTH-05) **[split from 0.5.05]**
+### Task 0.5.05b — Local session verification in middleware (AUTH-05) **[split from 0.5.05; done]**
 
-**Goal:** Replace the runtime middleware's per-request `/api/verify` round-trip to the auth server with **local** verification of a signed token, using `SOVEREIGN_AUTH_SECRET`.
+**Goal:** Replace the runtime middleware's per-request `/api/verify` round-trip to the auth server with **local** verification of the session, using the shared secret.
 
-**Notes:** Security-sensitive. better-auth currently issues DB-backed session cookies with no JWT or cookie-cache configured, so this requires (a) auth-side token issuance the runtime can verify offline (e.g. better-auth JWT/cookie-cache, signed with the shared secret) and (b) Edge-compatible verification in `runtime/middleware.ts` (e.g. `jose`), preserving the current behaviour (redirect to `/login` on failure; inject `x-sovereign-user-*` headers; `adminOnly` 403, disabled-plugin 404, root-plugin rewrite). The existing `/api/verify` flow is correct and stays until this lands.
+**Delivered:** The auth server enables better-auth's signed cookie cache (`session.cookieCache`, `maxAge` 300s), which sets a `session_data` cookie holding session+user HMAC-signed with `AUTH_SECRET`. The runtime middleware verifies it offline via `getCookieCache` (`better-auth/cookies`, Edge-safe) plus the pure `verifiedUserFromCache`/`resolveAuthSecret` helpers (`runtime/src/session-verify.ts`), using `SOVEREIGN_AUTH_SECRET ?? AUTH_SECRET` (local verify skipped when neither is set — no insecure default). On a cache miss it falls back to `/api/verify` (AUTH-06), which now re-emits better-auth's `Set-Cookie`, forwarded by the middleware so the cache self-refreshes. All prior behaviour is preserved (`/login` redirect, `x-sovereign-user-*` headers, `adminOnly` 403, disabled-plugin 404, root-plugin rewrite). Trade-off: role/active changes are stale for at most `maxAge`. Runtime services in all compose files now receive `AUTH_SECRET`.
 
 **SRS reference:** AUTH-05
 

--- a/plugins/account/app/actions.ts
+++ b/plugins/account/app/actions.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import { headers } from 'next/headers';
+import { cookies, headers } from 'next/headers';
 import { sdk } from '@sovereignfs/sdk';
 import { validatePasswordChange } from './_lib/password';
 
@@ -10,6 +10,22 @@ const SELF_URL = 'http://localhost:3000';
 
 async function sessionCookie(): Promise<string> {
   return (await headers()).get('cookie') ?? '';
+}
+
+/**
+ * Drop better-auth's signed session-cache cookie (`session_data`) after a
+ * profile change. The runtime middleware verifies sessions from that cookie
+ * locally (AUTH-05), so without this the chrome/profile keep showing the old
+ * name until the cache window expires. Clearing it forces the next request to
+ * re-verify via /api/verify and pick up the change immediately; the session
+ * token itself is untouched.
+ */
+async function invalidateSessionCache(): Promise<void> {
+  const jar = await cookies();
+  jar.set('better-auth.session_data', '', { maxAge: 0, path: '/' });
+  // The `__Secure-`-prefixed name (production, HTTPS) can only be unset with the
+  // Secure attribute, so clear it explicitly rather than via delete().
+  jar.set('__Secure-better-auth.session_data', '', { maxAge: 0, path: '/', secure: true });
 }
 
 /** Change the display name (ACC-02). Delegates to better-auth's update-user. */
@@ -31,6 +47,7 @@ export async function updateDisplayNameAction(formData: FormData): Promise<void>
     body: JSON.stringify({ name }),
   });
   if (!res.ok) throw new Error(`Failed to update display name: ${res.status}`);
+  await invalidateSessionCache();
   revalidatePath('/account/profile');
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,7 +100,7 @@ importers:
         version: link:../../packages/ui
       better-auth:
         specifier: ^1.6.16
-        version: 1.6.16(better-sqlite3@12.10.0)(drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.10.0)(kysely@0.29.2)(pg@8.21.0))(next@15.5.19(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8(@types/node@22.19.20)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))
+        version: 1.6.16(better-sqlite3@12.10.0)(drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.10.0)(kysely@0.29.2)(pg@8.21.0))(next@15.5.19(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8(@types/node@22.19.20)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))
       better-sqlite3:
         specifier: ^12.10.0
         version: 12.10.0
@@ -369,6 +369,9 @@ importers:
       '@sovereignfs/ui':
         specifier: workspace:*
         version: link:../packages/ui
+      better-auth:
+        specifier: ^1.6.16
+        version: 1.6.16(better-sqlite3@12.10.0)(drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.10.0)(kysely@0.29.2)(pg@8.21.0))(next@15.5.19(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8(@types/node@22.19.20)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))
       better-sqlite3:
         specifier: ^12.10.0
         version: 12.10.0
@@ -6454,7 +6457,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.37: {}
 
-  better-auth@1.6.16(better-sqlite3@12.10.0)(drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.10.0)(kysely@0.29.2)(pg@8.21.0))(next@15.5.19(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8(@types/node@22.19.20)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))):
+  better-auth@1.6.16(better-sqlite3@12.10.0)(drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.10.0)(kysely@0.29.2)(pg@8.21.0))(next@15.5.19(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8(@types/node@22.19.20)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))):
     dependencies:
       '@better-auth/core': 1.6.16(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.2.2)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.6.16(@better-auth/core@1.6.16(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.2.2)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.10.0)(kysely@0.29.2)(pg@8.21.0))

--- a/runtime/app/api/account/avatar/route.ts
+++ b/runtime/app/api/account/avatar/route.ts
@@ -56,5 +56,19 @@ export async function POST(request: Request): Promise<Response> {
     return NextResponse.json({ error: 'failed to update profile image' }, { status: 502 });
   }
 
-  return NextResponse.json({ url });
+  // The chrome and profile page read the avatar from the session snapshot, which
+  // the middleware now serves from better-auth's signed cookie cache (AUTH-05).
+  // That snapshot is stale until the cache window passes, so invalidate it here:
+  // the next request falls back to /api/verify and picks up the new image right
+  // away. The session token itself is untouched — this only drops the cache.
+  const res = NextResponse.json({ url });
+  res.cookies.set('better-auth.session_data', '', { maxAge: 0, path: '/' });
+  // The `__Secure-`-prefixed name (production, HTTPS) can only be unset with the
+  // Secure attribute, so clear it explicitly rather than via delete().
+  res.cookies.set('__Secure-better-auth.session_data', '', {
+    maxAge: 0,
+    path: '/',
+    secure: true,
+  });
+  return res;
 }

--- a/runtime/middleware.ts
+++ b/runtime/middleware.ts
@@ -1,6 +1,13 @@
+import { getCookieCache } from 'better-auth/cookies';
 import { type NextRequest, NextResponse } from 'next/server';
 import { getInstalledPlugins } from '@/src/registry';
 import { decidePluginRoute, underPrefix } from '@/src/route-guard';
+import {
+  type CachedSessionData,
+  type VerifiedSession,
+  resolveAuthSecret,
+  verifiedUserFromCache,
+} from '@/src/session-verify';
 
 const AUTH_URL = process.env.SOVEREIGN_AUTH_URL ?? 'http://localhost:3001';
 
@@ -52,28 +59,82 @@ async function fetchRootPluginPrefix(): Promise<string | null> {
 }
 
 /**
- * Session gate + plugin route protection. Verifies the request against the auth
- * server's /api/verify (v0.3 approach; SRS AUTH-05 targets local JWT
- * verification at v0.5). On success the verified user is injected as request
- * headers for downstream server components; otherwise the request is redirected
- * to /login. Routes under an `adminOnly` plugin's prefix are reachable only by
+ * Verify the request's session **locally** from better-auth's signed
+ * `session_data` cookie cache — no network call (SRS AUTH-05). The cookie is
+ * HMAC-signed with the shared auth secret, so a forged one cannot pass. Returns
+ * null when no secret is configured or no valid cache cookie is present, so the
+ * caller falls back to `/api/verify`. The cookie name carries the `__Secure-`
+ * prefix in production; try both so the read works in dev and prod regardless of
+ * NODE_ENV drift.
+ */
+async function verifyFromCookieCache(request: NextRequest): Promise<VerifiedSession | null> {
+  const secret = resolveAuthSecret();
+  if (!secret) return null;
+  for (const isSecure of [undefined, true, false] as const) {
+    const cached = (await getCookieCache(request, {
+      secret,
+      ...(isSecure === undefined ? {} : { isSecure }),
+    }).catch(() => null)) as CachedSessionData | null;
+    const session = verifiedUserFromCache(cached);
+    if (session) return session;
+  }
+  return null;
+}
+
+/**
+ * Verify the request against the auth server's /api/verify (AUTH-06) — the
+ * fallback when local verification has no cookie to read (e.g. a session that
+ * predates cookie-cache rollout, or just past the cache window). Returns the
+ * session plus better-auth's Set-Cookie headers, which the caller forwards so
+ * the `session_data` cache (re)installs and subsequent requests verify locally.
+ *
+ * Fails closed: a non-OK response *or* an unreachable auth server (fetch
+ * throws) returns null, so the caller redirects to /login rather than crashing
+ * the request with a 500.
+ */
+async function verifyViaAuthServer(
+  request: NextRequest,
+): Promise<{ session: VerifiedSession; setCookies: string[] } | null> {
+  try {
+    const verify = await fetch(`${AUTH_URL}/api/verify`, {
+      headers: { cookie: request.headers.get('cookie') ?? '' },
+    });
+    if (!verify.ok) return null;
+    const payload = (await verify.json()) as VerifiedSession;
+    return { session: payload, setCookies: verify.headers.getSetCookie() };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Session gate + plugin route protection. Verifies the session locally from the
+ * signed cookie cache and falls back to the auth server's /api/verify (SRS
+ * AUTH-05/06). On success the verified user is injected as request headers for
+ * downstream server components; otherwise the request is redirected to /login.
+ * Routes under an `adminOnly` plugin's prefix are reachable only by
  * `platform:admin` — everyone else gets 403 (SRS §3.4, PLT-03). Routes under a
  * disabled plugin's prefix return 404 (SRS CON-07, PLT-04).
  */
 export async function middleware(request: NextRequest): Promise<NextResponse> {
-  const verify = await fetch(`${AUTH_URL}/api/verify`, {
-    headers: { cookie: request.headers.get('cookie') ?? '' },
-  });
-
-  if (!verify.ok) {
-    return NextResponse.redirect(new URL('/login', request.url));
+  let session = await verifyFromCookieCache(request);
+  let setCookies: string[] = [];
+  if (!session) {
+    const fallback = await verifyViaAuthServer(request);
+    if (!fallback) {
+      return NextResponse.redirect(new URL('/login', request.url));
+    }
+    session = fallback.session;
+    setCookies = fallback.setCookies;
   }
+  const { user, expiresAt } = session;
 
-  const payload = (await verify.json()) as {
-    user: { id: string; email: string; name: string | null; image: string | null; role: string };
-    expiresAt: number;
+  // Forward any Set-Cookie from the fallback so the signed cookie cache
+  // (re)installs — subsequent requests then verify locally without a round-trip.
+  const withCookies = (response: NextResponse): NextResponse => {
+    for (const cookie of setCookies) response.headers.append('set-cookie', cookie);
+    return response;
   };
-  const { user, expiresAt } = payload;
 
   const { pathname } = request.nextUrl;
   const installedPlugins = getInstalledPlugins();
@@ -84,10 +145,10 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
     const disabledIds = await fetchDisabledPluginIds();
     const decision = decidePluginRoute(pathname, installedPlugins, disabledIds, user.role);
     if (decision === 'not-found') {
-      return new NextResponse('Not Found', { status: 404 });
+      return withCookies(new NextResponse('Not Found', { status: 404 }));
     }
     if (decision === 'forbidden') {
-      return new NextResponse('Forbidden', { status: 403 });
+      return withCookies(new NextResponse('Forbidden', { status: 403 }));
     }
   }
 
@@ -107,11 +168,13 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
   if (pathname === '/') {
     const rootPrefix = await fetchRootPluginPrefix();
     if (rootPrefix && rootPrefix !== '/') {
-      return NextResponse.rewrite(new URL(rootPrefix, request.url), { request: { headers } });
+      return withCookies(
+        NextResponse.rewrite(new URL(rootPrefix, request.url), { request: { headers } }),
+      );
     }
   }
 
-  return NextResponse.next({ request: { headers } });
+  return withCookies(NextResponse.next({ request: { headers } }));
 }
 
 export const config = {

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sovereignfs/runtime",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -18,6 +18,7 @@
     "@sovereignfs/manifest": "workspace:*",
     "@sovereignfs/sdk": "workspace:*",
     "@sovereignfs/ui": "workspace:*",
+    "better-auth": "^1.6.16",
     "better-sqlite3": "^12.10.0",
     "drizzle-orm": "^0.45.2",
     "next": "catalog:",

--- a/runtime/src/session-verify.test.ts
+++ b/runtime/src/session-verify.test.ts
@@ -1,0 +1,101 @@
+import { createHmac } from 'node:crypto';
+import { getCookieCache } from 'better-auth/cookies';
+import { describe, expect, it } from 'vitest';
+import { resolveAuthSecret, verifiedUserFromCache } from './session-verify';
+
+const FUTURE = new Date(Date.now() + 60_000).toISOString();
+const PAST = new Date(Date.now() - 60_000).toISOString();
+
+function cache(over: {
+  expiresAt?: string;
+  user?: Record<string, unknown>;
+}): Parameters<typeof verifiedUserFromCache>[0] {
+  return {
+    session: { expiresAt: over.expiresAt ?? FUTURE },
+    user: { id: 'u1', email: 'a@b.c', role: 'platform:admin', active: true, ...over.user },
+  };
+}
+
+describe('resolveAuthSecret', () => {
+  it('prefers SOVEREIGN_AUTH_SECRET, falls back to AUTH_SECRET, else null', () => {
+    expect(resolveAuthSecret({ SOVEREIGN_AUTH_SECRET: 's', AUTH_SECRET: 'a' })).toBe('s');
+    expect(resolveAuthSecret({ AUTH_SECRET: 'a' })).toBe('a');
+    expect(resolveAuthSecret({})).toBeNull();
+  });
+});
+
+describe('verifiedUserFromCache', () => {
+  it('returns the user for a valid, unexpired, active session', () => {
+    const session = verifiedUserFromCache(cache({}));
+    expect(session?.user).toMatchObject({ id: 'u1', email: 'a@b.c', role: 'platform:admin' });
+    expect(session?.expiresAt).toBeGreaterThan(Math.floor(Date.now() / 1000));
+  });
+
+  it('rejects an expired session', () => {
+    expect(verifiedUserFromCache(cache({ expiresAt: PAST }))).toBeNull();
+  });
+
+  it('rejects a deactivated account', () => {
+    expect(verifiedUserFromCache(cache({ user: { active: false } }))).toBeNull();
+  });
+
+  it('defaults a missing role to platform:user (least privilege)', () => {
+    const session = verifiedUserFromCache(cache({ user: { role: undefined } }));
+    expect(session?.user.role).toBe('platform:user');
+  });
+
+  it('rejects payloads without a user id', () => {
+    expect(verifiedUserFromCache({ session: { expiresAt: FUTURE }, user: {} })).toBeNull();
+    expect(verifiedUserFromCache(null)).toBeNull();
+  });
+});
+
+/**
+ * Offline-verification proof: forge a better-auth "compact" session_data cookie
+ * (the exact format setCookieCache writes — base64url JSON with an HMAC-SHA256
+ * signature over the session + expiry), then verify it with the real
+ * getCookieCache + verifiedUserFromCache, with no network call. A tampered
+ * cookie must be rejected.
+ */
+describe('getCookieCache (offline HMAC verification)', () => {
+  const SECRET = 'test-secret-test-secret-test-secret';
+
+  function forge(secret: string): string {
+    const inner = {
+      session: { id: 's1', userId: 'u1', expiresAt: FUTURE, token: 't1' },
+      user: { id: 'u1', email: 'a@b.c', role: 'platform:admin', active: true },
+    };
+    const expiresAt = Date.now() + 300_000;
+    const signature = createHmac('sha256', secret)
+      .update(JSON.stringify({ ...inner, expiresAt }))
+      .digest('base64url');
+    const value = Buffer.from(
+      JSON.stringify({ session: inner, expiresAt, signature }),
+      'utf8',
+    ).toString('base64url');
+    return `better-auth.session_data=${value}`;
+  }
+
+  it('extracts the user from a correctly-signed cookie', async () => {
+    const headers = new Headers({ cookie: forge(SECRET) });
+    const cached = await getCookieCache(headers, { secret: SECRET, isSecure: false });
+    expect(cached).not.toBeNull();
+    const session = verifiedUserFromCache(cached);
+    expect(session?.user.id).toBe('u1');
+    expect(session?.user.role).toBe('platform:admin');
+  });
+
+  it('rejects a cookie signed with the wrong secret', async () => {
+    const headers = new Headers({ cookie: forge('a-different-secret-aaaaaaaaaaaaaaaa') });
+    const cached = await getCookieCache(headers, { secret: SECRET, isSecure: false });
+    expect(cached).toBeNull();
+  });
+
+  it('rejects a tampered cookie value', async () => {
+    const forged = forge(SECRET);
+    const tampered = forged.slice(0, -3) + (forged.endsWith('AAA') ? 'BBB' : 'AAA');
+    const headers = new Headers({ cookie: tampered });
+    const cached = await getCookieCache(headers, { secret: SECRET, isSecure: false });
+    expect(cached).toBeNull();
+  });
+});

--- a/runtime/src/session-verify.ts
+++ b/runtime/src/session-verify.ts
@@ -1,0 +1,94 @@
+/**
+ * Local session verification for the runtime middleware (SRS AUTH-05).
+ *
+ * The middleware verifies the request's session offline from better-auth's
+ * signed `session_data` cookie cache (`getCookieCache`, HMAC-signed with the
+ * shared auth secret) instead of a `/api/verify` round-trip on every request.
+ * These helpers are kept pure so the trust decision is unit-testable; the
+ * Edge-runtime cookie read and the `/api/verify` fallback live in the
+ * middleware itself.
+ */
+
+/** The user identity the middleware injects as `x-sovereign-user-*` headers. */
+export interface VerifiedUser {
+  id: string;
+  email: string;
+  name: string | null;
+  image: string | null;
+  role: string;
+}
+
+export interface VerifiedSession {
+  user: VerifiedUser;
+  /** Session expiry as a Unix timestamp (seconds). */
+  expiresAt: number;
+}
+
+/** The (untrusted-until-verified) payload shape `getCookieCache` returns. */
+export interface CachedSessionData {
+  session?: { expiresAt?: string | number | Date | null } | null;
+  user?: {
+    id?: string | null;
+    email?: string | null;
+    name?: string | null;
+    image?: string | null;
+    role?: string | null;
+    active?: boolean | null;
+  } | null;
+}
+
+/**
+ * The shared signing secret the runtime uses to verify the cookie cache. It
+ * must equal the auth server's `AUTH_SECRET` (better-auth signs with it), so we
+ * prefer the explicit `SOVEREIGN_AUTH_SECRET` and fall back to the shared
+ * `AUTH_SECRET` both apps already load. Returns null when neither is set, in
+ * which case the middleware skips local verification and falls back to
+ * `/api/verify` — never a default/guessable secret.
+ */
+export function resolveAuthSecret(
+  env: Record<string, string | undefined> = process.env,
+): string | null {
+  return env.SOVEREIGN_AUTH_SECRET || env.AUTH_SECRET || null;
+}
+
+/**
+ * Turn an HMAC-verified cookie-cache payload into a trusted session, or null if
+ * it should not be honoured: no user id, an expired session, or a deactivated
+ * account (parity with the `/api/verify` `active === false` check). A missing
+ * role defaults to `platform:user` (least privilege).
+ *
+ * Note: `getCookieCache` has already checked the signature; this only applies
+ * the business rules. Freshness of `role`/`active` is bounded by the cookie's
+ * `maxAge` (the browser drops `session_data` after it), after which the
+ * middleware falls back to `/api/verify`.
+ */
+export function verifiedUserFromCache(
+  cached: CachedSessionData | null | undefined,
+  nowMs: number = Date.now(),
+): VerifiedSession | null {
+  const user = cached?.user;
+  const id = user?.id;
+  if (!id) return null;
+  if (user.active === false) return null;
+
+  const expiresAtMs = toMillis(cached?.session?.expiresAt);
+  if (expiresAtMs === null || expiresAtMs <= nowMs) return null;
+
+  return {
+    user: {
+      id,
+      email: user.email ?? '',
+      name: user.name ?? null,
+      image: user.image ?? null,
+      role: user.role ?? 'platform:user',
+    },
+    expiresAt: Math.floor(expiresAtMs / 1000),
+  };
+}
+
+/** Coerce an ISO string / epoch ms / Date to epoch milliseconds, or null. */
+function toMillis(value: string | number | Date | null | undefined): number | null {
+  if (value == null) return null;
+  const ms = value instanceof Date ? value.getTime() : new Date(value).getTime();
+  return Number.isNaN(ms) ? null : ms;
+}


### PR DESCRIPTION
## What

Implements **Task 0.5.05b** — local session verification in the runtime middleware (SRS **AUTH-05**). The middleware no longer makes an `/api/verify` round-trip on **every** request; it verifies the session **offline** from better-auth's signed session cookie, keeping `/api/verify` as the fallback (AUTH-06).

## How it works

- **Auth side** — `apps/auth/src/auth.ts` enables better-auth's signed cookie cache (`session.cookieCache`, `maxAge` 300s): a `better-auth.session_data` cookie holding the session + user, **HMAC-signed with `AUTH_SECRET`**. Host-scoped, so it already reaches the runtime.
- **Runtime side** — the middleware verifies that cookie offline with `getCookieCache` from `better-auth/cookies` (Edge-safe). Trust logic is in pure, unit-tested helpers in `runtime/src/session-verify.ts` (`resolveAuthSecret` = `SOVEREIGN_AUTH_SECRET ?? AUTH_SECRET`; `verifiedUserFromCache` enforces session expiry, `active !== false`, least-privilege role default).
- **Fallback + self-refresh** — on a cache miss it falls back to `/api/verify`, which now re-emits better-auth's `Set-Cookie` (`getSession({ returnHeaders: true })`); the middleware forwards it so the cache (re)installs and subsequent requests verify locally.

All prior behaviour is preserved: `/login` redirect, `x-sovereign-user-*` headers, `adminOnly` 403, disabled-plugin 404, root-plugin `/` rewrite.

## Bugs found during review & fixed in this PR

1. **Middleware crashed when the auth server was unreachable.** The fallback `fetch` wasn't wrapped, so an auth outage produced a 500 Runtime TypeError. It now **fails closed** — a non-OK response *or* a thrown `fetch` returns null → redirect to `/login` (matching the other middleware fetches).

2. **Avatar/display-name didn't update after a change (cookie-cache staleness).** The chrome and Account page render name/avatar from the **cached** session snapshot, so a self-mutation didn't appear until the 300s window elapsed (the avatar showed initials despite a successful upload). Fix: profile self-mutations now **invalidate the `session_data` cache cookie** so the next request re-verifies fresh — in the avatar upload route (`runtime/app/api/account/avatar/route.ts`) and the display-name action (`plugins/account/app/actions.ts`). Both bare and `__Secure-` cookie variants are cleared (the latter with `Secure` for prod HTTPS). The session token is untouched — no logout.

## Security / trade-off

- A forged `session_data` cookie can't pass the HMAC check; if no secret is configured local verification is simply skipped (no insecure default).
- **Bounded staleness:** admin-driven role/deactivation changes to *other* users take effect within `maxAge` (300s), then the cookie expires → fallback. Inherent to "no round-trip per request"; self-mutations are made immediate by the cache invalidation above. Documented in CLAUDE.md / the task doc.

## Docker-config impact

`AUTH_SECRET` added to the **runtime** service env in `docker-compose.yml` and `docker-compose.prod.yml` (the postgres overlay inherits it). `.env.example` and `docs/self-hosting.md` document that `SOVEREIGN_AUTH_SECRET` defaults to `AUTH_SECRET`.

## Versioning

`better-auth` added as a runtime dependency; `@sovereignfs/runtime` 0.5.0 → 0.6.0.

## How to test

```bash
pnpm install
pnpm vitest run runtime/src/session-verify   # offline-verification proof (forged-valid trusted; wrong-secret/tampered rejected)
pnpm test          # full suite: 172 passed / 9 skipped
pnpm typecheck && pnpm lint && pnpm format:check
pnpm --filter @sovereignfs/runtime build      # middleware must bundle better-auth/cookies for Edge
```

### Verified end-to-end against a running stack
- Public routes: `/api/health` 200, `/login` 307 → auth login UI.
- Unauthenticated gated routes (`/account`, `/console/plugins`, `/`) → 307 → `/login`.
- Authenticated (throwaway user): `/launcher` 200, `/account` → `/account/profile` 200.
- **Local verification:** authenticated `/launcher` request → **0** `/api/verify` calls (verified offline).
- **Self-heal:** session token without cache cookie → fallback used **and** `session_data` re-issued.
- **adminOnly:** non-admin → `/console/plugins` **403**.
- **Avatar fix:** upload returns 200 + URL and emits both `session_data` clearing `Set-Cookie` headers.

## Review checklist (Task 0.5.05b)

- [x] An authenticated request is verified with no network call to the auth server (cache hit)
- [x] An invalid/expired/missing session redirects to `/login`
- [x] Deactivated accounts are rejected (within the bounded staleness window; fallback rejects immediately)
- [x] No insecure default secret — local verify is skipped when unset; forged cookies fail the HMAC check
- [x] Profile self-changes (name/avatar) appear immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)