### PR TITLE
Add skip-ci label toggle; document CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,15 +22,20 @@ defaults:
   run:
     shell: bash
 
-# Every job carries the same guard: skip while the PR is a draft, run once it is
-# marked ready for review (and on pushes thereafter). The guard always passes
-# when this workflow is invoked via workflow_call (no pull_request context), so
-# the publish gate still runs.
+# Every job carries the same guard: skip while the PR is a draft OR carries the
+# `skip-ci` label, run once it is marked ready for review without that label (and
+# on pushes thereafter). Because label add/remove is not in the trigger types,
+# toggling `skip-ci` takes effect on the next push/sync/reopen/ready, not on an
+# in-flight run. The guard always passes when this workflow is invoked via
+# workflow_call (no pull_request context), so the publish gate still runs.
 jobs:
   format:
     name: Format
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.draft == false &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-ci'))
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
@@ -39,7 +44,10 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.draft == false &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-ci'))
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
@@ -48,7 +56,10 @@ jobs:
   typecheck:
     name: Typecheck
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.draft == false &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-ci'))
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
@@ -57,7 +68,10 @@ jobs:
   generate-validate:
     name: Generate & validate registry
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.draft == false &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-ci'))
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
@@ -70,7 +84,10 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.draft == false &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-ci'))
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
@@ -79,7 +96,10 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.draft == false &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-ci'))
     # A throwaway Postgres so the env-gated *.pg.test.ts parity suites run in CI
     # instead of skipping (NFR-03). SQLite tests need no service.
     services:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,8 @@ docker rm -f sov-test-pg
 ```
 
 These tests drop and recreate their own tables, so point them only at a
-disposable database. CI gains a Postgres service that runs them in Task 0.5.07.
+disposable database. CI runs them too — its `test` job starts a Postgres service
+and sets `TEST_DATABASE_URL`, so the parity suites execute on every PR.
 
 ---
 
@@ -129,6 +130,29 @@ Co-Authored-By: Claude Code <noreply@anthropic.com>
 - PRs are merged with **rebase and merge** — no squash, no merge commits.
 - Fix commit messages before the PR is merged; correcting them after means
   rewriting `main`.
+
+### Continuous integration
+
+CI runs automatically on every pull request targeting `main`
+(`.github/workflows/ci.yml`). There is no push-to-`main` trigger — `main` is
+validated pre-merge by the PR. Six jobs run in parallel:
+
+| Job                 | Checks                                                             |
+| ------------------- | ------------------------------------------------------------------ |
+| `format`            | `prettier --check`                                                 |
+| `lint`              | ESLint (incl. the SDK import-boundary rule)                        |
+| `typecheck`         | `tsc --noEmit` across the workspace                                |
+| `generate-validate` | `pnpm generate` (manifest validation) + the generated registry TS  |
+| `build`             | `turbo build` (production)                                         |
+| `test`              | `vitest run` with a Postgres service (runs the `*.pg.test.ts` too) |
+
+**While a PR is a draft, all jobs are skipped** — marking it _Ready for review_
+runs them. To skip CI on demand you have three options:
+
+- keep the PR a **draft**;
+- add the **`skip-ci` label** to the PR (takes effect on the next push, since a
+  label change alone does not re-trigger the workflow);
+- put **`[skip ci]`** (or `[ci skip]`, `[no ci]`) in the head commit message.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Sovereign
 
+[![CI](https://github.com/sovereignfs/sovereign/actions/workflows/ci.yml/badge.svg)](https://github.com/sovereignfs/sovereign/actions/workflows/ci.yml)
+
 Sovereign is a modular, self-hostable workspace runtime for running personal or
 organisational software under one roof. It provides the shared platform pieces
 applications need — authentication, data access, email, and UI — while allowing
@@ -82,7 +84,8 @@ bin/sv            the sv CLI
 - [Upgrade guide](docs/upgrade.md) — versioned changes, migration notes, and
   compatibility guidance.
 - [Contributing](CONTRIBUTING.md) — development workflow, project conventions,
-  and contribution expectations.
+  and contribution expectations. CI runs the full check suite on every
+  (non-draft) pull request.
 - [Concept · Plan · SRS](docs/sovereign-proposal-plan-srs.md) and the
   [implementation task breakdown](docs/sovereign-implementation-tasks.md) —
   product specification, scope, and implementation roadmap.


### PR DESCRIPTION
## What and why

Follow-up to the CI pipeline: gives contributors a per-PR way to disable CI on a PR that is already _Ready for review_, and documents CI properly.

### `skip-ci` label toggle (`.github/workflows/ci.yml`)
Each job's guard now also skips when the PR carries the **`skip-ci`** label, alongside the existing draft skip and the `workflow_call` pass-through:

```yaml
if: >-
  github.event_name != 'pull_request' ||
  (github.event.pull_request.draft == false &&
   !contains(github.event.pull_request.labels.*.name, 'skip-ci'))
```

A label change alone is not in the trigger `types`, so toggling `skip-ci` takes effect on the **next push/sync/reopen/ready** — intentional, to avoid noisy re-runs on every label change.

So there are now three ways to skip CI per PR: keep it a **draft**, add the **`skip-ci` label**, or put **`[skip ci]`** in the head commit.

### Docs
- `CONTRIBUTING.md`: fixed the stale "in Task 0.5.07" note (CI runs the Postgres parity tests today) and added a **Continuous integration** subsection — the six jobs, the PR-only trigger, the draft skip, and the three skip methods.
- `README.md`: CI status badge + a note that CI runs on every non-draft PR.

> **Badge caveat:** because CI is PR-only (no `push: main` trigger, by design), the badge reflects the workflow's latest run and may show "no status" against `main` until a run is associated with the default branch. Accepted cosmetic trade-off of the PR-only policy.

## Type of change
- [x] `chore` — tooling, scaffolding, dependencies, maintenance

## Verification
- `pnpm format:check` passes.
- This PR is itself the live test of the label toggle (add `skip-ci` + push → jobs skip; remove + push → jobs run; draft → jobs skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)