### PR TITLE
docs: plugin-development + architecture guides, with a doc-sync test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,13 @@ they are authoritative over assumptions:
   (writable dir or served asset dir), a new native dep, or anything affecting
   `next build`/standalone output — call it out in the same turn and update the
   relevant config (or ask), rather than letting it drift behind the code.
+- **Docs are part of the change.** Changing the manifest schema
+  (`packages/manifest`), the SDK surface (`packages/sdk`), or env vars
+  (`.env.example`) means updating the matching doc in the same PR —
+  `docs/plugin-development.md` (manifest fields, permissions, SDK methods) and
+  `docs/self-hosting.md` (env vars). The `runtime/src/docs-parity.test.ts` parity
+  test enforces the enumerable parts (every field/permission/SDK key/env var must
+  appear in its doc) and fails CI otherwise; review covers the prose.
 - **Version bumps** are part of the PR — bump the relevant `package.json`(s)
   in the same branch, following semver tied to the change type:
   - `fix/` → **patch** (0.0.x)
@@ -526,7 +533,8 @@ pnpm install:plugins    # clone sovereign/community plugins declared in sovereig
 - ✅ Task 0.5.04 — `sv` CLI core commands (platform → 0.6.0): `bin/sv.ts` (`citty` + `consola`, run via `tsx`; `pnpm sv <cmd>` or the `./bin/sv` shim). A **thin orchestrator** — commands delegate to the existing scripts and `pnpm`/`turbo` (one source of truth per operation): `install`/`generate`/`build`/`dev` shell out, `serve` orchestrates both `next start` processes with mutual teardown (Docker stays canonical for prod), `plugin add <repo>` shallow-clones into a temp dir under `plugins/`, derives the destination from the manifest `id` (`validateManifest`), then composes, and `plugin remove <id>` guards the built-in platform plugins (`account`/`console`/`launcher`) before deleting + re-composing. Pure logic in `bin/helpers.ts` (unit-tested). Vitest `include` extended to `bin/**`. SRS §2.2 (merged to `main`).
 - ✅ Task 0.5.05 (SDK surface) — `sdk.db.getClient()` implemented (`@sovereignfs/sdk` → 0.7.0). Last v1 SDK stub is gone: `getClient()` now returns the live platform Drizzle instance from `getPlatformDb()` — **async** (`Promise<DrizzleClient>`, same dialect-agnostic reason as `getConfig()`); `DrizzleClient` stays opaque (`unknown`) so the published SDK takes no dialect dependency. `sdk.auth.getSession()` now populates `tenantId` with `DEFAULT_TENANT_ID` (v1 single-tenant). `sdk.platform`/`sdk.mailer` were already implemented directly in `packages/sdk` (the doc's "runtime injects impls / SDK re-exports" model is obsolete — `packages/sdk/src/*.ts` import `@sovereignfs/db`/`@sovereignfs/mailer` directly). Migration note in `docs/upgrade.md`. SRS §3.6 (merged to `main`).
 - ✅ Task 0.5.05b — local session verification in middleware (AUTH-05; `runtime` → 0.6.0). Auth server enables better-auth's signed cookie cache (`session.cookieCache`, 300s); the runtime middleware verifies the `session_data` cookie offline via `getCookieCache` (`better-auth/cookies`, Edge-safe) + the pure `verifiedUserFromCache`/`resolveAuthSecret` in `runtime/src/session-verify.ts`, falling back to `/api/verify` (which now re-emits better-auth's `Set-Cookie`, forwarded by the middleware so the cache self-refreshes). Secret = `SOVEREIGN_AUTH_SECRET ?? AUTH_SECRET`; runtime services in all compose files get `AUTH_SECRET`. `better-auth` added as a runtime dep. SRS AUTH-05/06 (merged to `main`).
-- ⏳ Next: Task 0.5.06 — Documentation. Branch from an up-to-date `main`.
+- ✅ Task 0.5.06 — Documentation: new `docs/plugin-development.md` (file structure, full manifest reference, SDK usage, local dev, DB conventions, registry) and `docs/architecture.md` (contributor summary of SRS §3); expanded `README.md` (features, quick start, monorepo layout, docs index); completeness passes on `docs/self-hosting.md` (every `.env.example` var documented) and `docs/upgrade.md` (platform v0.3→v0.4→v0.5 notes). **Anti-drift:** `runtime/src/docs-parity.test.ts` asserts every manifest field, permission, SDK surface, and env var is documented (manifest exposes `manifestFieldNames`); CLAUDE.md "docs are part of the change" convention. SRS NFR-10 (merged to `main`).
+- ⏳ Next: Task 0.5.07 — CI pipeline (`.github/workflows/ci.yml` + `publish.yml`). Branch from an up-to-date `main`.
 - ⏳ Spec complete: Shell sidebar three-section architecture (PLT-11–PLT-15, SRS updated).
 - ⏳ Spec complete: Plainwrite sovereign plugin (`docs/plugins/plainwrite.md`, v0.2 — provider + SSG adapters).
 - ⏳ Spec complete: API Composer sovereign plugin (`docs/plugins/api-composer.md`) — GUI API builder, `/api` namespace (PLT-16, Task 0.5.08).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,88 @@
 # Sovereign
 
-Sovereign is a modular, self-hostable workspace runtime: a shared platform foundation — authentication, data access, email, and shared UI — on top of which installable plugins run as first-class applications. It is open source, privacy-first, and designed to be owned entirely by the person or organisation running it. See the [Concept · Plan · SRS](docs/sovereign-proposal-plan-srs.md) for architecture and rationale, and the [implementation task breakdown](docs/sovereign-implementation-tasks.md) for the phased build plan.
+Sovereign is a modular, self-hostable workspace runtime: a shared platform
+foundation — authentication, data access, email, and shared UI — on top of which
+installable plugins run as first-class applications. It is open source,
+privacy-first, and designed to be owned entirely by the person or organisation
+running it.
+
+The plugin system _is_ the product: the platform is a host, and apps
+(task managers, expense splitters, writing tools, …) install into it as plugins
+that share one login, one database, and one design system.
+
+## Features
+
+- **Plugin-first** — native Next.js plugins compose into the runtime at build
+  time and serve under their own URL prefix, inside the platform shell.
+- **One account, one workspace** — shared auth (better-auth), role-based admin,
+  and a Console for managing users and plugins.
+- **Self-hostable** — single-machine Docker Compose deployment; SQLite by
+  default, PostgreSQL via env.
+- **Privacy-first & single-tenant** — your instance, your data; `tenant_id` is
+  carried from day one for a future multi-tenant path.
+- **Installable PWA** and a typed SDK (`@sovereignfs/sdk`) + design system
+  (`@sovereignfs/ui`) published for plugin developers.
+
+## Quick start
+
+Requirements: [Docker](https://docs.docker.com/get-docker/) with Compose, or
+Node ≥20 + pnpm for local development.
+
+### Run with Docker
+
+```bash
+git clone https://github.com/sovereignfs/sovereign.git
+cd sovereign
+cp .env.example .env          # set AUTH_SECRET, SOVEREIGN_ADMIN_KEY, NEXT_PUBLIC_RUNTIME_URL
+docker compose up --build
+```
+
+Open http://localhost:3000 — the first user to register becomes the platform
+admin. Full instructions, env vars, and production/Postgres setup are in
+[docs/self-hosting.md](docs/self-hosting.md).
+
+### Develop locally
+
+```bash
+pnpm install
+cp .env.example .env          # fill in AUTH_SECRET + SOVEREIGN_ADMIN_KEY
+pnpm dev                      # runtime on :3000, auth on :3001
+```
+
+The `sv` CLI wraps common tasks: `pnpm sv <command>` (`dev`, `build`, `generate`,
+`plugin add/remove`, …).
+
+## Monorepo layout
+
+```
+apps/auth/        better-auth identity server (the only separate Next.js app)
+packages/
+  sdk/            @sovereignfs/sdk — plugin↔platform contract (published)
+  ui/             @sovereignfs/ui — design system (published)
+  db/             Drizzle client factory + schema (SQLite/Postgres)
+  manifest/       manifest schema + validation
+  mailer/         SMTP abstraction
+  tsconfig/       shared TypeScript configs
+runtime/          the platform shell: middleware, plugin host, SDK bridge
+plugins/          built-in platform plugins (console, launcher, account)
+scripts/          install-plugins, generate-registry, dev orchestrator
+bin/sv            the sv CLI
+```
+
+## Documentation
+
+- [Self-hosting](docs/self-hosting.md) — deploy and operate an instance.
+- [Plugin development](docs/plugin-development.md) — build a plugin on the SDK.
+- [Architecture](docs/architecture.md) — how the platform fits together.
+- [Design system](docs/design-system.md) — `@sovereignfs/ui` tokens and
+  components.
+- [Upgrade guide](docs/upgrade.md) — versioned migration notes.
+- [Contributing](CONTRIBUTING.md) — workflow and conventions.
+- [Concept · Plan · SRS](docs/sovereign-proposal-plan-srs.md) and the
+  [implementation task breakdown](docs/sovereign-implementation-tasks.md) — the
+  authoritative specification and build plan.
 
 ## License
 
-Sovereign is licensed under the GNU Affero General Public License v3.0 or later (AGPL-3.0-or-later). See [LICENSE](LICENSE) for the full text.
+Sovereign is licensed under the GNU Affero General Public License v3.0 or later
+(AGPL-3.0-or-later). See [LICENSE](LICENSE) for the full text.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,96 @@
+# Architecture
+
+A contributor-oriented summary of how Sovereign fits together. It distils the
+authoritative specification in
+[sovereign-proposal-plan-srs.md](sovereign-proposal-plan-srs.md) §3 — follow the
+section links for the full detail and rationale. For building plugins see
+[plugin-development.md](plugin-development.md); for running an instance see
+[self-hosting.md](self-hosting.md).
+
+## What Sovereign is
+
+A modular, self-hostable workspace runtime. A shared platform — auth, database,
+email, UI — hosts installable **plugins** as first-class apps. The plugin system
+_is_ the product. v1 is single-tenant, multi-user, privacy-first.
+
+## Deployment model (SRS §3.1)
+
+Two Next.js apps behind one public entry point:
+
+- **runtime** (`runtime/`) — the platform shell, middleware, plugin host, and
+  SDK bridge. The only publicly-exposed service.
+- **auth** (`apps/auth/`) — a self-contained better-auth server owning the
+  identity database and login UI. Not mapped to a public port; reached over the
+  internal network (and behind one reverse proxy in production, so the session
+  cookie is shared by host).
+
+Docker Compose is the canonical deployment. Production images build from Next.js
+standalone output.
+
+## Layer overview (SRS §3.2)
+
+```
+Browser → runtime (shell, middleware, plugins)
+              │  sdk.auth · sdk.db · sdk.mailer · sdk.platform
+              ├─ auth server (better-auth)         identity
+              ├─ Drizzle DB (SQLite | Postgres)    platform + plugin data
+              └─ mailer (SMTP)                      email
+```
+
+## Auth (SRS §3.3, §3.10; AUTH-05/06)
+
+better-auth manages sessions via an httpOnly, host-scoped cookie. The runtime
+middleware verifies each request **locally** from better-auth's signed
+`session_data` cookie cache (HMAC with the shared `AUTH_SECRET`), avoiding a
+round-trip per request; it falls back to the auth server's `/api/verify` when no
+cache cookie is present, forwarding the refreshed cookie so the cache self-heals.
+The first registered user becomes `platform:admin`; everyone else is
+`platform:user`.
+
+## Runtime (SRS §3.4)
+
+The middleware is the gate: it authenticates the request, injects the verified
+user as `x-sovereign-user-*` headers for downstream server components, enforces
+`adminOnly` (403) and disabled-plugin (404) rules, and serves the configured
+root plugin at `/`. Plugin routes are composed into the App Router at build time.
+
+## Plugin system & manifest (SRS §3.5, §3.8, §3.9)
+
+Each plugin ships a strict `manifest.json` (validated at build — invalid manifest
+fails the build) and an `app/` tree. The generate step composes `app/` into the
+runtime under the manifest's `routePrefix` as **copies** (not symlinks; Next's
+dev route watcher doesn't follow symlinked route dirs), git-ignored, with
+`plugins/<id>/` as the source of truth. The SDK (`@sovereignfs/sdk`) is the only
+plugin↔platform contract, enforced by an ESLint import-boundary rule.
+
+## Database (SRS §3.7)
+
+Drizzle ORM, dialect-agnostic: SQLite by default, Postgres via env. One shared
+schema with **slug-prefixed** plugin tables (`tasks_lists`), no per-plugin
+databases in v1. `tenant_id` is present on user-scoped tables from day one for
+future multi-tenancy. The platform data layer is **async** (Postgres has no
+synchronous query), so platform DB reads and `sdk.db`/`sdk.platform` return
+promises.
+
+## SDK (SRS §3.6)
+
+`@sovereignfs/sdk` exposes `auth`, `db`, `mailer`, `platform` (implemented) and
+`storage`, `notifications`, `events`, `data` (reserved, post-v1). It is published
+to npm as a public contract for plugin developers; `DrizzleClient` is kept
+opaque so the published SDK takes no dialect dependency.
+
+## PWA (SRS §3.11)
+
+The runtime is an installable PWA. The web manifest and icons are committed
+source; the service worker is generated at build and disabled in dev.
+
+## Post-v1 (specified, not built)
+
+Native mobile via a Capacitor shell + `sdk.device.*` (SRS §3.12) and
+consent-gated cross-plugin data sharing via `sdk.data` (SRS §3.13, RFC 0002) are
+designed but out of scope for v1.
+
+## Repository layout
+
+See the monorepo structure in the [README](../README.md#monorepo-layout) and the
+detailed breakdown in SRS §2.3.

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -1,0 +1,221 @@
+# Plugin development
+
+This guide is for building a Sovereign plugin. A plugin is a self-contained app
+— Next.js App Router routes plus an optional database schema — that the platform
+composes into the runtime at build time and serves under a URL prefix you
+choose. Plugins talk to the platform **only** through the SDK
+(`@sovereignfs/sdk`); they never import runtime internals.
+
+If you are deploying an instance rather than building a plugin, see
+[self-hosting.md](self-hosting.md). For the platform internals, see
+[architecture.md](architecture.md).
+
+## How plugins work
+
+- **Native runtime.** A v1 plugin is plain Next.js App Router code (server
+  components, route handlers, server actions, client components). No iframes, no
+  separate process.
+- **Build-time composition.** The generate step copies your plugin's `app/`
+  tree into the runtime's App Router under your manifest's `routePrefix`, so your
+  routes render inside the platform shell (sidebar, auth, theming) with zero
+  wiring. The copies are generated and git-ignored — your `plugins/<id>/app/` is
+  always the source of truth.
+- **The SDK is the only contract.** Auth, database, email, and platform config
+  come from `@sovereignfs/sdk`. The design system comes from `@sovereignfs/ui`.
+  Importing from `runtime/src` is forbidden and enforced by ESLint.
+
+## File structure
+
+A plugin lives in one directory. Minimal shape (modelled on the built-in
+`account` plugin):
+
+```
+my-plugin/
+  manifest.json          # required — identity, routing, capabilities (see below)
+  package.json           # name, version, deps (react, @sovereignfs/sdk, @sovereignfs/ui)
+  icon.svg               # optional — sidebar/launcher icon (monogram generated if absent)
+  app/                   # composed into the runtime at your routePrefix
+    page.tsx             #   → <routePrefix>/
+    layout.tsx           #   optional plugin-level layout
+    actions.ts           #   'use server' actions
+    settings/page.tsx    #   → <routePrefix>/settings
+    _components/         #   private components (underscore = not a route)
+    _lib/                #   private helpers/tests
+    my-plugin.module.css #   CSS Modules + design tokens
+  db/
+    schema.ts            # optional — Drizzle tables (slug-prefixed, see Database)
+```
+
+Anything under `app/` that isn't an underscore-prefixed folder becomes a route
+relative to your `routePrefix`. `routePrefix: "/tasks"` + `app/lists/page.tsx`
+serves at `/tasks/lists`.
+
+## Manifest reference
+
+`manifest.json` is validated at build time against a strict schema
+(`packages/manifest`); unknown keys fail the build. Every field:
+
+| Field           | Type                                                                    | Required                             | Description                                                                                            |
+| --------------- | ----------------------------------------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------ |
+| `schemaVersion` | integer                                                                 | yes                                  | Manifest format version. Currently `1`.                                                                |
+| `id`            | string                                                                  | yes                                  | Globally-unique reverse-DNS id, e.g. `io.example.tasks`. Also the install directory name.              |
+| `name`          | string                                                                  | yes                                  | Human-readable name shown in the sidebar and Launcher.                                                 |
+| `version`       | string                                                                  | yes                                  | Plugin version (semver recommended).                                                                   |
+| `description`   | string                                                                  | no                                   | Short description.                                                                                     |
+| `database`      | `shared` \| `isolated`                                                  | no                                   | Data isolation model. v1 supports `shared` (the default behaviour); `isolated` is reserved (RFC 0004). |
+| `type`          | `platform` \| `sovereign` \| `community`                                | yes                                  | Origin/trust tier (see below).                                                                         |
+| `runtime`       | `native` \| `static` \| `iframe-local` \| `iframe-remote` \| `external` | yes                                  | Execution model. v1 plugins use `native`; the others are reserved for future runtimes.                 |
+| `routePrefix`   | string starting with `/`                                                | yes                                  | URL prefix the plugin serves under, e.g. `/tasks`. The single source of truth for the plugin's URL.    |
+| `permissions`   | array of permission strings                                             | yes (may be `[]`)                    | SDK capabilities the plugin declares (see below).                                                      |
+| `shell`         | `default` \| `minimal`                                                  | no                                   | Chrome to render in. `default` = platform sidebar; `minimal` is reserved (not wired in v1).            |
+| `adminOnly`     | boolean                                                                 | no (default `false`)                 | When `true`, only `platform:admin` users may reach the plugin's routes (403 otherwise).                |
+| `icon`          | string                                                                  | no                                   | Path to an SVG icon relative to the plugin root. A monogram is generated if omitted.                   |
+| `compatibility` | object `{ minPlatformVersion: string }`                                 | yes                                  | Minimum platform version the plugin supports.                                                          |
+| `repository`    | string (URL)                                                            | required for `sovereign`/`community` | Git repository URL. Required unless `type` is `platform`.                                              |
+
+### `type`
+
+- `platform` — built-in plugins that ship in this monorepo (Console, Launcher,
+  Account). No `repository` required.
+- `sovereign` — first-party plugins maintained by the project, installed from
+  their own repos. `repository` required.
+- `community` — third-party plugins. `repository` required.
+
+### `permissions`
+
+Declared capabilities. The v1-functional ones:
+
+| Permission     | Grants                                             |
+| -------------- | -------------------------------------------------- |
+| `auth:session` | Read the current session via `sdk.auth`.           |
+| `db:readWrite` | Read/write access to the platform DB via `sdk.db`. |
+| `db:readOnly`  | Read-only DB access.                               |
+| `mailer:send`  | Send email via `sdk.mailer`.                       |
+| `admin:*`      | Administrative capabilities (platform plugins).    |
+
+Reserved for post-v1 (declaring them is allowed; the backing surfaces throw
+`NotImplementedError` until implemented): `storage:readWrite`,
+`notifications:send`, `events:publish`, `events:subscribe`, and the cross-plugin
+data-sharing pair `data:provide` / `data:consume` (RFC 0002).
+
+### Example `manifest.json`
+
+```json
+{
+  "schemaVersion": 1,
+  "id": "io.example.tasks",
+  "name": "Tasks",
+  "version": "0.1.0",
+  "description": "A minimal, privacy-first task manager.",
+  "type": "sovereign",
+  "runtime": "native",
+  "routePrefix": "/tasks",
+  "shell": "default",
+  "icon": "icon.svg",
+  "permissions": ["auth:session", "db:readWrite"],
+  "repository": "https://github.com/sovereignfs/sovereign-plugin-tasks",
+  "compatibility": { "minPlatformVersion": "0.5.0" }
+}
+```
+
+## Using the SDK
+
+Import everything platform-related from `@sovereignfs/sdk`:
+
+```ts
+import { sdk } from '@sovereignfs/sdk';
+```
+
+The SDK surface (`sdk.*`):
+
+- **`auth`** — session and account.
+  - `getSession()` → `Session | null`; `requireSession()` → `Session` (throws
+    `NotAuthenticatedError` if unauthenticated).
+  - `changePassword({ currentPassword, newPassword })`,
+    `listSessions()`, `revokeSession(token)`.
+  ```ts
+  const { user } = await sdk.auth.requireSession();
+  // user.id, user.email, user.name, user.image, user.role, user.tenantId
+  ```
+- **`db`** — `getClient()` returns the platform Drizzle client (await it — the
+  data layer is dialect-agnostic and async). Query your own slug-prefixed tables
+  with it (see Database).
+  ```ts
+  const db = await sdk.db.getClient();
+  ```
+- **`mailer`** — `send({ to, subject, text, html })`. No-ops when SMTP is
+  unconfigured.
+- **`platform`** — `getConfig()` → `{ tenantName, inviteOnly, version }`
+  (await it).
+- **Reserved** (throw `NotImplementedError` in v1): `storage`, `notifications`,
+  `events`, and `data` (cross-plugin data sharing, RFC 0002).
+
+### The SDK boundary rule
+
+Plugins **must not** import from `runtime/src` or internal `@sovereignfs/*`
+packages (`db`, `manifest`, `mailer`) directly — only `@sovereignfs/sdk` and
+`@sovereignfs/ui`. ESLint enforces this; violations fail `pnpm lint`.
+
+### UI
+
+Build your interface with the Sovereign Design System (`@sovereignfs/ui`):
+
+```ts
+import { Button, Card, Input, Badge } from '@sovereignfs/ui';
+```
+
+Design tokens (`--sv-*` CSS custom properties) are injected globally by the
+runtime shell — reference them directly in your CSS, e.g.
+`color: var(--sv-color-text-primary)`. See [design-system.md](design-system.md).
+
+## Database
+
+Plugins share the single platform database; isolation is by **convention**:
+
+- **Prefix every table with your plugin slug** — `tasks_lists`, `tasks_items`,
+  `splitify_groups`. There are no per-plugin databases in v1.
+- **Use Drizzle**, defined in `db/schema.ts`, and stay dialect-agnostic: the
+  same schema must run on SQLite (default) and Postgres. Don't write
+  SQLite-specific SQL.
+- **Add `tenant_id` to user-scoped tables** from day one, even though v1 is
+  single-tenant — it keeps the door open for multi-tenancy.
+
+Get a client with `await sdk.db.getClient()` and query through your schema.
+
+## Local development
+
+Run a plugin against a local platform checkout:
+
+1. **Add it** — either clone with the CLI:
+   ```bash
+   pnpm sv plugin add https://github.com/you/sovereign-plugin-foo
+   ```
+   or declare it in `sovereign.plugins.json` and run `pnpm install:plugins`.
+   Both clone into `plugins/<id>/` and compose it.
+2. **Develop** — `pnpm dev` starts the runtime (`:3000`) and auth (`:3001`).
+   Edits under `plugins/<id>/app/` are re-composed and hot-reloaded
+   automatically.
+3. **Remove it** — `pnpm sv plugin remove <id>` (deletes the directory and
+   re-composes; built-in platform plugins are protected).
+
+Never edit the composed copies under
+`runtime/app/(platform)/(plugins)/` — they are generated and git-ignored. Your
+`plugins/<id>/` directory is the source of truth.
+
+## Publishing & the registry
+
+To distribute a plugin, set `type` to `sovereign` or `community` and point
+`repository` at its public git URL. Today, instances install declared plugins
+from `sovereign.plugins.json`:
+
+```json
+{
+  "plugins": [
+    { "id": "io.example.tasks", "repository": "https://github.com/you/sovereign-plugin-tasks" }
+  ]
+}
+```
+
+A formal registry and contribution/review process is planned for v1.0 (see the
+roadmap in [sovereign-implementation-tasks.md](sovereign-implementation-tasks.md)).
+Until then, share your repository URL and instances add it as above.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -74,6 +74,7 @@ to get started — every variable is documented there.
 | `AUTH_SECRET`             | **yes**  | —                            | Signing secret for the auth server. The runtime also reads it to verify the session cookie locally (AUTH-05). Generate with `openssl rand -base64 32`. Never share or commit.     |
 | `SOVEREIGN_ADMIN_KEY`     | **yes**  | —                            | Shared secret for runtime↔auth internal admin API calls (Console user/plugin management). Generate with `openssl rand -base64 32`.                                                |
 | `NEXT_PUBLIC_RUNTIME_URL` | **yes**  | `http://localhost:3000`      | Public URL of the runtime — used by the auth server to redirect users after login.                                                                                                |
+| `SOVEREIGN_AUTH_URL`      | no       | `http://localhost:3001`      | Where the runtime reaches the auth server. Docker Compose sets it to the internal service name (`http://auth:3001`) automatically — only set it for non-Docker/native runs.       |
 | `AUTH_INVITE_ONLY`        | no       | `false`                      | When `true`, registration requires a valid invite token. The first user is exempt.                                                                                                |
 | `AUTH_DATABASE_URL`       | no       | `file:./data/auth.db`        | Auth server database. SQLite file path (relative paths resolve against the repo root) or a `postgres://` URL.                                                                     |
 | `DATABASE_URL`            | no       | `file:./data/sovereign.db`   | Runtime database. SQLite file path (relative paths resolve against the repo root) or a `postgres://` URL.                                                                         |
@@ -85,6 +86,8 @@ to get started — every variable is documented there.
 | `SMTP_FROM`               | no       | —                            | Sender address, e.g. `Sovereign <noreply@example.com>`.                                                                                                                           |
 | `RUNTIME_PORT`            | no       | `3000` (dev) / `4000` (prod) | Host port the runtime container is mapped to.                                                                                                                                     |
 | `SOVEREIGN_AUTH_SECRET`   | no       | `AUTH_SECRET`                | Secret for local session verification (AUTH-05). Must equal the auth server's signing secret, so it defaults to `AUTH_SECRET` — set it only to run a deliberately distinct value. |
+| `MAILPIT_SMTP_PORT`       | no       | `1025`                       | Dev only — host port for the Mailpit SMTP listener in `docker-compose.yml`.                                                                                                       |
+| `MAILPIT_UI_PORT`         | no       | `8025`                       | Dev only — host port for the Mailpit web inbox in `docker-compose.yml`.                                                                                                           |
 
 ---
 
@@ -249,7 +252,8 @@ After the first user registers, invite new users via the Console:
 
 ## Upgrading
 
-See `docs/upgrade.md` for version-specific migration notes (Task 0.5.06).
+See the [upgrade guide](upgrade.md) for version-specific migration notes,
+including platform-release notes and any required configuration changes.
 
 The general upgrade process:
 

--- a/docs/sovereign-implementation-tasks.md
+++ b/docs/sovereign-implementation-tasks.md
@@ -866,9 +866,16 @@ consistent info/success/warn/error formatting. CLI is monorepo-internal in v1
 
 ---
 
-### Task 0.5.06 — Documentation
+### Task 0.5.06 — Documentation **[done]**
 
 **Goal:** Complete self-hosting and plugin developer documentation.
+
+> **Delivered.** `docs/plugin-development.md` and `docs/architecture.md` written;
+> `README.md` expanded; `docs/self-hosting.md` and `docs/upgrade.md` completed
+> (platform v0.3→v0.4→v0.5 notes). A docs-parity test
+> (`runtime/src/docs-parity.test.ts`) + a "docs are part of the change" CLAUDE.md
+> convention keep manifest fields, permissions, the SDK surface, and env vars in
+> sync with the code.
 
 **Deliverables:**
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -2,7 +2,36 @@
 
 Migration notes for breaking changes. Per NFR-04, any breaking change to a
 published package (`@sovereignfs/sdk`, `@sovereignfs/ui`) ships with at least a
-minor version bump and an entry here.
+minor version bump and an entry here. Operators upgrading an instance should read
+the platform-release notes; plugin developers should read the package notes.
+
+## Platform releases
+
+The platform version (root `package.json`) tracks roadmap milestones. To upgrade,
+pull the new version, then `docker compose -f docker-compose.prod.yml up --build -d`
+(or rebuild your deployment). Notes below call out any required configuration
+changes.
+
+### v0.4 → v0.5
+
+- **`SOVEREIGN_ADMIN_KEY` is required** (auth + runtime). Set it in `.env` — both
+  services refuse to start without it. Generate with `openssl rand -base64 32`.
+- **The runtime now reads `AUTH_SECRET`** to verify sessions locally (AUTH-05).
+  It must equal the auth server's `AUTH_SECRET`; since both apps load the one
+  root `.env`, no action is needed unless you set a distinct `SOVEREIGN_AUTH_SECRET`.
+  The provided Compose files pass `AUTH_SECRET` to the runtime service.
+- **PostgreSQL is supported** as an alternative to the default SQLite — opt in
+  with `DB_DIALECT=postgres` + `DATABASE_URL`/`AUTH_DATABASE_URL`, or the
+  `docker-compose.postgres.yml` overlay. See [self-hosting.md](self-hosting.md#postgresql).
+- No data migration is required for existing SQLite instances.
+
+### v0.3 → v0.4
+
+- First-class **Console** (user + plugin management), **Launcher**, and
+  **Account** plugins land. No configuration changes; existing data is carried
+  forward. The first registered user is the platform admin.
+
+## Published package migrations
 
 ## `@sovereignfs/sdk` 0.6.0 → 0.7.0
 

--- a/packages/manifest/src/index.ts
+++ b/packages/manifest/src/index.ts
@@ -1,3 +1,3 @@
-export { manifestSchema, permissionSchema } from './schema';
+export { manifestSchema, permissionSchema, manifestFieldNames } from './schema';
 export { validateManifest, type ValidationResult } from './validate';
 export type { SovereignManifest, Permission } from './types';

--- a/packages/manifest/src/schema.ts
+++ b/packages/manifest/src/schema.ts
@@ -27,7 +27,7 @@ export const permissionSchema = z.enum([
  * `.strict()` rejects unknown keys so manifest typos fail the build rather than
  * being silently ignored. Forward compatibility is handled by `schemaVersion`.
  */
-export const manifestSchema = z
+const manifestObjectSchema = z
   .object({
     schemaVersion: z.number().int().positive(),
     id: z.string().min(1),
@@ -47,8 +47,19 @@ export const manifestSchema = z
     }),
     repository: z.string().url().optional(),
   })
-  .strict()
-  .refine((m) => m.type === 'platform' || m.repository !== undefined, {
+  .strict();
+
+export const manifestSchema = manifestObjectSchema.refine(
+  (m) => m.type === 'platform' || m.repository !== undefined,
+  {
     message: 'repository is required when type is "sovereign" or "community"',
     path: ['repository'],
-  });
+  },
+);
+
+/**
+ * Manifest field names, sourced from the schema so docs and tooling share one
+ * source of truth (e.g. the docs-parity test that asserts every field is
+ * documented in `docs/plugin-development.md`). Order matches the schema.
+ */
+export const manifestFieldNames: string[] = Object.keys(manifestObjectSchema.shape);

--- a/runtime/src/docs-parity.test.ts
+++ b/runtime/src/docs-parity.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { findWorkspaceRoot } from '@sovereignfs/db';
+import { manifestFieldNames, permissionSchema } from '@sovereignfs/manifest';
+import { sdk } from '@sovereignfs/sdk';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Documentation parity — pins the enumerable, drift-prone parts of the docs to
+ * their source of truth so they cannot silently fall out of date (Task 0.5.06):
+ * every manifest field, permission, and SDK surface must be documented in
+ * `docs/plugin-development.md`, and every `.env.example` variable in
+ * `docs/self-hosting.md`. Adding one without documenting it fails the suite.
+ */
+const ROOT = findWorkspaceRoot();
+const read = (relPath: string): string => readFileSync(join(ROOT, relPath), 'utf8');
+
+const pluginDoc = read('docs/plugin-development.md');
+const selfHostingDoc = read('docs/self-hosting.md');
+const envExample = read('.env.example');
+
+/** Every variable key declared in .env.example (active or commented-out). */
+const envVarKeys = [
+  ...new Set(
+    [...envExample.matchAll(/^#?\s*([A-Z][A-Z0-9_]*)=/gm)].map((match) => match[1] as string),
+  ),
+];
+
+describe('docs parity', () => {
+  it('plugin-development.md documents every manifest field', () => {
+    for (const field of manifestFieldNames) {
+      expect(pluginDoc, `manifest field "${field}" is not documented`).toContain(field);
+    }
+  });
+
+  it('plugin-development.md documents every permission', () => {
+    for (const permission of permissionSchema.options) {
+      expect(pluginDoc, `permission "${permission}" is not documented`).toContain(permission);
+    }
+  });
+
+  it('plugin-development.md documents every SDK surface', () => {
+    for (const surface of Object.keys(sdk)) {
+      expect(pluginDoc, `sdk.${surface} is not documented`).toContain(surface);
+    }
+  });
+
+  it('self-hosting.md documents every .env.example variable', () => {
+    expect(envVarKeys.length).toBeGreaterThan(0);
+    for (const key of envVarKeys) {
+      expect(selfHostingDoc, `env var "${key}" is not documented`).toContain(key);
+    }
+  });
+});


### PR DESCRIPTION
## What

Completes the v0.5 documentation set (Task 0.5.06) and adds a mechanism to keep docs from drifting.

### New docs
- **`docs/plugin-development.md`** — how plugins work, annotated file structure, the **full manifest reference** (every field with type/required/description, the permission set, the `type`/`runtime`/`shell` enums, an annotated example), SDK usage (`auth`/`db`/`mailer`/`platform` + reserved surfaces + the import-boundary rule), local development (`sv plugin add/remove`, `pnpm dev`), database conventions (slug-prefixed tables, dialect-agnostic, `tenant_id`), and distribution.
- **`docs/architecture.md`** — a concise contributor summary of SRS §3 (deployment, auth incl. AUTH-05, runtime, plugin system, DB, SDK, PWA), each section linking to the authoritative SRS.

### Updated docs
- **`README.md`** — expanded from a 7-line stub: features, quick start (Docker + dev), monorepo layout, documentation index.
- **`docs/self-hosting.md`** — now documents **every** `.env.example` variable (added `SOVEREIGN_AUTH_URL` and the dev-only `MAILPIT_*` ports); links the upgrade guide.
- **`docs/upgrade.md`** — adds **platform-release** notes (v0.3 → v0.4 → v0.5), incl. that the runtime now reads `AUTH_SECRET` for local verification.

## Keeping docs in sync (anti-drift)

The enumerable, drift-prone content is pinned to its source:

- **`runtime/src/docs-parity.test.ts`** asserts that every **manifest field**, **permission**, **SDK surface** (`Object.keys(sdk)`), and **`.env.example` variable** appears in its doc. Adding one without documenting it fails `pnpm test` / CI. `packages/manifest` now exports `manifestFieldNames` as the shared source (refactored the schema to expose the object shape; no behavioural change).
- A **"docs are part of the change"** convention in `CLAUDE.md`: schema / SDK-surface / env-var changes must update the matching doc in the same PR.

## Notes
- `docs/` task → no version bumps. The `packages/manifest` change is additive and internal (private package).
- No Docker/runtime behaviour changes.

## How to test
```bash
pnpm test           # 176 passed / 9 skipped — includes the 4 docs-parity checks
pnpm format:check
pnpm lint
pnpm typecheck
```
All relative inter-doc links resolve.

## Review checklist (Task 0.5.06)
- [x] A newcomer can deploy from scratch via `self-hosting.md`
- [x] The plugin guide covers **all** manifest fields with examples
- [x] All env vars documented with required/optional — enforced by the parity test

🤖 Generated with [Claude Code](https://claude.com/claude-code)