### PR TITLE
Overlay dialogs start at the sidebar edge, not the viewport edge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,7 +200,12 @@ iterable`. The slot's hand-written `@modal/default.tsx` (empty fallback) and
   `Dialog` renders **fixed-size boxes** (each size sets width AND height, content
   scrolls inside) so the dialog never resizes as its content changes between
   tabs — `lg` fills the viewport minus a fixed margin, `md`/`sm` are fixed and
-  centred; on mobile every size is a full-screen sheet.
+  centred; on mobile every size is a full-screen sheet. The `Dialog` scrim is
+  full-viewport by default but offsets its left edge by the
+  `--sv-dialog-inset-left` CSS var (default `0`); the shell sets it to the
+  sidebar width (`--sv-shell-sidebar-width`, reset to `0` on mobile) on `.shell`
+  so overlay dialogs start at the sidebar's right edge and leave the rail
+  visible/usable — never hardcode the sidebar width into the `Dialog`.
 - **`adminOnly` routes are gated in the runtime middleware.** A request under an
   admin-only plugin's `routePrefix` from a non-`platform:admin` user returns 403
   (SRS §3.4, PLT-03).

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sovereignfs/ui",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "description": "Sovereign Design System — design tokens and React components.",
   "license": "AGPL-3.0-or-later",

--- a/packages/ui/src/components/Dialog/Dialog.module.css
+++ b/packages/ui/src/components/Dialog/Dialog.module.css
@@ -7,11 +7,19 @@
  * while the panel and its close button stay put. The scrim's padding is the
  * fixed margin `lg` leaves around the viewport; `sm`/`md` are centered and cap
  * to that available space on short screens. On mobile every size becomes a
- * full-screen sheet. */
+ * full-screen sheet.
+ *
+ * `--sv-dialog-inset-left` lets a host inset the scrim past a fixed left nav
+ * rail (e.g. the platform sidebar) so the overlay's left margin is measured
+ * from the rail, not the viewport edge, and the rail stays visible/usable.
+ * Defaults to 0 (full-viewport scrim) for standalone use. */
 
 .scrim {
   position: fixed;
-  inset: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: var(--sv-dialog-inset-left, 0);
   z-index: 100;
   display: flex;
   align-items: center;

--- a/runtime/app/(platform)/shell.module.css
+++ b/runtime/app/(platform)/shell.module.css
@@ -1,6 +1,10 @@
 .shell {
+  /* Single source for the sidebar width — fed to the grid and to the overlay
+     dialog's scrim inset so dialogs start at the sidebar's right edge. */
+  --sv-shell-sidebar-width: 64px;
+  --sv-dialog-inset-left: var(--sv-shell-sidebar-width);
   display: grid;
-  grid-template-columns: 64px 1fr;
+  grid-template-columns: var(--sv-shell-sidebar-width) 1fr;
   min-height: 100vh;
 }
 
@@ -99,6 +103,8 @@
 
 @media (max-width: 768px) {
   .shell {
+    /* No sidebar on mobile — overlay dialogs span the full width. */
+    --sv-dialog-inset-left: 0;
     grid-template-columns: 1fr;
     grid-template-rows: auto 1fr auto;
   }

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sovereignfs/runtime",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Follow-up to the overlay shell mode (RFC 0001). The lg overlay dialog opens at the right size, but its scrim was fixed to the full viewport (`inset: 0`), so the **left margin was measured from the window edge** and the scrim dimmed the platform sidebar. This measures the left margin from the sidebar's right edge instead, leaving the nav rail visible and usable.

## Changes

- **`@sovereignfs/ui` Dialog** — the scrim's left edge is offset by a new `--sv-dialog-inset-left` CSS var (defaults to `0`, so standalone use is unchanged); top/right/bottom stay pinned to the viewport. The host can inset the scrim past a fixed left nav rail.
- **Runtime shell** — the sidebar width is hoisted into `--sv-shell-sidebar-width` (single source for the grid column) and fed to `--sv-dialog-inset-left` on `.shell`, reset to `0` in the `≤768px` breakpoint where the sidebar is hidden.

## Verification

Live-checked in the browser:
- Desktop: scrim starts at the sidebar's right edge (64px), scrim width = viewport − sidebar, panel left margin measured from the sidebar; the rail stays undimmed and clickable.
- `<768px`: sidebar hidden, scrim spans the full width (no phantom offset).

`format` / `lint` / `typecheck` clean; 205 tests pass.

Versions: `@sovereignfs/ui` 0.4.0 (additive CSS hook), `runtime` 0.9.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)