### PR TITLE
fix(console): reflect status/role in user-row actions after change

### DIFF
--- a/plugins/console/app/users/page.tsx
+++ b/plugins/console/app/users/page.tsx
@@ -95,7 +95,21 @@ export default async function UsersPage() {
                 <td className={styles.td}>
                   {member.status !== 'invited' && member.id ? (
                     <div className={styles.rowActions}>
-                      <form action={changeRoleAction} className={styles.roleForm}>
+                      {/*
+                        `key`s tie each form to the server state it renders. React
+                        19 resets a form after its action runs, which reverts the
+                        uncontrolled <select defaultValue> (role) and the
+                        status-derived button to their pre-submit values even
+                        though the row re-rendered with fresh data. Re-keying on
+                        the value forces a remount so the controls reflect the
+                        change (the Status/Role badges, not being form controls,
+                        already update correctly).
+                      */}
+                      <form
+                        action={changeRoleAction}
+                        className={styles.roleForm}
+                        key={`role-${member.role ?? 'none'}`}
+                      >
                         <input type="hidden" name="userId" value={member.id} />
                         <select
                           name="role"
@@ -111,7 +125,7 @@ export default async function UsersPage() {
                         </button>
                       </form>
 
-                      <form action={toggleActiveAction}>
+                      <form action={toggleActiveAction} key={`active-${member.status}`}>
                         <input type="hidden" name="userId" value={member.id} />
                         <input
                           type="hidden"

--- a/plugins/console/package.json
+++ b/plugins/console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sovereignfs/plugin-console",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
## Bug

On the Console **Users** page, changing a user's active status (Deactivate/Reactivate) or role updated the **Status/Role badge** column, but the controls in the **Actions** column kept their pre-change values — e.g. after deactivating, the badge read "Deactivated" while the button still said "Deactivate", and the role `<select>` reverted to the old role after Save.

## Root cause

React 19 automatically **resets a `<form>` after its action completes**. The Actions-column controls are uncontrolled form elements (`<select defaultValue>`, and a submit button whose label/hidden value derive from `member.status`). After the server action runs `revalidatePath` and the row re-renders with fresh data, React reuses the existing form DOM and the post-action reset reverts those controls to their pre-submit values. The Status/Role **badges** aren't form controls, so they re-render normally — which is exactly the "label updated but the action didn't" symptom.

## Fix

Re-key each Actions form on the server value it renders:

- role form → `key={\`role-${member.role}\`}`
- status toggle form → `key={\`active-${member.status}\`}`

When the underlying data changes, the key changes, so React **remounts** the form and its controls pick up the fresh `defaultValue` / button label / hidden value. No behavioural change otherwise. Self-contained to `plugins/console/app/users/page.tsx`.

Independent of the AUTH-05 work (PR #40) — this is a pre-existing rendering bug.

## How to test

1. Console → **Users**, with at least one other user present.
2. **Deactivate** an active user → the Status badge flips to "Deactivated" **and** the button now reads "Reactivate" (previously stayed "Deactivate"). Reactivate flips it back.
3. Change a user's **role** and click **Save** → the Role badge updates **and** the `<select>` shows the new role (previously reverted).

```bash
pnpm lint && pnpm typecheck && pnpm format:check   # all clean
```

## Version

`@sovereignfs/plugin-console` 0.4.0 → 0.4.1 (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)