### PR TITLE
docs: post-v1 planning — RFC 0027, RFC 0028, Storybook task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,5 +55,9 @@ runtime/public/fallback-*.js
 .claude/settings.local.json
 .claude/launch.json
 
+# Claude Code memory — private persistent context for the AI assistant.
+# Machine-local; never committed (would conflict across sessions/users).
+memory/
+
 # OS
 .DS_Store

--- a/docs/rfcs/0027-white-labeling.md
+++ b/docs/rfcs/0027-white-labeling.md
@@ -1,10 +1,10 @@
 # RFC 0027 — White-labeling (tenant branding)
 
-**Status:** Draft\
+**Status:** Accepted\
 **Date:** June 2026\
-**Author:** Open Code\
+**Author:** kasunben\
 **Scope:** Whole platform — `packages/ui`, `packages/db`, `runtime`, `apps/auth`, `packages/mailer`, `bin/sv`, `.env.example`, docs, Docker/compose, SRS\
-**Incorporated into plan:** No — documentation-first. This RFC describes the design for per-tenant white-labeling (visual + email tier); implementation tasks and SRS sections to be assigned when scheduled.
+**Incorporated into plan:** Yes — post-v1. SRS §3.18 documents the architecture; roadmap Tasks 1.0.03 (Phase 1: DB + shell + Console form + SDK), 1.0.04 (Phase 2: email + auth login), and 1.0.05 (Phase 3: dynamic PWA manifest + favicon) schedule the implementation.
 
 ---
 

--- a/docs/rfcs/0028-operator-fork-model.md
+++ b/docs/rfcs/0028-operator-fork-model.md
@@ -1,0 +1,435 @@
+# RFC 0028 — Operator Fork Model & Upstream Sync
+
+**Status:** Draft\
+**Date:** June 2026\
+**Author:** kasunben\
+**Scope:** `docs/`, `operator/` directory convention — no code changes, no new runtime surfaces, no version bumps\
+**Incorporated into plan:** No — documentation-first. This RFC defines the operator fork model; implementation tasks (docs updates + any tooling follow-on) to be assigned when scheduled.
+
+---
+
+## Summary
+
+Most Sovereign operators should never fork the source — environment variables,
+community plugins installed via `sv plugin add`, and the RFC 0027 branding system
+give them full control over their deployment without touching a single source
+file. This RFC documents the smaller group who genuinely need a fork: operators
+running custom private plugins compiled into the same image, and commercial OEMs
+building a white-labeled product for distribution under the dual-licensing model
+(§2.7).
+
+The fork model has one overriding rule — **never modify upstream files**. Custom
+code lives in a dedicated `operator/` layer and `plugins/<operator-id>/`
+directories. Because the operator's additions never share paths with upstream
+files, `git rebase upstream/main` applies every upstream release without
+conflict. This is the git-level expression of the SDK boundary rule: just as
+plugins must not import from `runtime/src`, fork operators must not modify files
+owned by upstream. Respecting this boundary means the fork can track upstream
+indefinitely, picking up security patches and features with a single rebase
+command.
+
+## Motivation
+
+Sovereign's positioning as a "modular, self-hostable workspace runtime" and its
+AGPL + commercial dual-license model (§2.7) both point toward a world where
+organisations and commercial builders extend the platform with their own code.
+Three groups feel the gap today:
+
+- **Organisations** deploying Sovereign internally who want to commit proprietary
+  plugins to a private fork alongside the platform, then deploy one coherent
+  image without an external clone step at build time.
+- **Commercial OEM builders** constructing a white-labeled product for
+  distribution on top of Sovereign core — they need a private (or public) fork
+  that they can brand and release under a different name.
+- **Ambitious self-hosters** who want to pin one or two private plugins alongside
+  the platform and still receive upstream security fixes promptly.
+
+All three share the same problem: no documented strategy for structuring the fork
+so it does not diverge, and no documented process for pulling upstream changes
+without conflict.
+
+RFC 0006 (§3.15) defines the upgrade path for config-only operators (pull
+versioned images, expand-contract migrations, `sv backup`/`restore`) but assumes
+no source divergence. RFC 0027 (§3.18) defines the branding surface but says
+nothing about the git workflow. This RFC fills both gaps.
+
+## Current state
+
+### Existing operator customisation surface (no fork needed)
+
+```
+.env                             ← secrets and per-deployment config (gitignored)
+sovereign.plugins.json           ← declares community plugins to clone at install time
+```
+
+Operators can:
+
+- Configure via `BRAND_*`, `DATABASE_URL`, `SMTP_*`, `AUTH_*` env vars
+- Add community plugins with `sv plugin add <repo>` (clones into `plugins/<id>/`)
+- Control installed plugins and root plugin from Console
+- (Post RFC 0027) Upload logos and configure branding entirely via Console
+
+`.gitignore` already ignores `/plugins/*/` except the three platform plugins
+(`account`, `console`, `launcher`) — the foundation for a custom plugin layer
+exists but no convention governs it.
+
+### Existing upgrade guidance
+
+RFC 0006/§3.15 documents a pull-based upgrade path (versioned Docker images,
+expand-contract migrations, `sv backup`/`restore`, tag-pinned rollback). This
+path assumes operators pull from upstream's image registry without source changes.
+It does not cover fork-and-track scenarios.
+
+### Existing open-source model
+
+§2.7 states:
+
+- Runtime and core plugins: AGPL-3.0
+- SDK and shared packages: MIT
+- Third-party (community) plugins: any license
+- Commercial dual-license available for organisations needing private deployment
+  without AGPL source-disclosure obligations
+
+AGPL triggers on **distribution**, not self-hosted use. A private fork deployed
+internally incurs no AGPL obligation; distributing a modified Sovereign to others
+requires either AGPL source disclosure or the commercial license.
+
+## Proposed design
+
+### Track 1 — Config-only (the recommended default)
+
+No fork. Operators use pre-built Docker images pinned by `SOVEREIGN_VERSION`,
+configure entirely through env vars and Console, and install community plugins
+via `sv plugin add` or `sovereign.plugins.json`. This track requires zero source
+changes and survives every upstream release with `docker compose pull && docker compose up -d`.
+
+**Operators should start here and only escalate to Track 2 when they have a
+specific need that Track 1 cannot meet.** The two legitimate escalation reasons
+are:
+
+1. Custom plugins that must be compiled into the same image (not cloned from an
+   external repo at build time) — typically for air-gapped environments or
+   proprietary plugins whose source cannot be hosted publicly even temporarily.
+2. Commercial OEM distribution — the operator is building a derivative product to
+   distribute, not just deploying for themselves.
+
+Everything else — branding, custom installed plugins, tenant settings, root
+plugin — is satisfied by Track 1.
+
+### Track 2 — Fork-and-track
+
+#### Initial setup
+
+```bash
+# 1. Fork sovereignfs/sovereign on GitHub (public or private per your AGPL posture)
+# 2. Clone your fork locally
+git clone https://github.com/<org>/sovereign-fork
+cd sovereign-fork
+
+# 3. Track upstream as a named remote
+git remote add upstream https://github.com/sovereignfs/sovereign
+git fetch upstream
+```
+
+#### The isolation principle
+
+The fork model rests on a single rule enforced by convention:
+
+> **Operators never modify upstream-owned files. They only add new files in the
+> fork-safe zone.**
+
+This is the direct git equivalent of the SDK boundary rule (`no-restricted-imports`
+blocks `runtime/src` imports in plugins). Both rules have the same justification:
+crossing the boundary makes the component unmaintainable in the long run.
+
+The file taxonomy:
+
+| Zone            | Paths                                                                                                                                                                                                                                                    | Rule                                                                                                                                                                                            |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Core-locked** | `runtime/`, `packages/`, `apps/`, `scripts/`, `bin/`, `plugins/account/`, `plugins/console/`, `plugins/launcher/`, `turbo.json`, `eslint.config.ts`, `prettier.config.ts`, `vitest.config.ts`, `pnpm-workspace.yaml`, `.github/workflows/` (upstream CI) | Never modify. Owned by upstream. Any edit here creates a conflict on the next rebase and signals a design problem — the right answer is almost always a community plugin or a new upstream RFC. |
+| **Fork-safe**   | `plugins/<operator-id>/`, `operator/`, `sovereign.plugins.json` (additions only), `.env.example` (additions only), `.github/workflows/<operator>-*.yml` (operator CI only), `registry/` (additions only)                                                 | Operator-owned. Safe to add files freely. Upstream never creates files at these paths.                                                                                                          |
+
+When the isolation principle is respected, `git rebase upstream/main` produces
+zero conflicts because the two path sets are disjoint.
+
+#### The `operator/` directory
+
+Every fork should have a committed `operator/` directory containing the operator
+layer. Its structure:
+
+```
+operator/
+├── OPERATOR.md                   # fork identity, purpose, plugin list, AGPL note
+├── UPSTREAM                      # plain text: upstream tag this fork is based on
+└── docker-compose.override.yml   # deployment overrides (optional)
+```
+
+**`operator/UPSTREAM`** — updated by the operator after each successful upstream
+sync. A single line: the upstream tag (e.g. `v1.3.0`) or commit SHA. Serves as
+the machine-readable source of truth for which upstream version the fork tracks,
+enabling a future `sv fork check` command to flag if the fork is behind.
+
+**`operator/OPERATOR.md`** — a human-readable record of the fork:
+
+```markdown
+# <Org> Sovereign Fork
+
+**Upstream:** sovereignfs/sovereign  
+**Based on:** see `operator/UPSTREAM`  
+**Purpose:** Internal deployment with proprietary CRM integration plugin
+
+## Custom plugins
+
+| Plugin ID          | Location                    | License     |
+| ------------------ | --------------------------- | ----------- |
+| `com.acme.crm`     | `plugins/com.acme.crm/`     | Proprietary |
+| `com.acme.billing` | `plugins/com.acme.billing/` | Proprietary |
+
+## AGPL compliance
+
+This fork is deployed internally and not distributed externally.
+No AGPL source-disclosure obligation applies.
+For distribution scenarios, contact the Sovereign maintainers for the
+commercial dual-license (see docs/sovereign-proposal-plan-srs.md §2.7).
+
+## Contacts
+
+Maintainer: platform-team@acme.com
+```
+
+**`operator/docker-compose.override.yml`** — Docker Compose natively merges an
+`override` file with the base `docker-compose.yml`. Operators can use this to
+customise service definitions (resource limits, extra volumes, network names)
+without touching `docker-compose.yml` or `docker-compose.prod.yml`. Example:
+
+```yaml
+# operator/docker-compose.override.yml
+services:
+  runtime:
+    environment:
+      BRAND_NAME: 'Acme Workspace'
+    deploy:
+      resources:
+        limits:
+          memory: 2g
+```
+
+Apply with: `docker compose -f docker-compose.prod.yml -f operator/docker-compose.override.yml up -d`
+
+#### Custom plugins in the fork
+
+Operator plugins live in `plugins/<reverse-dns-id>/` — the community plugin
+pattern (`type: "community"` in `manifest.json`). No new tooling is needed;
+`pnpm generate` picks them up automatically since it scans all `plugins/*/`.
+
+Because upstream plugin directories all use the `fs.sovereign.*` and
+`io.openfs.sovereign.*` naming conventions, and operator plugins use their own
+reverse-DNS IDs, the paths never collide.
+
+**Update `.gitignore` to unignore your custom plugins:**
+
+```gitignore
+# .gitignore — add alongside the existing platform-plugin allowlist:
+!/plugins/com.acme.crm/
+!/plugins/com.acme.billing/
+```
+
+Custom plugins are full community plugins: they use `@sovereignfs/sdk` and
+`@sovereignfs/ui` only (the SDK boundary rule applies to them too), declare their
+own permissions and `minPlatformVersion`, and appear in the Launcher grid and
+sidebar like any installed plugin. They can be any license — they are not subject
+to AGPL copyleft because they only import the MIT-licensed SDK and design system.
+
+#### Asset management
+
+**Pre-RFC 0027 (today):** Operators who need a custom logo or favicon can commit
+them to `operator/assets/` (never to `runtime/public/` — that is core-locked).
+A thin community plugin with a static asset route (`GET /my-brand/logo`) serves
+them before the RFC 0027 branding infrastructure exists.
+
+**Post-RFC 0027 (recommended):** Upload assets via the Console branding form.
+They are stored in `data/brand/` (the named volume) and served by `/api/brand/*`.
+Nothing is committed to the fork. This is the canonical path once RFC 0027 ships
+and eliminates the need for the pre-RFC workaround entirely.
+
+#### Upstream sync workflow
+
+```bash
+# Run this after each Sovereign upstream release:
+
+# 1. Fetch latest upstream history
+git fetch upstream
+
+# 2. Rebase the fork's commits on top of the new upstream main
+git rebase upstream/main
+# Expected result when isolation principle is respected: zero conflicts.
+# A conflict means a core-locked file was modified — fix by reverting the
+# operator's change and expressing the intent as a community plugin or RFC instead.
+
+# 3. Record the synced upstream version
+git tag -l 'v*' upstream/main | sort -V | tail -1   # or note the tag manually
+echo "v1.3.0" > operator/UPSTREAM
+git add operator/UPSTREAM
+git commit -m "chore: sync with upstream v1.3.0"
+
+# 4. Push the rebased fork (force-push is required after a rebase;
+#    use with care on a shared branch — coordinate with your team)
+git push --force-with-lease origin main
+
+# 5. Deploy using the standard upgrade procedure (RFC 0006 §3.15):
+sv backup
+docker compose -f docker-compose.prod.yml pull
+docker compose -f docker-compose.prod.yml up -d
+```
+
+The rebase strategy is preferred over merge because it keeps the fork's history
+linear (operator commits always appear after upstream commits), makes individual
+upstream changes easy to inspect with `git log upstream/main..HEAD`, and avoids
+merge commits that obscure the upgrade boundary.
+
+#### When you hit a conflict
+
+A conflict on `git rebase upstream/main` means one of two things:
+
+1. **A core-locked file was modified by the fork** — almost always wrong. Identify
+   what the fork was trying to achieve and express it as a community plugin, a
+   new env var, or an upstream RFC instead. Then revert the core-locked change
+   before the next sync.
+
+2. **Upstream renamed or removed a fork-safe file** — rare (upstream almost never
+   touches `operator/` or community plugin directories). Resolve normally.
+
+If a conflict is unavoidable (e.g. `sovereign.plugins.json` — both the fork and
+upstream added entries), resolve by keeping both sets of entries and committing
+the merged result.
+
+### AGPL compliance reference
+
+| Scenario                                                            | Obligation                                                                       |
+| ------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| Private fork, self-hosted internally, not distributed               | None. AGPL triggers on distribution, not private use.                            |
+| Hosting a modified Sovereign as a service for external users (SaaS) | Must publish all source changes under AGPL **or** obtain the commercial license. |
+| Building and distributing a white-labeled product                   | Requires the commercial dual-license (§2.7 — contact maintainer).                |
+
+Custom community plugins (`plugins/<operator-*>/`) carry no AGPL obligation
+regardless of scenario — they use only the MIT-licensed `@sovereignfs/sdk` and
+`@sovereignfs/ui`, and the AGPL copyleft does not propagate through the SDK
+boundary into plugins.
+
+Operators should include a brief AGPL note in `operator/OPERATOR.md` describing
+their compliance posture (as shown in the template above).
+
+## UI flows
+
+### Fork setup flow (one-time)
+
+1. Fork on GitHub → clone locally → `git remote add upstream` → `git fetch upstream`.
+2. Create `operator/UPSTREAM` (set to the current upstream tag).
+3. Create `operator/OPERATOR.md` (fill in purpose, plugin list, AGPL note).
+4. Add custom plugin directories under `plugins/<operator-id>/`; update `.gitignore` allowlist.
+5. `pnpm install && pnpm generate` — verify the new plugins compose correctly.
+6. Push to your fork's remote.
+
+### Upstream sync flow (per release)
+
+1. Check `operator/UPSTREAM` to see which version was last synced.
+2. Read the Sovereign release notes / `docs/upgrade.md` for the new version.
+3. `sv backup` — snapshot before the sync.
+4. `git fetch upstream && git rebase upstream/main` — apply upstream changes.
+5. Resolve any conflicts (see "When you hit a conflict" above).
+6. Update `operator/UPSTREAM`, commit, push.
+7. `docker compose pull && docker compose up -d` — deploy.
+
+## Alternatives considered
+
+### Git subtree instead of rebase
+
+`git subtree` embeds upstream history as a flattened blob, making it easy to
+pull updates but impossible to inspect individual upstream commits or cherry-pick
+specific fixes. The history becomes opaque. Rebase is more operationally complex
+(force-push required) but gives a transparent, inspectable history. For
+operators who sync with every release rather than cherry-picking, the rebase
+overhead is one command.
+
+### Operator plugins in a separate repo (installed at deploy time)
+
+This is exactly Track 1 with `sv plugin add` or `sovereign.plugins.json` entries
+pointing to the operator's private plugin repos. It is the right choice for
+operators who can reach the plugin repos from their build environment. Committing
+plugins to the fork is for operators who cannot (air-gapped environments, strict
+supply-chain controls) or who prefer a single-repo deployment artefact.
+
+### Package-based extension (operator publishes npm packages overriding runtime behaviour)
+
+Rejected. The SDK boundary rule (`no-restricted-imports` ESLint rule) prevents
+any code from importing `runtime/src` — including a hypothetical operator npm
+package. There is no plugin API for overriding middleware, shell chrome, or auth
+logic because that would break the isolation that makes upgrades safe. Any need
+to change core behaviour at that level should be proposed as an upstream RFC.
+
+### A `sv fork sync` CLI command
+
+Deferred. The sync workflow is three git commands and one shell command. A
+wrapper adds surface area without enough benefit at this stage. A `sv fork check`
+command (warn when `operator/UPSTREAM` is behind the newest upstream tag) would
+be more useful and is a natural follow-on once the convention is established.
+
+### Monorepo split (fork the runtime only, plugins in sibling repos)
+
+Some projects split the platform and its plugins into separate repositories and
+use git submodules or workspace references to compose them. This adds tooling
+complexity (submodule churn on every upstream bump) without meaningful benefit
+for an operator who just wants to add one or two private plugins. The
+`plugins/<operator-id>/` convention achieves the same result without submodules.
+
+## Open questions
+
+1. **`operator/UPSTREAM` format: plain text or JSON?** Plain text (single version
+   tag line) is recommended now — simple to write, simple to read. A future
+   `sv fork check` command can parse it. If structured metadata is later needed
+   (pinned ref per plugin, minimum platform version the fork supports, etc.) it
+   can evolve to JSON without breaking existing forks.
+
+2. **Generate script integrity check** — should `pnpm generate` warn when it
+   detects that core-locked files (e.g. `runtime/src/`) have been modified since
+   the upstream version recorded in `operator/UPSTREAM`? This could be
+   implemented by hashing the core-locked tree at each upstream tag and comparing
+   at generate time. Deferred: the CI approach (running upstream's own test suite
+   against the fork) catches violations more robustly, and the hash approach adds
+   complexity to the generate script that most operators will never need.
+
+3. **`docker-compose.override.yml` location** — `operator/docker-compose.override.yml`
+   requires the operator to pass `-f operator/docker-compose.override.yml` on
+   every `docker compose` invocation. An alternative is placing it at the repo
+   root as `docker-compose.override.yml` (Docker Compose automatically merges a
+   file with that name). The automatic merge is convenient but means a single
+   override file must serve all compose targets (dev, prod, postgres overlay).
+   The `operator/` convention keeps the operator layer clearly separated. The
+   recommended upgrade docs can show both.
+
+## Adoption path
+
+This RFC is **documentation-first**. No code changes ship with the RFC. All
+deliverables are documents.
+
+| Phase  | Deliverable                                                                           | Status              |
+| ------ | ------------------------------------------------------------------------------------- | ------------------- |
+| 1      | `docs/rfcs/0028-operator-fork-model.md` (this file)                                   | Documentation-first |
+| 1      | `docs/self-hosting.md` — "Maintaining a fork" section                                 | Documentation-first |
+| 1      | `docs/rfcs/README.md` — new row                                                       | Documentation-first |
+| 1      | `docs/sovereign-proposal-plan-srs.md` — §2.7 pointer + decision-log row               | Documentation-first |
+| Future | `sv fork check` command — warns when `operator/UPSTREAM` lags the newest upstream tag | Optional follow-on  |
+
+### Required doc updates
+
+- `docs/self-hosting.md` — a new "Maintaining a fork" section summarising the
+  two tracks and the upstream sync workflow (this RFC as the authoritative source)
+- `docs/sovereign-proposal-plan-srs.md` — §2.7 Open Source Strategy gains a
+  pointer to this RFC; one decision-log row
+- `docs/rfcs/README.md` — new row for RFC 0028
+
+## Changelog
+
+| Version | Date      | Change        |
+| ------- | --------- | ------------- |
+| 0.1     | June 2026 | Initial draft |

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -36,4 +36,5 @@ for the full process.
 | [0024](0024-plugin-compatibility.md)             | Plugin compatibility & versioning     | Accepted             | Yes — Task 0.5.21                                            |
 | [0025](0025-accessibility.md)                    | Accessibility (WCAG 2.1 AA)           | Accepted             | Yes — Task 0.5.28                                            |
 | [0026](0026-non-docker-deployment.md)            | Non-Docker production deployment      | Accepted             | Yes (phased) — Task 0.5.29 (Phase 1) + Task 1.0.09 (Phase 2) |
-| [0027](0027-white-labeling.md)                   | White-labeling (tenant branding)      | Draft                | No — design only, scheduling deferred                        |
+| [0027](0027-white-labeling.md)                   | White-labeling (tenant branding)      | Accepted             | Yes (phased) — Tasks 1.0.03 + 1.0.04 + 1.0.05                |
+| [0028](0028-operator-fork-model.md)              | Operator fork model & upstream sync   | Draft                | No — documentation-first                                     |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1605,42 +1605,6 @@ supported path to production.
 
 ---
 
-#### Task 0.8.03 — Non-Docker production deployment, Phase 2 — systemd (RFC 0026) **[post-v1]**
-
-**Goal:** Add systemd as a zero-extra-dependency alternative to PM2 for Linux
-server operators (RFC 0026 Phase 2). Phase 1 (PM2) must ship first.
-
-**Deliverables:**
-
-- `bin/sv.ts`: `sv setup systemd [--user <user>] [--dir <dir>] [--env-file <path>]`
-  sub-command writing two pre-filled unit files to the current directory; template
-  logic in `bin/helpers.ts`; unit-tested
-- `docs/examples/sovereign-auth.service`, `docs/examples/sovereign-runtime.service`
-  — canonical unit files (same as `sv setup systemd` defaults): `User=sovereign`,
-  `WorkingDirectory=`, `EnvironmentFile=`, `HOSTNAME=127.0.0.1` on auth,
-  `ExecStartPre` health-poll on the runtime unit, `Restart=on-failure`
-- `docs/self-hosting.md`: "Non-Docker deployment (systemd)" section alongside the
-  PM2 section; covers account creation, `EnvironmentFile` setup, `systemctl enable`,
-  log access via `journalctl`, and the upgrade procedure
-- Document `sv serve` as a valid single-process target under either PM2 or systemd
-  (simplest path for minimal init systems)
-- SRS §3.1: systemd noted as the recommended Linux-native alternative to PM2
-
-**Dependencies:** Task 0.5.29 (Phase 1 — PM2 and `sv serve` health-gate must be
-in place)
-
-**SRS reference:** RFC 0026 Phase 2, SRS §3.1
-
-**Review checklist:**
-
-- `sv setup systemd` produces two syntactically valid unit files with correct
-  `WorkingDirectory`, `EnvironmentFile`, `HOSTNAME`, and `ExecStartPre` health-poll
-- `systemctl start sovereign-runtime` waits for `sovereign-auth` to pass its health
-  check before the runtime process starts
-- `docs/self-hosting.md` systemd section is self-contained alongside the PM2 section
-
----
-
 ## v1
 
 The v1.0 release line and post-release work — net-new features, the capability
@@ -1693,6 +1657,221 @@ exploratory proposals (added as tasks but gated on RFC acceptance).
 - A dev-mode request reads only the mock DB; concurrent real requests are unaffected; nothing egresses
 
 ---
+
+#### Task 1.0.03 — White-labeling, Phase 1 — Brand DB + shell injection (RFC 0027) **[post-v1]**
+
+**Goal:** Let operators replace Sovereign's visual identity with their own brand. Phase 1 ships the data layer, CSS token namespace, runtime injection, and the Console branding form. Depends on the `tenant_branding` table and `BrandProvider` being in place before Phases 2 and 3.
+
+**Deliverables:**
+
+- `packages/db` → minor: `tenant_branding` table (dialect-aware DDL, bootstrapped by `bootstrapPlatformDb()` alongside the default-tenant seed); `getTenantBranding(pdb, tenantId)` (merges DB values over `BRAND_*` env defaults); `setTenantBranding(pdb, tenantId, partial)` (upsert; validates `brand_primary` as `/^#[0-9a-fA-F]{6}$/` before writing — raw user input must never reach a `<style>` block unchecked)
+- `packages/ui` → minor: `--sv-brand-logo`, `--sv-brand-logo-dark`, `--sv-brand-favicon` tokens added to `semantic.css` (separate namespace from `--sv-color-*` — brand tokens hold URLs, not colours; they are set once by the operator and do not change with dark mode or user prefs); documented in `docs/design-system.md`
+- `runtime` → minor: `BrandProvider` server component (`runtime/src/brand-provider.tsx`) — reads `tenant_branding`, merges env defaults, renders a `<style>` block setting `--sv-brand-*` tokens and (if `brandPrimary` set) `--sv-color-accent` / `--sv-color-accent-hover` (HSL lightness delta, `ACCENT_HOVER_LIGHTNESS_DELTA = 8`, clamped to stay in range); passes `brandName` as a React prop to children; called from `(platform)/layout.tsx`
+- `runtime` (continued): `GET /api/brand/logo[?dark=1]` and `GET /api/brand/favicon` routes serving uploaded files from `data/brand/` (MIME type validated, 2 MB cap); `POST /api/brand/logo` / `POST /api/brand/favicon` upload routes (admin-gated); all three excluded from the middleware session gate (must load on the login page)
+- `runtime` (continued): `GET /api/admin/tenant-branding` route — returns merged brand config (DB + env defaults) for the auth server proxy in Phase 2
+- `@sovereignfs/sdk` → minor: `sdk.platform.getConfig()` gains `brandName` (falls back to `tenantName`) and `brandPrimaryColor?` (validated hex or undefined), documented in `docs/plugin-development.md`
+- `plugins/console` → minor: new **Branding** section under `/console/settings/branding` — brand name input, logo upload (light + dark) or external URL, primary colour picker (validated hex client + server), favicon upload, email sender name, email logo URL; live preview panel (client-side CSS variable swap); PATCH writes to `tenant_branding`
+- New `BRAND_*` env vars added to `.env.example` and `docs/self-hosting.md`; `docs/plugin-development.md` documents `--sv-brand-*` token usage and the `getConfig()` branding fields
+
+**Dependencies:** Task 0.5.03 (Postgres), Task 0.5.05 (`sdk.platform`), Task 0.5.15 (CSP — `/api/brand/*` must be in the middleware exclusion list alongside `/api/health` and PWA assets)
+
+**SRS reference:** RFC 0027, SRS §3.18
+
+**Review checklist:**
+
+- Brand name set in Console renders in the sidebar header and login page instead of "Sovereign"
+- Uploading a logo serves it from `/api/brand/logo` on the login page (pre-auth, session gate excluded)
+- `brand_primary` write rejects any non-hex value; valid hex sets `--sv-color-accent` via `BrandProvider`
+- `sdk.platform.getConfig()` returns `brandName` and `brandPrimaryColor` (or undefined when unset)
+- `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, and docs-parity test pass
+
+---
+
+#### Task 1.0.04 — White-labeling, Phase 2 — Email templates + auth login page (RFC 0027) **[post-v1]**
+
+**Goal:** Extend white-labeling to outbound email and the auth server's login/registration page. Depends on Phase 1 (`tenant_branding` table and `/api/admin/tenant-branding` endpoint).
+
+**Deliverables:**
+
+- `packages/mailer` → minor: `MailOptions` gains `branding?: { name: string; logoUrl?: string }` parameter; email HTML templates use `branding.name` as the sender display name and render `<img src="logoUrl" alt="name">` with graceful text fallback (hosted URL, not `data:` URI — Gmail and most webmail clients refuse inline base64 images); `packages/mailer/CHANGELOG.md` updated; `docs/plugin-development.md` documents the `branding` option
+- `apps/auth` → minor: root layout fetches `GET <SOVEREIGN_AUTH_URL replaced with runtime>/api/admin/tenant-branding` at render time (proxy approach — one store, no dual-write); result cached in-process with a 60-second TTL to avoid a brand fetch on every login render; `BrandProvider` (duplicated into `apps/auth/src/brand-provider.tsx`, same pattern as the duplicated `security.ts`) renders brand tokens and brand name on the login and registration pages; on fetch failure the layout falls back to Sovereign defaults (graceful degradation)
+- Runtime invite and password-reset email routes pass branding from `getTenantBranding()` to the mailer
+
+**Dependencies:** Task 1.0.03 (Phase 1 — `tenant_branding` table and `/api/admin/tenant-branding` route must exist)
+
+**SRS reference:** RFC 0027 Phase 2, SRS §3.18
+
+**Review checklist:**
+
+- A branded instance shows the operator's logo and name on the login page (not "Sovereign")
+- Invite email renders the operator's sender name in the `From` header; logo `<img>` appears in supported clients; plain-text version uses the brand name
+- Auth server login page falls back to Sovereign defaults if the runtime is unreachable
+
+---
+
+#### Task 1.0.05 — White-labeling, Phase 3 — Dynamic PWA manifest + favicon route (RFC 0027) **[post-v1]**
+
+**Goal:** Extend white-labeling to the PWA manifest and favicon so the installed PWA shows the operator's app name and icons. Depends on Phase 1 (brand DB and serving routes).
+
+**Deliverables:**
+
+- `runtime` → minor: `GET /manifest.webmanifest` route — when branding is configured reads `tenant_branding` and returns a dynamic manifest with the operator's `name`, `short_name`, and icon URLs; when no branding is configured the static `runtime/public/manifest.json` continues to be served. Route is excluded from the middleware session gate (required for PWA installability)
+- `runtime` (continued): `GET /favicon.ico` route — returns the tenant's branded favicon when configured, falling back to `runtime/public/favicon.ico`; `runtime/app/layout.tsx` `<head>` metadata updated to point to the dynamic route unconditionally so the fallback is transparent
+- Document in `docs/self-hosting.md`: when branding changes, cached service-worker users see the old name/icons until the SW updates (known limitation, acceptable for v1)
+
+**Dependencies:** Task 1.0.03 (Phase 1 — branded logo served from `/api/brand/logo`; `tenant_branding` table)
+
+**SRS reference:** RFC 0027 Phase 3, SRS §3.18
+
+**Review checklist:**
+
+- `GET /manifest.webmanifest` returns the operator's brand name and icon URLs when configured; returns the static Sovereign manifest when unconfigured
+- `GET /favicon.ico` returns the operator's favicon when configured; falls back to the committed favicon
+- PWA installation on a branded instance shows the operator's name and icons in the OS launcher
+
+---
+
+#### Task 1.0.06 — Non-Docker production deployment, Phase 2 — systemd (RFC 0026) **[post-v1]**
+
+**Goal:** Add systemd as a zero-extra-dependency alternative to PM2 for Linux
+server operators (RFC 0026 Phase 2). Phase 1 (PM2) must ship first.
+
+**Deliverables:**
+
+- `bin/sv.ts`: `sv setup systemd [--user <user>] [--dir <dir>] [--env-file <path>]`
+  sub-command writing two pre-filled unit files to the current directory; template
+  logic in `bin/helpers.ts`; unit-tested
+- `docs/examples/sovereign-auth.service`, `docs/examples/sovereign-runtime.service`
+  — canonical unit files (same as `sv setup systemd` defaults): `User=sovereign`,
+  `WorkingDirectory=`, `EnvironmentFile=`, `HOSTNAME=127.0.0.1` on auth,
+  `ExecStartPre` health-poll on the runtime unit, `Restart=on-failure`
+- `docs/self-hosting.md`: "Non-Docker deployment (systemd)" section alongside the
+  PM2 section; covers account creation, `EnvironmentFile` setup, `systemctl enable`,
+  log access via `journalctl`, and the upgrade procedure
+- Document `sv serve` as a valid single-process target under either PM2 or systemd
+  (simplest path for minimal init systems)
+- SRS §3.1: systemd noted as the recommended Linux-native alternative to PM2
+
+**Dependencies:** Task 0.5.29 (Phase 1 — PM2 and `sv serve` health-gate must be
+in place)
+
+**SRS reference:** RFC 0026 Phase 2, SRS §3.1
+
+**Review checklist:**
+
+- `sv setup systemd` produces two syntactically valid unit files with correct
+  `WorkingDirectory`, `EnvironmentFile`, `HOSTNAME`, and `ExecStartPre` health-poll
+- `systemctl start sovereign-runtime` waits for `sovereign-auth` to pass its health
+  check before the runtime process starts
+- `docs/self-hosting.md` systemd section is self-contained alongside the PM2 section
+
+---
+
+#### Task 1.0.07 — Operator fork model & upstream sync (RFC 0028) **[post-v1]**
+
+**Goal:** Publish the operator fork model documentation and add the "Maintaining a fork" section to `docs/self-hosting.md`. This is a documentation-only task — no code, no version bumps.
+
+**Deliverables:**
+
+- `docs/rfcs/0028-operator-fork-model.md` — the RFC (already drafted)
+- `docs/self-hosting.md` — "Maintaining a fork" section: two-track summary (config-only vs fork-and-track), `operator/` directory convention, upstream sync command sequence, isolation principle, asset management guidance
+- `docs/sovereign-proposal-plan-srs.md` — §2.7 pointer + decision-log row (already added in RFC documentation pass)
+- `docs/rfcs/README.md` — RFC 0028 row updated from Draft to Accepted
+
+**Optional follow-on (separate task):** `sv fork check` CLI command — reads `operator/UPSTREAM`, compares against the latest upstream tag, and warns if the fork is behind.
+
+**Dependencies:** None hard. RFC 0027 (Task 1.0.03) should ship first so the "Post-RFC 0027 asset management" recommendation in the RFC is actionable.
+
+**SRS reference:** RFC 0028, SRS §2.7
+
+**Review checklist:**
+
+- `docs/self-hosting.md` "Maintaining a fork" section is self-contained; a reader can follow it from fork setup through first upstream sync without consulting the RFC
+- The two-track model, isolation principle, AGPL table, and rebase workflow are consistent between the RFC and the self-hosting doc
+- RFC 0028 status in `docs/rfcs/README.md` updated to Accepted
+
+---
+
+#### Task 1.0.08 — Storybook for the design system and app shell **[post-v1]**
+
+**Goal:** Give component authors, plugin developers, and designers a live, isolated environment to develop and inspect every `@sovereignfs/ui` component and its token context. Storybook 8 is the choice — it has native CSS Modules support (via `@storybook/nextjs`), the best a11y addon ecosystem, and wide team familiarity. No RFC is warranted: this is developer tooling with no runtime surfaces, no SDK changes, and no architectural trade-offs that need RFC-level documentation. The decision rationale is recorded in the SRS decision log.
+
+**Scope:**
+
+Phase 1 (this task) targets `packages/ui` exclusively. The `runtime` App Router shell uses React Server Components heavily — Storybook's RSC support is immature as of mid-2026; RSC stories are a follow-on tracked under "Optional extensions" below.
+
+**Deliverables:**
+
+- **Storybook installation (`packages/ui`):**
+  - `@storybook/nextjs` (Vite builder) + `storybook` CLI as devDependencies in `packages/ui/package.json`; versions pinned in the pnpm catalog (new `"storybook"` catalog entry, referenced as `"catalog:"`)
+  - `.storybook/main.ts` — framework: `@storybook/nextjs`, addons (see below), `stories` glob targeting `src/**/*.stories.tsx`
+  - `.storybook/preview.ts` — global decorator importing the full token stack (`primitives.css`, `semantic.css`); `data-theme` parameter wired so the themes addon toggles dark mode correctly
+  - `packages/ui/package.json` gains `"storybook": "storybook dev -p 6006"` and `"build-storybook": "storybook build --output-dir storybook-static"` scripts
+  - `packages/ui/.storybook/` added to `.prettierignore` (generated config files should not be linted)
+
+- **Addons:**
+  - `@storybook/addon-a11y` — accessibility panel; every story must pass WCAG 2.1 AA checks; a11y failures treated as errors in CI
+  - `@storybook/addon-viewport` — responsive preview (mobile 375px, tablet 768px, desktop 1280px presets matching the shell breakpoints)
+  - `@storybook/addon-themes` — single decorator toggles `[data-theme="dark"]` on the canvas root; eliminates the need for per-story dark variants
+  - `@storybook/addon-docs` — auto-generates prop tables from TypeScript types; used for `ComponentName.stories.tsx` `meta.parameters.docs` entries
+
+- **Token Gallery story (`src/stories/TokenGallery.stories.tsx`):**
+  - One story per token tier — Colour (semantic, both themes side-by-side), Space scale, Typography scale, Radius scale, Shadow scale, Icon sizes
+  - Reads CSS custom properties at render time via `getComputedStyle(document.documentElement)` — always reflects the actual loaded CSS, not a hardcoded snapshot
+  - Dark mode toggle shows both themes on the same canvas for comparison
+
+- **Component stories (one `*.stories.tsx` per component):**
+  - `Button` — all `variant` × `size` combinations; loading state; disabled; icon-only
+  - `Card` — default, with header/footer slots, interactive (clickable)
+  - `Input` — text/email/password types; error state; disabled; with label
+  - `Badge` — all variants
+  - `Dialog` — `sm`/`md`/`lg` sizes; `open`/`closed`; trigger interaction (Storybook `play` function using `@storybook/test`)
+  - `Drawer` — mobile breakpoint (viewport addon at 375px); open/closed; with list items
+  - `Icon` — full icon grid (all 26 names from `IconName`); `sm`/`md`/`lg` sizes; `aria-label` vs `aria-hidden` variants
+
+- **Monorepo integration:**
+  - `turbo.json`: add `"build-storybook"` to the `pipeline` with `dependsOn: ["^build"]` and `outputs: ["storybook-static/**"]`; Storybook dev (`pnpm storybook`) is not a Turborepo task — it runs ad-hoc
+  - Root `package.json` gains `"storybook": "pnpm --filter @sovereignfs/ui storybook"` and `"build-storybook": "pnpm --filter @sovereignfs/ui build-storybook"` scripts for convenience
+  - `storybook-static/` added to root `.gitignore`
+
+- **CI (`storybook-build` job in `.github/workflows/ci.yml`):**
+  - Runs `pnpm build-storybook` — catches stories that fail to compile or reference missing tokens
+  - Fails on a11y errors via `--test` flag (Storybook 8 CLI test mode)
+  - Runs on the same draft-PR exclusion logic as the existing jobs
+  - Uploads `storybook-static/` as a CI artifact (7-day retention) for PR preview inspection without deploying a Storybook hosting service
+
+- **Documentation:**
+  - `docs/design-system.md` gains a "Component stories (Storybook)" section: how to run (`pnpm storybook`), what the Token Gallery shows, how to add a story for a new component, the a11y policy
+  - `docs/plugin-development.md` notes that `@sovereignfs/ui` ships with Storybook stories developers can run locally to explore the component API
+
+**Optional extensions (follow-on tasks, not in scope here):**
+
+- **Visual regression testing (Chromatic):** requires a paid Chromatic account; added as a follow-on when the team is ready. The `build-storybook` CI artifact enables manual visual comparison in the interim.
+- **`runtime` client-component stories:** once Storybook's RSC story support matures, extend to `runtime/app/_components/` client components (avatar popover, `ActivePluginTitle`, `MobileNav`, etc.). Tracked as a future task.
+- **Plugin developer guide stories:** example stories shipped in `plugins/fs.sovereign.example-basic/` demonstrating how a plugin consumes `@sovereignfs/ui` components in Storybook.
+
+**Dependencies:** Task 0.3.07 (`packages/ui` scaffold must exist — ✅ already merged), Task 0.5.17 (Icon system — all `IconName` values needed for the Icon story — ✅ already merged)
+
+**Version impact:** `packages/ui` → **minor** (adds a new developer-facing capability; no breaking changes to the published component API)
+
+**SRS reference:** SRS §3.19 (design system tooling), NFR-10 (documentation completeness)
+
+**Review checklist:**
+
+- `pnpm storybook` starts the dev server at `:6006` with all stories rendering; Token Gallery correctly reads both light and dark theme token values
+- `pnpm build-storybook` exits 0; a11y check passes on all stories
+- Dialog and Drawer stories: the `play` function opens and dismisses the component; keyboard navigation works (Tab, Esc); focus trap confirmed in the a11y panel
+- Icon story renders all 26 icons with correct sizes; `aria-hidden` icons have no accessible name; `aria-label` icons are announced correctly
+- Dark mode toggle in the Storybook toolbar applies `[data-theme="dark"]` to the canvas root and all semantic colour tokens update immediately
+- CI `storybook-build` job is green; artifact is uploaded
+
+---
+
+_Version 1.23 — June 2026. Planning change (no task completed, no version bumps): (1) Corrected duplicate task numbering — RFC 0028 operator fork model task renumbered from 1.0.06 to 1.0.07 (1.0.06 is already occupied by Non-Docker/systemd deployment, RFC 0026). (2) Added Task 1.0.08 — Storybook for `@sovereignfs/ui` design system (no RFC needed — developer tooling; Storybook 8 + `@storybook/nextjs`, Token Gallery, all component stories, a11y addon, CI build job). SRS decision-log row added (v0.28). Earlier notes retained._
+
+_Version 1.22 — June 2026. Planning change (no task completed, no version bumps): Operator fork model (RFC 0028) incorporated as a documentation-only post-v1 task (originally numbered 1.0.06; corrected to 1.0.07 in v1.23). Mirrored in SRS v0.27 (§2.7 pointer + decision-log row). Earlier notes retained._
+
+_Version 1.21 — June 2026. Planning change (no task completed, no version bumps): White-labeling / tenant branding (RFC 0027) incorporated as three post-v1 tasks (1.0.03–1.0.05) in Phase v1.0+. Phase 1 ships the data layer + shell injection + Console branding form + SDK extension; Phase 2 adds branded email templates and auth login page branding; Phase 3 adds dynamic PWA manifest and favicon route. Mirrored in SRS v0.26 (§3.18, §4.6, decision-log row). Earlier notes retained._
 
 _Version 1.20 — June 2026. **Task 0.5.18 — Registry contribution process** completed and merged. New `registry/plugins.json` public discovery index — each entry is a **thin record** `{ id, repository: { type: git|path, url }, name, description, tags? }` (a pointer to the source + display metadata, **not** a copy of the manifest; the manifest is fetched from the source at install time, avoiding drift). Lists only third-party plugins; the array starts empty and grows by submission. Adds `registryEntrySchema` + `validateRegistryEntry` to `@sovereignfs/manifest` (**0.7.0 → 0.8.0**, additive `feat`). Entries carry author/license/homepage/keywords + an optional pinned `repository.ref`. A validation pipeline — `scripts/validate-registry.ts` (`pnpm registry:validate` / `registry:check`) — clones each source, validates its manifest + LICENSE, and records `provenance` (resolved commit + sha256 content hash over the source tree); a `.github/workflows/registry-validate.yml` job gated by `paths: ['registry/**']` re-verifies on registry changes only. Used by `registry/__tests__` (wired into `vitest.config.ts`) + `registry/CONTRIBUTING.md` + a directory-based `.github/PULL_REQUEST_TEMPLATE/registry-submission.md` + a "Submitting to the registry" section in `docs/plugin-development.md`. Earlier notes retained._
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -350,6 +350,69 @@ a signal to test the plugin against the newer platform and publish an update.
 
 ---
 
+## Maintaining a fork
+
+Most operators should never fork Sovereign's source — env vars, community plugins
+(`sv plugin add`), and the RFC 0027 branding system cover the full customisation
+surface without touching any source file. A fork is warranted only when you need
+custom plugins compiled into the same image (e.g. for air-gapped environments or
+proprietary code), or when you are building a commercial white-labeled derivative.
+
+For the full model, zone taxonomy, AGPL compliance table, and `sv fork check`
+follow-on, see [RFC 0028](rfcs/0028-operator-fork-model.md).
+
+### Quick-start: Track 2 fork setup
+
+```bash
+# Fork sovereignfs/sovereign on GitHub, then:
+git clone https://github.com/<org>/sovereign-fork && cd sovereign-fork
+git remote add upstream https://github.com/sovereignfs/sovereign
+git fetch upstream
+```
+
+Add an `operator/` directory to the repo root:
+
+```
+operator/
+├── OPERATOR.md          # fork purpose, plugin list, AGPL posture
+├── UPSTREAM             # plain text: upstream tag this fork is based on
+└── docker-compose.override.yml   # deployment overrides (optional)
+```
+
+Add custom plugins under `plugins/<com.yourorg.pluginid>/` and unignore them in
+`.gitignore`:
+
+```gitignore
+!/plugins/com.yourorg.myplugin/
+```
+
+**The isolation principle:** never modify files owned by upstream (`runtime/`,
+`packages/`, `apps/`, `scripts/`, `plugins/account/`, `plugins/console/`,
+`plugins/launcher/`, etc.). Operator additions go in `operator/` and
+`plugins/<operator-id>/` only. Because the two file sets never overlap,
+`git rebase upstream/main` applies every upstream release with zero conflicts.
+
+### Upstream sync
+
+```bash
+git fetch upstream
+git rebase upstream/main          # zero conflicts when the isolation principle is respected
+echo "v1.3.0" > operator/UPSTREAM
+git add operator/UPSTREAM && git commit -m "chore: sync with upstream v1.3.0"
+git push --force-with-lease origin main
+
+# Then deploy normally:
+sv backup
+docker compose -f docker-compose.prod.yml pull
+docker compose -f docker-compose.prod.yml up -d
+```
+
+A conflict during rebase signals that a core-locked file was modified — fix by
+reverting the change and expressing the intent as a community plugin or upstream
+RFC instead.
+
+---
+
 ## Upgrading
 
 See the [upgrade guide](upgrade.md) for version-specific migration notes,

--- a/docs/sovereign-proposal-plan-srs.md
+++ b/docs/sovereign-proposal-plan-srs.md
@@ -46,6 +46,7 @@
    - 3.15 [Deployment & Upgrade Strategy (RFC 0006)](#315-deployment--upgrade-strategy-rfc-0006)
    - 3.16 [User Data Portability (RFC 0007)](#316-user-data-portability-rfc-0007)
    - 3.17 [Security & Encryption Architecture (RFC 0008)](#317-security--encryption-architecture-rfc-0008)
+   - 3.18 [White-labeling (RFC 0027) (post-v1 plan)](#318-white-labeling-rfc-0027-post-v1-plan)
 
 4. [Software Requirements Specification](#4-software-requirements-specification)
    - 4.1 [User Roles and Capabilities](#41-user-roles-and-capabilities)
@@ -351,6 +352,14 @@ A complete reference deployment (platform + Tasks + Splitify + Plainwrite) requi
 - **Third-party plugins:** Any license, declared in `manifest.json`
 - **Contributor License Agreement:** Required before merging PRs (as per v1 precedent)
 - **Dual licensing:** Commercial license available for organisations needing to operate the runtime privately without AGPL obligations (contact maintainer)
+
+**Fork model:** Operators who need custom compiled-in plugins or who are building
+a commercial OEM derivative should follow the fork model documented in RFC 0028
+(`docs/rfcs/0028-operator-fork-model.md`). The key principle: never modify
+upstream-owned files; add only to the fork-safe zone (`operator/`,
+`plugins/<operator-id>/`). This keeps `git rebase upstream/main` conflict-free.
+AGPL triggers on distribution, not private self-hosted use; community plugins
+(`plugins/<operator-*>/`) are MIT-SDK-bound and carry no AGPL copyleft.
 
 ---
 
@@ -778,6 +787,80 @@ only the zero-knowledge tier does. Amends §3.15 (encrypted backups) and §3.16
 zero-knowledge E2EE (Tiers 2–4) are **post-v1** (Task 1.0.01). Deferred per
 RFC 0008.
 
+### 3.18 White-labeling (RFC 0027) (post-v1 plan)
+
+Let any Sovereign operator replace Sovereign's visual identity with their own
+brand. An operator deploys Sovereign as the core and customises the logo, app
+name, favicon, colours, and email sender identity per tenant. The same
+infrastructure enables the dual-licensing model (AGPL + commercial) where a
+closed-source derivative ships under an operator's own brand.
+
+**Config layering:** env-var defaults merged with per-tenant DB overrides. Env
+vars define the baseline at deploy time; the `tenant_branding` table stores
+per-tenant overrides. Single-tenant operators get a pure env-var experience;
+multi-tenant operators configure each tenant in Console.
+
+**New `BRAND_*` env vars (all optional, Sovereign defaults apply when unset):**
+`BRAND_NAME`, `BRAND_LOGO`, `BRAND_LOGO_DARK`, `BRAND_FAVICON`,
+`BRAND_PRIMARY_COLOR` (sets `--sv-color-accent`), `BRAND_EMAIL_FROM_NAME`,
+`BRAND_EMAIL_LOGO`.
+
+**`tenant_branding` table** (`packages/db`): dialect-aware DDL bootstrapped
+alongside the default-tenant seed. Written via `setTenantBranding()` (upsert);
+read via `getTenantBranding()` which merges DB values over env defaults.
+`brand_primary` is validated hex `/^#[0-9a-fA-F]{6}$/` at write time — a
+malformed value injected into a `<style>` block would be CSS injection.
+
+**`--sv-brand-*` token namespace** (separate from `--sv-color-*` semantic
+tokens): `--sv-brand-logo`, `--sv-brand-logo-dark`, `--sv-brand-favicon`. Brand
+tokens carry URLs, not colours; they are set by the operator once and do not
+change with dark mode. The brand name is a React prop from `BrandProvider`, not
+a CSS custom property — CSS `content:` cannot supply rendered text content.
+
+**`BrandProvider`** (`runtime/src/brand-provider.tsx`): React server component.
+Reads `tenant_branding` from the platform DB, merges with env defaults, renders
+a `<style>` block setting `--sv-brand-*` tokens and (if `brandPrimary` is set)
+`--sv-color-accent` / `--sv-color-accent-hover` (HSL lightness delta derivation,
+`ACCENT_HOVER_LIGHTNESS_DELTA = 8`). Called from `(platform)/layout.tsx` and
+the auth server root layout. No in-process brand cache — the per-request render
+boundary provides isolation; brand values change rarely.
+
+**Logo serving and CSP:** uploaded logos stored at `data/brand/<tenant_id>.<ext>`
+(same volume as `data/avatars/`), served by `GET /api/brand/logo[?dark=1]` and
+`GET /api/brand/favicon` — excluded from the middleware session gate (must load
+on the login page). MIME type validated + 2 MB cap at upload. External URLs
+entered by the operator are stored as-is; the preferred approach for CSP
+compliance is proxying through `/api/brand/proxy?url=…` (keeps `img-src 'self'`
+strict) rather than widening `img-src`.
+
+**Auth server login page:** obtains brand values by fetching
+`GET <runtime>/api/admin/tenant-branding` at render time (proxy approach — one
+store, no dual-write). Fails gracefully to Sovereign defaults if the runtime is
+unreachable. An in-memory TTL cache (60 s) prevents a brand fetch on every login
+render.
+
+**Email templates:** `packages/mailer` `MailOptions` gains an optional
+`branding?: { name, logoUrl? }` parameter. Hosted URL (not `data:` URI — Gmail
+and most webmail strip base64 URIs); template degrades gracefully with text
+fallback when images are blocked.
+
+**PWA manifest:** becomes a served route (`GET /manifest.webmanifest`) when
+branding is configured. Cached SW users see the old name/icons until the SW
+updates — acceptable for v1; documented in `docs/self-hosting.md`.
+
+**`sdk.platform.getConfig()` extension:** gains `brandName` (falls back to
+`tenantName`) and `brandPrimaryColor?` (validated hex or undefined), enabling
+plugins to display the instance name and primary colour without reading CSS
+variables.
+
+**Phasing (post-v1):** Phase 1 — `tenant_branding` table, env vars,
+`--sv-brand-*` tokens, `BrandProvider`, Console branding form, `getConfig()`
+extension. Phase 2 — branded email templates, auth login page branding via
+runtime proxy. Phase 3 — dynamic PWA manifest route, dynamic favicon route.
+Published packages (`@sovereignfs/ui`, `@sovereignfs/sdk`) receive additive
+minor bumps only. See RFC 0027 (`docs/rfcs/0027-white-labeling.md`) for the
+full design and security analysis.
+
 ---
 
 ## 4. Software Requirements Specification
@@ -888,6 +971,7 @@ Granular per-user capability overrides and per-plugin role assignments are expli
 - Per-plugin permission assignment for individual users
 - Public-facing plugin marketplace or install UI
 - Federated instances
+- White-labeling / tenant branding (planned post-v1 — see §3.18 for the decided approach)
 
 ---
 
@@ -1045,8 +1129,17 @@ type Permission =
 | Jun 2026 | Test organization (RFC 0010) incorporated: boundary-based layout — within-package tests (unit/component/visual + within-package integration) live in per-directory `__tests__/`; cross-service integration + e2e live at root `/__tests__/`. Task 0.5.16                                                                                                                                                                                                                                                                                                                                                     | Placement should follow the boundary a test crosses, not its type label; in a Turborepo monorepo a test belongs to the package owning the code (locality + per-package runs), so "integration" is not one location. e2e (Playwright) and visual are reserved with no dependencies added yet.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | Jun 2026 | Icon system (RFC 0011) incorporated: adopt Lucide via a curated set generated into the design system as inline SVGs behind a Sovereign `<Icon>`; `lucide` is a build-time devDependency only (zero runtime/peer dep); replace chrome monograms/emoji; render plugin `icon.svg` safely. Task 0.5.17                                                                                                                                                                                                                                                                                                           | No icon system existed (monograms + an OS-dependent `⚙` emoji), yet the platform's own `icon.svg` already follows Lucide's 24×24 stroke/`currentColor` convention. ISC license + bundling fit NFR-02 and the no-telemetry stance; generating SVGs honors the design system's "zero extra dependencies" rule and RFC 0008's supply-chain ethos. Plugin SVGs are untrusted (rendered via `<img>`/sanitized, never `dangerouslySetInnerHTML`).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | Jun 2026 | Package codenames (RFC 0009 — `ui`→`mosaic`, `mailer`→`dispatch`, `db`→`database`) withdrawn/deferred                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | Reconsidered and not pursued at this time. The pre-publish rename window stays open (nothing is on npm yet), so it can be revisited before first publish without breakage. RFC 0009 marked Withdrawn.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| Jun 2026 | Operator fork model & upstream sync (RFC 0028) documented: two tracks (config-only = recommended; fork-and-track = for committed custom plugins or OEM distribution); isolation principle (never modify core-locked files: `runtime/`, `packages/`, `apps/`, core plugins); fork-safe zone (`operator/`, `plugins/<operator-id>/`); rebase-over-merge upstream sync; `operator/UPSTREAM` version tracking; AGPL compliance table. Full design in `docs/rfcs/0028-operator-fork-model.md`. §2.7 updated with pointer.                                                                                         | Most self-hosters need no fork — env vars + community plugins + RFC 0027 branding cover the full surface. The fork model is for operators who need custom plugins compiled into the same image (air-gapped or proprietary) or who are building a commercial OEM derivative. The isolation principle makes the fork directly analogous to the SDK boundary rule: just as plugins must not import `runtime/src`, fork operators must not modify upstream files. Rebase over merge keeps history linear and conflicts localised to the operator's own changes; when the isolation principle is respected, rebase produces zero conflicts. Custom community plugins use only the MIT SDK/UI and carry no AGPL copyleft regardless of distribution scenario.                                                                                                                                                                                                                                                                                                                                                 |
+| Jun 2026 | White-labeling / tenant branding (RFC 0027) incorporated as a **post-v1** plan (§3.18): `tenant_branding` table + `BRAND_*` env vars + `--sv-brand-*` token namespace + `BrandProvider` + Console branding form + `getConfig()` extension (Phase 1); branded email templates + auth login page via runtime proxy (Phase 2); dynamic PWA manifest + favicon route (Phase 3). Full design in `docs/rfcs/0027-white-labeling.md`. Tasks 1.0.03–1.0.05                                                                                                                                                           | The existing infrastructure (`tenant_id`, `tenants` table, `platform_settings`, design-system token architecture) already points toward this capability; what was missing was a structured `tenant_branding` table, a dedicated `--sv-brand-*` token namespace, and a delivery mechanism for the runtime, auth server, email, and PWA. CSS variable injection achieves the visual result without forking any template. `platform_settings` is not used as a branding store (untyped, unstructured; brand values benefit from explicit columns). Brand name is a React prop from `BrandProvider`, not a CSS custom property — `content:` on pseudo-elements does not work for rendered text. Auth server branding obtained via proxy to runtime (one store, no dual-write) — the dual-write approach is appropriate for invite-only (safety-critical boolean) but not for 7 cosmetic fields where a stale value is cosmetically wrong, not a security failure. `data:` URI email logo rejected — Gmail and most webmail refuse to render them.                                                           |
+| Jun 2026 | Storybook 8 chosen for `@sovereignfs/ui` design system documentation (Task 1.0.08, post-v1). No RFC — pure developer tooling, no runtime surface, no SDK/manifest/DB change. `@storybook/nextjs` (Vite builder) with `addon-a11y`, `addon-viewport`, `addon-themes`. Token Gallery story + one story per component. CI `storybook-build` job with a11y enforcement. RSC stories deferred until Storybook RSC support matures.                                                                                                                                                                                | Alternatives considered: **Ladle** (fast, Vite-native, but minimal addon ecosystem — no a11y addon), **Histoire** (Vue-first, React support immature), **Docz** (stagnant since 2022). Storybook 8 is the only option with mature CSS Modules support (`@storybook/nextjs`), a production-ready a11y addon (`addon-a11y`), dark mode toggling for CSS custom property themes, and widespread team familiarity. Scoped to `packages/ui` because App Router RSC components cannot be rendered in Storybook without significant workarounds; client-component stories in `runtime` added as a follow-on.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 
 ---
+
+_Version 0.28 — June 2026. Storybook for `@sovereignfs/ui` added as post-v1 Task 1.0.08. Decision-log row added. No architecture section needed (developer tooling only — no runtime surface, SDK, permission, or schema change)._
+
+_Version 0.27 — June 2026. Operator fork model (RFC 0028) documented. §2.7 gains a "Fork model" paragraph pointing to RFC 0028; one decision-log row added. No architecture section needed (purely process/convention guidance). No SDK surface change, no permission change, no schema change._
+
+_Version 0.26 — June 2026. White-labeling / tenant branding (RFC 0027) incorporated as a post-v1 plan. New §3.18; §4.6 gains "White-labeling" as an out-of-scope v1 item; decision-log row added. Roadmap gains Tasks 1.0.03–1.0.05 (three phases). No SDK surface change, no permission change, no schema change in v1._
 
 _Version 0.25 — June 2026. Post-implementation refinement of the overlay shell (Task 0.5.09, RFC 0001 open questions 2 & 4 resolved): §5 manifest reference gains the optional `shellConfig` object with `overlaySize` (`sm`/`md`/`lg`, default `lg`, valid only for `shell: "overlay"`); §3.8 records that overlay dialogs are fixed-size (never content-driven) and that intra-overlay navigation must use `replace` so a single `router.back()` dismisses the dialog. No new requirement or permission; implementation-only (already merged)._
 


### PR DESCRIPTION
## Summary

- **RFC 0027 white-labeling accepted** — status updated from Draft to Accepted; three-phase post-v1 implementation plan (Tasks 1.0.03–1.0.05) scheduled in the roadmap and fully architected in SRS §3.18. Covers the `tenant_branding` DB table, `--sv-brand-*` CSS token namespace, `BrandProvider` server component, Console branding form, email templates, auth login page proxy, and dynamic PWA manifest/favicon route.
- **RFC 0028 operator fork model** — new RFC documenting how to maintain a fork of Sovereign while staying in sync with upstream. Defines two operator tracks (config-only vs fork-and-track), the isolation principle (never modify core-locked files — the git-level equivalent of the SDK boundary rule), the `operator/` directory convention, the upstream rebase workflow, and AGPL compliance guidance. `docs/self-hosting.md` gains a "Maintaining a fork" section. Scheduled as post-v1 Task 1.0.07 (docs-only).
- **Storybook task added** — Task 1.0.08 schedules Storybook 8 for `@sovereignfs/ui` post-v1: Token Gallery story, per-component stories (all 7 components), `addon-a11y` + `addon-viewport` + `addon-themes`, CI `storybook-build` job. No RFC needed — developer tooling with no runtime surface. Decision rationale recorded in SRS decision log.
- **Duplicate task number fixed** — the RFC 0028 task was incorrectly numbered 1.0.06 (already occupied by the systemd deployment task from RFC 0026). Corrected to 1.0.07.
- **.gitignore** — `memory/` directory added (Claude Code session memory, machine-local, must not be committed).

## SRS references

RFC 0027 → §3.18, §4.6, decision log · RFC 0028 → §2.7, decision log · Storybook → decision log

🤖 Generated with [Claude Code](https://claude.com/claude-code)