### PR TITLE
fix: read platform version from package.json in admin health route

### DIFF
--- a/runtime/app/api/admin/health/route.ts
+++ b/runtime/app/api/admin/health/route.ts
@@ -1,10 +1,10 @@
 import { statSync } from 'node:fs';
 import { NextResponse } from 'next/server';
 import { pingDb, resolveDialect, resolveSqlitePath } from '@sovereignfs/db';
-import { sdk } from '@sovereignfs/sdk';
 import { checkAdminKey } from '@/src/admin-guard';
 import { getPlatformDb } from '@/src/db';
 import { getIncompatiblePlugins } from '@/src/plugin-compat';
+import { getPlatformVersion } from '@/src/platform-version';
 
 const AUTH_URL = process.env.SOVEREIGN_AUTH_URL ?? 'http://localhost:3001';
 
@@ -59,7 +59,7 @@ export async function GET(request: Request): Promise<Response> {
   }));
 
   const report: HealthReport = {
-    platformVersion: (await sdk.platform.getConfig()).version,
+    platformVersion: getPlatformVersion(),
     database: { dialect: resolved.dialect, status: dbStatus, sizeBytes },
     auth: { status: authStatus },
     incompatiblePlugins,

--- a/runtime/src/boot-compat.ts
+++ b/runtime/src/boot-compat.ts
@@ -7,21 +7,11 @@
  * middleware gate treats them as disabled) and their reasons are stored in the
  * in-memory `plugin-compat.ts` module (read by the health + admin API routes).
  */
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
-import { findWorkspaceRoot, getPlatformDb, setPluginEnabled } from '@sovereignfs/db';
+import { getPlatformDb, setPluginEnabled } from '@sovereignfs/db';
 import { checkCompatibility } from '@sovereignfs/manifest';
 import { getInstalledPlugins } from './registry';
 import { markIncompatible, recordWarnings } from './plugin-compat';
-
-function getPlatformVersion(): string {
-  try {
-    const raw = readFileSync(join(findWorkspaceRoot(), 'package.json'), 'utf8');
-    return (JSON.parse(raw) as { version?: string }).version ?? '0.0.0';
-  } catch {
-    return '0.0.0';
-  }
-}
+import { getPlatformVersion } from './platform-version';
 
 export async function checkBootCompatibility(): Promise<void> {
   const platformVersion = getPlatformVersion();

--- a/runtime/src/platform-version.ts
+++ b/runtime/src/platform-version.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { findWorkspaceRoot } from '@sovereignfs/db';
+
+/** Reads the platform version from the root package.json. Returns '0.0.0' on any failure. */
+export function getPlatformVersion(): string {
+  try {
+    const raw = readFileSync(join(findWorkspaceRoot(), 'package.json'), 'utf8');
+    return (JSON.parse(raw) as { version?: string }).version ?? '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}


### PR DESCRIPTION
## Summary

- `GET /api/admin/health` was returning 500 because it called `sdk.platform.getConfig()` to read the platform version. That goes through `requireHost()`, which throws `"no runtime host is registered"` — the SDK host singleton set in `instrumentation.ts` is not shared with API route module contexts (a Next.js module isolation boundary).
- Extracted `getPlatformVersion()` into a new shared helper `runtime/src/platform-version.ts` — reads directly from the root `package.json` via `findWorkspaceRoot()`, the same pattern already used in `runtime/src/sdk-host.ts` and the generate scripts.
- Health route now imports this helper and drops its `@sovereignfs/sdk` import entirely.
- `runtime/src/boot-compat.ts` previously had an identical inline copy of the same function; it now imports the shared one instead.

## Test plan

- [ ] `curl http://localhost:3000/api/admin/health -H "Authorization: Bearer <SOVEREIGN_ADMIN_KEY>"` returns 200 with a valid JSON report including `platformVersion`
- [ ] Console → System Health page loads without error
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)