### PR TITLE
Delegate the public /api/* namespace to a provider plugin (PLT-16)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,20 @@ pnpm lint:fix        # run ESLint with auto-fix
   rule forbids plugins importing `runtime/src` or internal packages. The route
   is session-gated (middleware injects `x-sovereign-user-role`) and role-filters
   via `selectLauncherPlugins`; `sdk.db` replaces this fetch in Task 0.5.05.
+- **The `/api/*` namespace is split: reserved runtime segments vs. the public
+  provider namespace (PLT-16).** The runtime serves its own first-level segments
+  — `account`, `admin`, `health`, `plugins` (`runtime/app/api/*`) — listed in
+  `RESERVED_API_SEGMENTS` (`runtime/src/api-namespace.ts`); a parity test asserts
+  the set matches the on-disk dirs, so a new runtime API route can't silently
+  become delegatable. Every other `/api/<slug>/*` is the **public** namespace:
+  the middleware handles it **before** the session gate (it is unauthenticated —
+  the provider owns auth, e.g. API keys), rewriting to the single registered
+  provider's serve route `<routePrefix>/serve/<slug>/<path>`, or 404 when no
+  enabled provider is installed. The provider is the one plugin with
+  `apiProvider: true` in its manifest; **exactly one per instance** — the
+  generate script fails the build on a second one (`findApiProvider` in
+  `@sovereignfs/manifest` is the shared resolver). Never add a new
+  `runtime/app/api/*` segment without adding it to `RESERVED_API_SEGMENTS`.
 - **Server-to-server calls to better-auth (`/api/auth/*`) must send an `Origin`
   header** equal to the auth base URL (`SOVEREIGN_AUTH_URL`) — better-auth
   enforces a CSRF origin check and rejects originless POSTs with
@@ -535,7 +549,8 @@ pnpm install:plugins    # clone sovereign/community plugins declared in sovereig
 - ✅ Task 0.5.05b — local session verification in middleware (AUTH-05; `runtime` → 0.6.0). Auth server enables better-auth's signed cookie cache (`session.cookieCache`, 300s); the runtime middleware verifies the `session_data` cookie offline via `getCookieCache` (`better-auth/cookies`, Edge-safe) + the pure `verifiedUserFromCache`/`resolveAuthSecret` in `runtime/src/session-verify.ts`, falling back to `/api/verify` (which now re-emits better-auth's `Set-Cookie`, forwarded by the middleware so the cache self-refreshes). Secret = `SOVEREIGN_AUTH_SECRET ?? AUTH_SECRET`; runtime services in all compose files get `AUTH_SECRET`. `better-auth` added as a runtime dep. SRS AUTH-05/06 (merged to `main`).
 - ✅ Task 0.5.06 — Documentation: new `docs/plugin-development.md` (file structure, full manifest reference, SDK usage, local dev, DB conventions, registry) and `docs/architecture.md` (contributor summary of SRS §3); expanded `README.md` (features, quick start, monorepo layout, docs index); completeness passes on `docs/self-hosting.md` (every `.env.example` var documented) and `docs/upgrade.md` (platform v0.3→v0.4→v0.5 notes). **Anti-drift:** `runtime/src/docs-parity.test.ts` asserts every manifest field, permission, SDK surface, and env var is documented (manifest exposes `manifestFieldNames`); CLAUDE.md "docs are part of the change" convention. SRS NFR-10 (merged to `main`).
 - ✅ Task 0.5.07 — CI pipeline: `.github/workflows/ci.yml` (PR-only — `pull_request` against `main` + `workflow_call`, **no push trigger**; every job skips while the PR is a draft and runs on `ready_for_review`/subsequent pushes via `if: github.event_name != 'pull_request' || github.event.pull_request.draft == false`) with six jobs — `format`/`lint`/`typecheck`/`generate-validate`/`build`/`test`. The `test` job wires a **Postgres 16 service** + `TEST_DATABASE_URL` so the env-gated `*.pg.test.ts` parity suites run (not skipped). Shared toolchain setup is a composite action (`.github/actions/setup`). `.github/workflows/publish.yml` publishes on per-package tags (`sdk-v*.*.*` → `@sovereignfs/sdk`, `ui-v*.*.*` → `@sovereignfs/ui`), gated by reusing `ci.yml` via `workflow_call`; needs the `NPM_TOKEN` repo secret. **`@sovereignfs/ui` npm packaging finalised** (deferred from 0.3.07): `package.json` `publishConfig` repoints `exports`/`types` to `dist/` on publish (workspace dev still uses `src`), and `tsup.config.ts`'s `onSuccess` copies CSS into `dist/` (CSS Modules flattened by basename to match esbuild's bundled imports — unique per `<Component>.module.css`, build fails on a basename collision; token CSS keeps its tree). **Caveat:** `@sovereignfs/sdk` is not yet npm-installable — its `dist` imports the `private` `@sovereignfs/db`/`@sovereignfs/mailer`; making sdk publishable (bundle via `noExternal`, or publish those deps) is a separate follow-up before any `sdk-v*` tag (merged to `main`).
-- ⏳ Next: Task 0.5.08 — Public `/api` namespace delegation (PLT-16; `[parallel]`). Branch from an up-to-date `main`.
+- ✅ Task 0.5.08 — Public `/api` namespace delegation (PLT-16; `runtime` → 0.7.0, `@sovereignfs/manifest` → 0.5.0): manifest gains an optional `apiProvider` flag + a shared `findApiProvider(manifests)` resolver; the generate script fails the build if two plugins declare it. The runtime splits `/api/*` into reserved runtime segments (`account`/`admin`/`health`/`plugins`, in `RESERVED_API_SEGMENTS`, guarded by a dir-parity test) and the public namespace `/api/<slug>/*`, which the middleware handles **before** the session gate — rewriting to the provider's `<routePrefix>/serve/<slug>/<path>` (preserving query string) or returning 404 when no enabled provider is installed. Pure logic in `runtime/src/api-namespace.ts` (unit-tested). SRS PLT-16 (merged to `main`).
+- ⏳ Next: Task 0.5.09 — Overlay shell mode (RFC 0001; `[parallel]`). Branch from an up-to-date `main`.
 - ⏳ Spec complete: Shell sidebar three-section architecture (PLT-11–PLT-15, SRS updated).
 - ⏳ Spec complete: Plainwrite sovereign plugin (`docs/plugins/plainwrite.md`, v0.2 — provider + SSG adapters).
 - ⏳ Spec complete: API Composer sovereign plugin (`docs/plugins/api-composer.md`) — GUI API builder, `/api` namespace (PLT-16, Task 0.5.08).

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -55,23 +55,24 @@ serves at `/tasks/lists`.
 `manifest.json` is validated at build time against a strict schema
 (`packages/manifest`); unknown keys fail the build. Every field:
 
-| Field           | Type                                                                    | Required                             | Description                                                                                            |
-| --------------- | ----------------------------------------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------ |
-| `schemaVersion` | integer                                                                 | yes                                  | Manifest format version. Currently `1`.                                                                |
-| `id`            | string                                                                  | yes                                  | Globally-unique reverse-DNS id, e.g. `io.example.tasks`. Also the install directory name.              |
-| `name`          | string                                                                  | yes                                  | Human-readable name shown in the sidebar and Launcher.                                                 |
-| `version`       | string                                                                  | yes                                  | Plugin version (semver recommended).                                                                   |
-| `description`   | string                                                                  | no                                   | Short description.                                                                                     |
-| `database`      | `shared` \| `isolated`                                                  | no                                   | Data isolation model. v1 supports `shared` (the default behaviour); `isolated` is reserved (RFC 0004). |
-| `type`          | `platform` \| `sovereign` \| `community`                                | yes                                  | Origin/trust tier (see below).                                                                         |
-| `runtime`       | `native` \| `static` \| `iframe-local` \| `iframe-remote` \| `external` | yes                                  | Execution model. v1 plugins use `native`; the others are reserved for future runtimes.                 |
-| `routePrefix`   | string starting with `/`                                                | yes                                  | URL prefix the plugin serves under, e.g. `/tasks`. The single source of truth for the plugin's URL.    |
-| `permissions`   | array of permission strings                                             | yes (may be `[]`)                    | SDK capabilities the plugin declares (see below).                                                      |
-| `shell`         | `default` \| `minimal`                                                  | no                                   | Chrome to render in. `default` = platform sidebar; `minimal` is reserved (not wired in v1).            |
-| `adminOnly`     | boolean                                                                 | no (default `false`)                 | When `true`, only `platform:admin` users may reach the plugin's routes (403 otherwise).                |
-| `icon`          | string                                                                  | no                                   | Path to an SVG icon relative to the plugin root. A monogram is generated if omitted.                   |
-| `compatibility` | object `{ minPlatformVersion: string }`                                 | yes                                  | Minimum platform version the plugin supports.                                                          |
-| `repository`    | string (URL)                                                            | required for `sovereign`/`community` | Git repository URL. Required unless `type` is `platform`.                                              |
+| Field           | Type                                                                    | Required                             | Description                                                                                                   |
+| --------------- | ----------------------------------------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| `schemaVersion` | integer                                                                 | yes                                  | Manifest format version. Currently `1`.                                                                       |
+| `id`            | string                                                                  | yes                                  | Globally-unique reverse-DNS id, e.g. `io.example.tasks`. Also the install directory name.                     |
+| `name`          | string                                                                  | yes                                  | Human-readable name shown in the sidebar and Launcher.                                                        |
+| `version`       | string                                                                  | yes                                  | Plugin version (semver recommended).                                                                          |
+| `description`   | string                                                                  | no                                   | Short description.                                                                                            |
+| `database`      | `shared` \| `isolated`                                                  | no                                   | Data isolation model. v1 supports `shared` (the default behaviour); `isolated` is reserved (RFC 0004).        |
+| `type`          | `platform` \| `sovereign` \| `community`                                | yes                                  | Origin/trust tier (see below).                                                                                |
+| `runtime`       | `native` \| `static` \| `iframe-local` \| `iframe-remote` \| `external` | yes                                  | Execution model. v1 plugins use `native`; the others are reserved for future runtimes.                        |
+| `routePrefix`   | string starting with `/`                                                | yes                                  | URL prefix the plugin serves under, e.g. `/tasks`. The single source of truth for the plugin's URL.           |
+| `permissions`   | array of permission strings                                             | yes (may be `[]`)                    | SDK capabilities the plugin declares (see below).                                                             |
+| `shell`         | `default` \| `minimal`                                                  | no                                   | Chrome to render in. `default` = platform sidebar; `minimal` is reserved (not wired in v1).                   |
+| `adminOnly`     | boolean                                                                 | no (default `false`)                 | When `true`, only `platform:admin` users may reach the plugin's routes (403 otherwise).                       |
+| `apiProvider`   | boolean                                                                 | no (default `false`)                 | When `true`, the plugin serves the public `/api/*` namespace (PLT-16). One provider per instance — see below. |
+| `icon`          | string                                                                  | no                                   | Path to an SVG icon relative to the plugin root. A monogram is generated if omitted.                          |
+| `compatibility` | object `{ minPlatformVersion: string }`                                 | yes                                  | Minimum platform version the plugin supports.                                                                 |
+| `repository`    | string (URL)                                                            | required for `sovereign`/`community` | Git repository URL. Required unless `type` is `platform`.                                                     |
 
 ### `type`
 
@@ -98,6 +99,24 @@ Reserved for post-v1 (declaring them is allowed; the backing surfaces throw
 `notifications:send`, `events:publish`, `events:subscribe`, the cross-plugin
 data-sharing pair `data:provide` / `data:consume` (RFC 0002), and
 `activity:write` (record activity-log events via `sdk.activity`, RFC 0005).
+
+### `apiProvider` and the public `/api/*` namespace (PLT-16)
+
+The runtime reserves the top-level `/api/*` namespace for plugin-served **public**
+APIs. A plugin that sets `apiProvider: true` becomes the instance's API provider:
+
+- Requests to `/api/<slug>/<path>` are **exempt from the session gate** — the
+  provider owns authentication for them (e.g. API keys). They are **not**
+  redirected to `/login`.
+- The runtime rewrites `/api/<slug>/<path>` to the provider's serve route,
+  `<routePrefix>/serve/<slug>/<path>` — implement it as a catch-all route handler
+  at `app/serve/[slug]/[[...path]]/route.ts`.
+- **Exactly one** provider is allowed per instance; the build fails if two
+  plugins declare `apiProvider: true`. With no provider installed (or the
+  provider disabled), `/api/*` returns **404**.
+- The segments the runtime serves itself — `account`, `admin`, `health`,
+  `plugins` — are reserved and never delegated; a provider must reject them (and
+  any future runtime segment) as slugs.
 
 ### Example `manifest.json`
 

--- a/docs/sovereign-proposal-plan-srs.md
+++ b/docs/sovereign-proposal-plan-srs.md
@@ -949,6 +949,12 @@ interface SovereignManifest {
   // If true, plugin requires platform:admin role (console:access capability)
   adminOnly?: boolean;
 
+  // If true, this plugin serves the public /api/* namespace (PLT-16). At most
+  // one provider per instance; the runtime rewrites /api/<slug>/* to the
+  // provider's serve route (<routePrefix>/serve/<slug>/*), exempt from the
+  // session gate. With no provider installed, /api/* returns 404.
+  apiProvider?: boolean;
+
   // Minimum Sovereign platform version required
   compatibility: {
     minPlatformVersion: string;

--- a/packages/manifest/package.json
+++ b/packages/manifest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sovereignfs/manifest",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "description": "Plugin manifest schema, types, and validation for Sovereign.",

--- a/packages/manifest/src/api-provider.test.ts
+++ b/packages/manifest/src/api-provider.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { findApiProvider } from './api-provider';
+import type { SovereignManifest } from './types';
+
+const make = (id: string, apiProvider?: boolean): SovereignManifest =>
+  ({
+    schemaVersion: 1,
+    id,
+    name: id,
+    version: '1.0.0',
+    type: 'sovereign',
+    runtime: 'native',
+    routePrefix: `/${id}`,
+    permissions: [],
+    compatibility: { minPlatformVersion: '0.5.0' },
+    ...(apiProvider === undefined ? {} : { apiProvider }),
+  }) as SovereignManifest;
+
+describe('findApiProvider', () => {
+  it('returns no provider when none declare apiProvider', () => {
+    const res = findApiProvider([make('a'), make('b', false)]);
+    expect(res.provider).toBeUndefined();
+    expect(res.duplicates).toEqual([]);
+  });
+
+  it('returns the single provider when exactly one declares apiProvider', () => {
+    const res = findApiProvider([make('a'), make('api-composer', true)]);
+    expect(res.provider?.id).toBe('api-composer');
+    expect(res.duplicates).toHaveLength(1);
+  });
+
+  it('reports duplicates and resolves no provider when more than one declares it', () => {
+    const res = findApiProvider([make('one', true), make('two', true)]);
+    expect(res.provider).toBeUndefined();
+    expect(res.duplicates.map((m) => m.id)).toEqual(['one', 'two']);
+  });
+});

--- a/packages/manifest/src/api-provider.ts
+++ b/packages/manifest/src/api-provider.ts
@@ -1,0 +1,21 @@
+import type { SovereignManifest } from './types';
+
+/** The single API provider resolved from a set of manifests, plus any conflict. */
+export interface ApiProviderResult {
+  /** The provider, when exactly one manifest declares `apiProvider: true`. */
+  provider?: SovereignManifest;
+  /** All manifests declaring `apiProvider: true` — length > 1 means a conflict. */
+  duplicates: SovereignManifest[];
+}
+
+/**
+ * Resolve the API-namespace provider from a set of manifests (PLT-16). Exactly
+ * one plugin per instance may serve the public `/api/*` namespace in v1; this is
+ * the shared source of truth for that invariant — the generate script uses it to
+ * fail the build on a conflict, and the runtime middleware to find the provider
+ * it rewrites `/api/<slug>/*` into.
+ */
+export function findApiProvider(manifests: readonly SovereignManifest[]): ApiProviderResult {
+  const duplicates = manifests.filter((m) => m.apiProvider === true);
+  return { provider: duplicates.length === 1 ? duplicates[0] : undefined, duplicates };
+}

--- a/packages/manifest/src/index.ts
+++ b/packages/manifest/src/index.ts
@@ -1,3 +1,4 @@
 export { manifestSchema, permissionSchema, manifestFieldNames } from './schema';
 export { validateManifest, type ValidationResult } from './validate';
+export { findApiProvider, type ApiProviderResult } from './api-provider';
 export type { SovereignManifest, Permission } from './types';

--- a/packages/manifest/src/schema.ts
+++ b/packages/manifest/src/schema.ts
@@ -43,6 +43,7 @@ const manifestObjectSchema = z
     permissions: z.array(permissionSchema),
     shell: z.enum(['default', 'minimal']).optional(),
     adminOnly: z.boolean().optional(),
+    apiProvider: z.boolean().optional(),
     icon: z.string().optional(),
     compatibility: z.object({
       minPlatformVersion: z.string().min(1),

--- a/packages/manifest/src/validate.test.ts
+++ b/packages/manifest/src/validate.test.ts
@@ -78,6 +78,11 @@ describe('validateManifest', () => {
     expect(res.valid).toBe(true);
   });
 
+  it('accepts a manifest that declares apiProvider (PLT-16)', () => {
+    const res = validateManifest({ ...base, apiProvider: true });
+    expect(res.valid).toBe(true);
+  });
+
   it('accepts the reserved cross-plugin data-sharing permissions (RFC 0002)', () => {
     const res = validateManifest({
       ...base,

--- a/runtime/middleware.ts
+++ b/runtime/middleware.ts
@@ -1,5 +1,6 @@
 import { getCookieCache } from 'better-auth/cookies';
 import { type NextRequest, NextResponse } from 'next/server';
+import { decideApiNamespace, isPublicApiPath } from '@/src/api-namespace';
 import { getInstalledPlugins } from '@/src/registry';
 import { decidePluginRoute, underPrefix } from '@/src/route-guard';
 import {
@@ -117,6 +118,26 @@ async function verifyViaAuthServer(
  * disabled plugin's prefix return 404 (SRS CON-07, PLT-04).
  */
 export async function middleware(request: NextRequest): Promise<NextResponse> {
+  const { pathname } = request.nextUrl;
+
+  // Public `/api/*` namespace (PLT-16): handled before the session gate — these
+  // routes are unauthenticated (the provider plugin owns auth, e.g. API keys).
+  // Delegate `/api/<slug>/*` to the registered provider's serve route, or 404
+  // when none is installed/enabled. Reserved runtime segments (account, admin,
+  // health, plugins) are not public and fall through to the normal flow below.
+  if (isPublicApiPath(pathname)) {
+    const disabledIds = await fetchDisabledPluginIds();
+    const decision = decideApiNamespace(pathname, getInstalledPlugins(), disabledIds);
+    if (decision.kind === 'not-found') {
+      return new NextResponse('Not Found', { status: 404 });
+    }
+    if (decision.kind === 'rewrite') {
+      const target = new URL(decision.target, request.url);
+      target.search = request.nextUrl.search;
+      return NextResponse.rewrite(target);
+    }
+  }
+
   let session = await verifyFromCookieCache(request);
   let setCookies: string[] = [];
   if (!session) {
@@ -136,7 +157,6 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
     return response;
   };
 
-  const { pathname } = request.nextUrl;
   const installedPlugins = getInstalledPlugins();
 
   // Only consult plugin status when the path is actually under a plugin prefix.

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sovereignfs/runtime",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/runtime/src/api-namespace.test.ts
+++ b/runtime/src/api-namespace.test.ts
@@ -1,0 +1,79 @@
+import { readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { SovereignManifest } from '@sovereignfs/manifest';
+import { describe, expect, it } from 'vitest';
+import { RESERVED_API_SEGMENTS, decideApiNamespace, isPublicApiPath } from './api-namespace';
+
+const provider = {
+  id: 'fs.sovereign.api-composer',
+  routePrefix: '/api-composer',
+  apiProvider: true,
+} as SovereignManifest;
+const other = { id: 'fs.sovereign.tasks', routePrefix: '/tasks' } as SovereignManifest;
+const none = new Set<string>();
+
+describe('isPublicApiPath', () => {
+  it('is true for a non-reserved /api/<slug> path', () => {
+    expect(isPublicApiPath('/api/blog')).toBe(true);
+    expect(isPublicApiPath('/api/blog/posts/1')).toBe(true);
+  });
+
+  it('is false for reserved runtime segments', () => {
+    for (const seg of RESERVED_API_SEGMENTS) {
+      expect(isPublicApiPath(`/api/${seg}`)).toBe(false);
+      expect(isPublicApiPath(`/api/${seg}/x`)).toBe(false);
+    }
+  });
+
+  it('is false for non-api paths and the bare /api root', () => {
+    expect(isPublicApiPath('/console')).toBe(false);
+    expect(isPublicApiPath('/api')).toBe(false);
+    expect(isPublicApiPath('/api/')).toBe(false);
+  });
+});
+
+describe('decideApiNamespace', () => {
+  it('passes through reserved and non-api paths', () => {
+    expect(decideApiNamespace('/api/plugins', [provider, other], none)).toEqual({ kind: 'pass' });
+    expect(decideApiNamespace('/console/users', [provider], none)).toEqual({ kind: 'pass' });
+  });
+
+  it('rewrites to the provider serve route, preserving slug and path', () => {
+    expect(decideApiNamespace('/api/blog/posts/1', [provider, other], none)).toEqual({
+      kind: 'rewrite',
+      target: '/api-composer/serve/blog/posts/1',
+    });
+    expect(decideApiNamespace('/api/blog/openapi.json', [provider], none)).toEqual({
+      kind: 'rewrite',
+      target: '/api-composer/serve/blog/openapi.json',
+    });
+    expect(decideApiNamespace('/api/blog', [provider], none)).toEqual({
+      kind: 'rewrite',
+      target: '/api-composer/serve/blog',
+    });
+  });
+
+  it('is not-found when no provider is installed', () => {
+    expect(decideApiNamespace('/api/blog', [other], none)).toEqual({ kind: 'not-found' });
+  });
+
+  it('is not-found when the provider is disabled', () => {
+    expect(decideApiNamespace('/api/blog', [provider], new Set([provider.id]))).toEqual({
+      kind: 'not-found',
+    });
+  });
+});
+
+describe('RESERVED_API_SEGMENTS parity', () => {
+  it('lists every top-level directory under runtime/app/api', () => {
+    const apiDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'app', 'api');
+    const segments = readdirSync(apiDir, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name);
+    expect(segments.length).toBeGreaterThan(0);
+    for (const seg of segments) {
+      expect(RESERVED_API_SEGMENTS.has(seg), `/api/${seg} must be reserved`).toBe(true);
+    }
+  });
+});

--- a/runtime/src/api-namespace.ts
+++ b/runtime/src/api-namespace.ts
@@ -1,0 +1,73 @@
+/**
+ * Pure logic for the public `/api/*` namespace delegation (PLT-16). Kept free of
+ * Next.js and database imports so it is unit-testable; the middleware supplies
+ * the installed plugins and the disabled-plugin set and acts on the decision.
+ *
+ * The runtime owns part of `/api/*` for its own routes, so the namespace is
+ * split: requests to a reserved segment keep their normal (session-gated)
+ * handling, while `/api/<slug>/*` for any other slug is the public namespace —
+ * exempt from the session gate and delegated to the single registered provider
+ * plugin (or 404 when there is none).
+ */
+import { findApiProvider, type SovereignManifest } from '@sovereignfs/manifest';
+
+/**
+ * First-level `/api/*` segments the runtime serves itself. Keep in sync with the
+ * top-level directories under `runtime/app/api/` — a parity test enforces this so
+ * a new runtime API route can never silently become delegatable. Reserved
+ * segments are NOT part of the public namespace; the provider plugin is
+ * responsible for rejecting them as slugs.
+ */
+export const RESERVED_API_SEGMENTS: ReadonlySet<string> = new Set([
+  'account',
+  'admin',
+  'health',
+  'plugins',
+]);
+
+/** The first path segment after `/api/`, or '' when there is none. */
+function apiSlug(pathname: string): string {
+  if (pathname === '/api' || pathname === '/api/') return '';
+  if (!pathname.startsWith('/api/')) return '';
+  return pathname.slice('/api/'.length).split('/')[0] ?? '';
+}
+
+/**
+ * Whether a path is in the *public* `/api/*` namespace — under `/api/` with a
+ * non-empty, non-reserved first segment. Reserved segments and non-`/api` paths
+ * return false (they keep their normal middleware handling).
+ */
+export function isPublicApiPath(pathname: string): boolean {
+  const slug = apiSlug(pathname);
+  return slug !== '' && !RESERVED_API_SEGMENTS.has(slug);
+}
+
+export type ApiNamespaceDecision =
+  | { kind: 'pass' }
+  | { kind: 'not-found' }
+  | { kind: 'rewrite'; target: string };
+
+/**
+ * Decide how a public `/api/*` request is delegated:
+ * - not a public api path → 'pass' (caller continues normal handling)
+ * - no installed provider, provider disabled, or no slug → 'not-found' (404)
+ * - otherwise → 'rewrite' to `<provider.routePrefix>/serve/<slug>/<rest>`
+ *
+ * The target preserves the slug and the remaining path so the provider's
+ * `serve/[slug]/[...path]` route receives them intact. Query strings are the
+ * caller's concern (carried on the request URL).
+ */
+export function decideApiNamespace(
+  pathname: string,
+  plugins: readonly SovereignManifest[],
+  disabledIds: ReadonlySet<string>,
+): ApiNamespaceDecision {
+  if (!isPublicApiPath(pathname)) return { kind: 'pass' };
+
+  const { provider } = findApiProvider(plugins);
+  if (!provider || disabledIds.has(provider.id)) return { kind: 'not-found' };
+
+  const rest = pathname.slice('/api/'.length); // "<slug>" or "<slug>/<path…>"
+  const prefix = provider.routePrefix.replace(/\/+$/, '');
+  return { kind: 'rewrite', target: `${prefix}/serve/${rest}` };
+}

--- a/scripts/generate-registry.ts
+++ b/scripts/generate-registry.ts
@@ -39,7 +39,7 @@ import {
 } from 'node:fs';
 import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { validateManifest, type SovereignManifest } from '@sovereignfs/manifest';
+import { findApiProvider, validateManifest, type SovereignManifest } from '@sovereignfs/manifest';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const PLUGINS_DIR = join(ROOT, 'plugins');
@@ -84,6 +84,19 @@ function readPlugins(): PluginEntry[] {
   }
 
   plugins.sort((a, b) => a.manifest.id.localeCompare(b.manifest.id));
+
+  // PLT-16: at most one plugin may serve the public /api/* namespace. Fail
+  // loudly rather than picking one non-deterministically at request time.
+  const { duplicates } = findApiProvider(plugins.map((p) => p.manifest));
+  if (duplicates.length > 1) {
+    console.error(
+      '[generate] more than one plugin declares apiProvider: true — exactly one ' +
+        'API provider is allowed per instance (PLT-16):',
+    );
+    for (const m of duplicates) console.error(`  - ${m.id}`);
+    process.exit(1);
+  }
+
   return plugins;
 }
 


### PR DESCRIPTION
## What and why

Reserves the top-level `/api/*` namespace for plugin-served public APIs and delegates it to a single registered provider plugin (**PLT-16**) — the platform prerequisite for the API Composer plugin's generated REST/GraphQL endpoints at `/api/<slug>/*`.

### The namespace split
The runtime already owns its own first-level `/api` segments (`account`, `admin`, `health`, `plugins`), so `/api/*` can't be blanket-delegated:
- **Reserved runtime segments** keep their existing (session-gated) handling.
- **Public namespace** = `/api/<slug>/*` for any other slug — handled **before** the session gate (unauthenticated; the provider owns auth, e.g. API keys), rewritten to the provider's serve route `<routePrefix>/serve/<slug>/<path>` (query string preserved), or **404** when no enabled provider is installed.

### Provider registration
A plugin declares `apiProvider: true` in its manifest. **Exactly one per instance** — the generate script fails the build on a second one. `findApiProvider` in `@sovereignfs/manifest` is the shared resolver for both the build-time check and the runtime lookup.

### Anti-drift
`RESERVED_API_SEGMENTS` (`runtime/src/api-namespace.ts`) is pinned to the on-disk `runtime/app/api/*` dirs by a parity test, so a new runtime route can never silently become delegatable.

## Type of change
- [x] `feat` — new feature or capability

## SRS reference
PLT-16; §3.4 (PLT-02 session-redirect exemption); §5 manifest reference.

## Verification
- `pnpm format:check`, `pnpm lint`, `pnpm typecheck`, `pnpm build` — all green.
- `pnpm test` — new unit tests (`api-provider`, `api-namespace`) + the api-dir parity test; full suite green (SQLite 189 passed / 9 skipped; with local Postgres 198 passed / 0 skipped).
- **Two-provider guard:** setting `apiProvider: true` on two installed plugins makes `pnpm generate` exit non-zero with a clear message.
- **End-to-end** (throwaway provider plugin + `pnpm dev`, no session cookie):
  - `GET /api/blog/posts/1?q=1` → `200` echoed JSON, slug/path/query intact, **no** login redirect.
  - `GET /api/blog` (slug only) → handled via optional catch-all.
  - `GET /api/plugins` and `/api/account/prefs` (reserved) → still `307` → `/login`.
  - Remove the provider → `/api/blog/posts/1` → `404`.

## Notes
Version bumps: `@sovereignfs/manifest` 0.4.0 → 0.5.0, `runtime` 0.6.0 → 0.7.0. No new env vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)