### PR TITLE
feat: offline connectivity banner for PWA shell

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,6 +319,15 @@ iterable`. The slot's hand-written `@modal/default.tsx` (empty fallback) and
   `/login` (middleware, logout route) must target the **public** auth URL
   (`SOVEREIGN_AUTH_PUBLIC_URL`), never the internal `SOVEREIGN_AUTH_URL`
   (`auth:3001`), which the browser cannot resolve in Docker.
+- **`'use client'` components must never read browser APIs (`navigator`, `window`,
+  `localStorage`, etc.) inside a `useState` initializer or during render.** The
+  server renders without those globals, producing different HTML than the client
+  and triggering a React hydration error. The pattern: always initialise state to
+  a server-safe value (e.g. `useState('online')`), then read the browser API
+  inside `useEffect` and call the setter if needed. The one-frame delay before
+  the UI reflects the real browser state is imperceptible. `OfflineBanner` is the
+  canonical example — it initialises to `'online'` and checks `navigator.onLine`
+  in `useEffect` (`runtime/app/(platform)/_components/OfflineBanner.tsx`).
 - **Never read `NEXT_PUBLIC_*` env vars for a value that must vary per deployment
   at run time.** Next.js inlines `process.env.NEXT_PUBLIC_*` literals at **build
   time** into every bundle (client and server); the Docker images build without

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -99,6 +99,21 @@ variables are available globally to every plugin.
 | `--sv-shadow-card`          | composed shadow | composed shadow | Card elevation             |
 | `--sv-shadow-overlay`       | composed shadow | composed shadow | Dialog / overlay elevation |
 
+### Status colours
+
+A minimal warning (amber) and success (green) palette for banners, badges, and inline validation. Always reference these tokens — never hardcode amber or green hex in a component or plugin.
+
+| Token                        | Light     | Dark      | Role                              |
+| ---------------------------- | --------- | --------- | --------------------------------- |
+| `--sv-color-warning-surface` | amber-100 | amber-900 | Warning banner / badge background |
+| `--sv-color-warning-text`    | amber-800 | amber-200 | Text on warning surface           |
+| `--sv-color-warning-border`  | amber-200 | amber-800 | Warning surface border            |
+| `--sv-color-success-surface` | green-100 | green-900 | Success banner / badge background |
+| `--sv-color-success-text`    | green-800 | green-200 | Text on success surface           |
+| `--sv-color-success-border`  | green-200 | green-800 | Success surface border            |
+
+These tokens are backed by `--sv-amber-*` and `--sv-green-*` primitive swatches defined in `primitives.css`. The primitives are fixed across themes; only the semantic mapping changes.
+
 ## Building a component
 
 1. **Location:** `src/components/<Name>/<Name>.tsx` with a co-located

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1898,8 +1898,6 @@ _Version 1.22 — June 2026. Planning change (no task completed, no version bump
 
 _Version 1.24 — June 2026. **Task 0.5.30 — Offline connectivity banner** completed and merged. Thin fixed banner surfaces connectivity status (soft-offline case — hard-offline was already covered by the `/offline` SW fallback). `@sovereignfs/ui` → 0.7.0 (warning/success status colour tokens); `runtime` → 0.20.0. CLAUDE.md gains the browser-API / `useState` SSR hydration rule. SRS v0.29. Earlier notes retained._
 
-
-
 _Version 1.23 — June 2026. Planning change (no task completed, no version bumps): (1) Corrected duplicate task numbering — RFC 0028 operator fork model task renumbered from 1.0.06 to 1.0.07 (1.0.06 is already occupied by Non-Docker/systemd deployment, RFC 0026). (2) Added Task 1.0.08 — Storybook for `@sovereignfs/ui` design system (no RFC needed — developer tooling; Storybook 8 + `@storybook/nextjs`, Token Gallery, all component stories, a11y addon, CI build job). SRS decision-log row added (v0.28). Earlier notes retained._
 
 _Version 1.22 — June 2026. Planning change (no task completed, no version bumps): Operator fork model (RFC 0028) incorporated as a documentation-only post-v1 task (originally numbered 1.0.06; corrected to 1.0.07 in v1.23). Mirrored in SRS v0.27 (§2.7 pointer + decision-log row). Earlier notes retained._

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1471,6 +1471,31 @@ supported path to production.
 
 ---
 
+#### ✅ Task 0.5.30 — Offline connectivity banner (PWA shell)
+
+**Goal:** Surface connectivity status to users who are already in an authenticated session when their network drops. The hard-offline case (navigating to an uncached page) was already handled by the `/offline` fallback route; this task covers the soft-offline case — the network disappears while the user is on a page.
+
+**Deliverables:**
+
+- `@sovereignfs/ui` → **minor** (0.7.0): status colour tokens — `--sv-color-warning-surface/text/border` (amber) and `--sv-color-success-surface/text/border` (green); backed by new `--sv-amber-*` / `--sv-green-*` primitive swatches; documented in `docs/design-system.md` "Status colours" section
+- `runtime` → **minor** (0.20.0): `OfflineBanner` client component (`runtime/app/(platform)/_components/OfflineBanner.tsx`) — initialises to `'online'` server-safely (avoids SSR hydration mismatch), then checks `navigator.onLine` in `useEffect`; listens to `window` `offline`/`online` events; amber "No internet connection" banner persists until reconnected; green "Back online" flash auto-dismisses after 3 s (coincides with `reloadOnOnline` SW reload); `position: fixed; top: 0; z-index: 200` (above the mobile header's `z-index: 101`); 200 ms slide-in animation; uses `alert-triangle` icon and `--sv-color-warning-*` / `--sv-color-success-*` tokens
+- Wired into both `(platform)/layout.tsx` and `(minimal)/layout.tsx`; excluded from `/offline` (implicit there)
+- `CLAUDE.md` gains the browser-API / `useState` hydration rule: never read `navigator`/`window`/`localStorage` in a `useState` initializer — initialise to a server-safe value and read in `useEffect`
+
+**Dependencies:** Task 0.5.01 (PWA — `reloadOnOnline`), Task 0.5.17 (Icon — `alert-triangle`), Task 0.5.25 (mobile shell — z-index context)
+
+**SRS reference:** SRS §3.11 (PWA)
+
+**Review checklist:**
+
+- DevTools → Network → Offline: amber banner slides in immediately; no hydration error in dev or production build
+- DevTools → Network → Online: green "Back online" flash appears then dismisses after ~3 s; page reloads from SW
+- Loading from SW cache while offline: amber banner present on mount (not deferred until a network event)
+- Mobile (< 768 px): banner is above the sticky header; `z-index: 200` > header's `101`
+- Dark mode: dark amber/green tokens render correctly
+
+---
+
 ### Phase v0.6 — User roles & capabilities
 
 #### Task 0.6.01 — Platform roles & capabilities (RFC 0021)
@@ -1866,6 +1891,14 @@ Phase 1 (this task) targets `packages/ui` exclusively. The `runtime` App Router 
 - CI `storybook-build` job is green; artifact is uploaded
 
 ---
+
+_Version 1.23 — June 2026. Planning change (no task completed, no version bumps): (1) Corrected duplicate task numbering — RFC 0028 operator fork model task renumbered from 1.0.06 to 1.0.07 (1.0.06 is already occupied by Non-Docker/systemd deployment, RFC 0026). (2) Added Task 1.0.08 — Storybook for `@sovereignfs/ui` design system (no RFC needed — developer tooling; Storybook 8 + `@storybook/nextjs`, Token Gallery, all component stories, a11y addon, CI build job). SRS decision-log row added (v0.28). Earlier notes retained._
+
+_Version 1.22 — June 2026. Planning change (no task completed, no version bumps): Operator fork model (RFC 0028) incorporated as a documentation-only post-v1 task (originally numbered 1.0.06; corrected to 1.0.07 in v1.23). Mirrored in SRS v0.27 (§2.7 pointer + decision-log row). Earlier notes retained._
+
+_Version 1.24 — June 2026. **Task 0.5.30 — Offline connectivity banner** completed and merged. Thin fixed banner surfaces connectivity status (soft-offline case — hard-offline was already covered by the `/offline` SW fallback). `@sovereignfs/ui` → 0.7.0 (warning/success status colour tokens); `runtime` → 0.20.0. CLAUDE.md gains the browser-API / `useState` SSR hydration rule. SRS v0.29. Earlier notes retained._
+
+
 
 _Version 1.23 — June 2026. Planning change (no task completed, no version bumps): (1) Corrected duplicate task numbering — RFC 0028 operator fork model task renumbered from 1.0.06 to 1.0.07 (1.0.06 is already occupied by Non-Docker/systemd deployment, RFC 0026). (2) Added Task 1.0.08 — Storybook for `@sovereignfs/ui` design system (no RFC needed — developer tooling; Storybook 8 + `@storybook/nextjs`, Token Gallery, all component stories, a11y addon, CI build job). SRS decision-log row added (v0.28). Earlier notes retained._
 

--- a/docs/sovereign-proposal-plan-srs.md
+++ b/docs/sovereign-proposal-plan-srs.md
@@ -663,6 +663,8 @@ The runtime's middleware reads the session cookie and verifies it (v0.3: a call 
 
 `@ducanh2912/next-pwa` is added to the runtime. The PWA shell is installable from the browser. The service worker caches the shell and static assets for offline availability. Plugin data is not cached offline in v1.
 
+**Offline connectivity banner (Task 0.5.30):** When a user is already in an authenticated session and the network drops, a thin fixed banner (`position: fixed; top: 0; z-index: 200`) slides in with an amber "No internet connection" state. On reconnection it flashes green "Back online" for 3 s, after which the service worker's `reloadOnOnline` triggers a full page reload to restore fresh content. The banner uses `navigator.onLine` + `window` `offline`/`online` events. SSR safety: the component always initialises to `'online'` (matching the server render) and reads the real state in `useEffect` — reading browser APIs during render or in a `useState` initializer causes a hydration mismatch. The banner is wired into both `(platform)` and `(minimal)` shell layouts; the `/offline` fallback page is excluded (it is the hard-offline landing).
+
 ### 3.12 Native Mobile App (post-v1 plan)
 
 Native mobile support is deferred to post-v1 but the approach is decided:
@@ -1134,6 +1136,8 @@ type Permission =
 | Jun 2026 | Storybook 8 chosen for `@sovereignfs/ui` design system documentation (Task 1.0.08, post-v1). No RFC — pure developer tooling, no runtime surface, no SDK/manifest/DB change. `@storybook/nextjs` (Vite builder) with `addon-a11y`, `addon-viewport`, `addon-themes`. Token Gallery story + one story per component. CI `storybook-build` job with a11y enforcement. RSC stories deferred until Storybook RSC support matures.                                                                                                                                                                                | Alternatives considered: **Ladle** (fast, Vite-native, but minimal addon ecosystem — no a11y addon), **Histoire** (Vue-first, React support immature), **Docz** (stagnant since 2022). Storybook 8 is the only option with mature CSS Modules support (`@storybook/nextjs`), a production-ready a11y addon (`addon-a11y`), dark mode toggling for CSS custom property themes, and widespread team familiarity. Scoped to `packages/ui` because App Router RSC components cannot be rendered in Storybook without significant workarounds; client-component stories in `runtime` added as a follow-on.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 
 ---
+
+_Version 0.29 — June 2026. Offline connectivity banner (Task 0.5.30). §3.11 extended with the soft-offline detection model, banner behaviour, and the SSR-safe `useState` initialisation rule. `@sovereignfs/ui` → 0.7.0 (warning/success status colour tokens — `--sv-color-warning-*` / `--sv-color-success-*`); `runtime` → 0.20.0._
 
 _Version 0.28 — June 2026. Storybook for `@sovereignfs/ui` added as post-v1 Task 1.0.08. Decision-log row added. No architecture section needed (developer tooling only — no runtime surface, SDK, permission, or schema change)._
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sovereignfs/ui",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "type": "module",
   "description": "Sovereign Design System — design tokens and React components.",
   "license": "AGPL-3.0-or-later",

--- a/packages/ui/src/tokens/primitives.css
+++ b/packages/ui/src/tokens/primitives.css
@@ -9,6 +9,17 @@
 :root {
   /* Neutral grey scale (monochrome identity) */
   --sv-white: #ffffff;
+
+  /* Status colour primitives — amber (warning) and green (success).
+     Kept minimal: only the swatches the semantic status tokens reference. */
+  --sv-amber-100: #fef3c7;
+  --sv-amber-200: #fde68a;
+  --sv-amber-800: #92400e;
+  --sv-amber-900: #78350f;
+  --sv-green-100: #dcfce7;
+  --sv-green-200: #bbf7d0;
+  --sv-green-800: #166534;
+  --sv-green-900: #14532d;
   --sv-black: #000000;
   --sv-grey-50: #fafafa;
   --sv-grey-100: #f4f4f5;

--- a/packages/ui/src/tokens/semantic.css
+++ b/packages/ui/src/tokens/semantic.css
@@ -27,6 +27,16 @@
 
   --sv-color-focus-ring: var(--sv-grey-900);
 
+  /* Status surfaces — warning (amber) and success (green).
+     Use these for banners, badges, and inline validation UI.
+     Never hardcode amber/green hex in components — reference these tokens. */
+  --sv-color-warning-surface: var(--sv-amber-100);
+  --sv-color-warning-text: var(--sv-amber-800);
+  --sv-color-warning-border: var(--sv-amber-200);
+  --sv-color-success-surface: var(--sv-green-100);
+  --sv-color-success-text: var(--sv-green-800);
+  --sv-color-success-border: var(--sv-green-200);
+
   /* Overlay surfaces (Dialog/Sheet): the scrim behind a dialog and the panel's
      elevation shadow. Composed rgba layers, like --sv-shadow-card. */
   --sv-color-scrim: rgba(0, 0, 0, 0.5);
@@ -51,6 +61,13 @@
   --sv-color-accent-hover: var(--sv-grey-200);
 
   --sv-color-focus-ring: var(--sv-grey-100);
+
+  --sv-color-warning-surface: var(--sv-amber-900);
+  --sv-color-warning-text: var(--sv-amber-200);
+  --sv-color-warning-border: var(--sv-amber-800);
+  --sv-color-success-surface: var(--sv-green-900);
+  --sv-color-success-text: var(--sv-green-200);
+  --sv-color-success-border: var(--sv-green-800);
 
   --sv-color-scrim: rgba(0, 0, 0, 0.65);
 

--- a/runtime/app/(minimal)/layout.tsx
+++ b/runtime/app/(minimal)/layout.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import { OfflineBanner } from '../(platform)/_components/OfflineBanner';
 import styles from './minimal.module.css';
 
 /**
@@ -15,5 +16,10 @@ import styles from './minimal.module.css';
 export const dynamic = 'force-dynamic';
 
 export default function MinimalLayout({ children }: { children: ReactNode }) {
-  return <div className={styles.root}>{children}</div>;
+  return (
+    <div className={styles.root}>
+      <OfflineBanner />
+      {children}
+    </div>
+  );
 }

--- a/runtime/app/(platform)/_components/OfflineBanner.module.css
+++ b/runtime/app/(platform)/_components/OfflineBanner.module.css
@@ -1,0 +1,38 @@
+.offline,
+.reconnected {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--sv-space-2);
+  height: 32px;
+  padding-inline: var(--sv-space-4);
+  font-size: var(--sv-font-size-xs);
+  font-weight: var(--sv-font-weight-medium);
+  animation: slideDown 200ms ease-out;
+}
+
+.offline {
+  background: var(--sv-color-warning-surface);
+  color: var(--sv-color-warning-text);
+  border-bottom: 1px solid var(--sv-color-warning-border);
+}
+
+.reconnected {
+  background: var(--sv-color-success-surface);
+  color: var(--sv-color-success-text);
+  border-bottom: 1px solid var(--sv-color-success-border);
+}
+
+@keyframes slideDown {
+  from {
+    transform: translateY(-100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}

--- a/runtime/app/(platform)/_components/OfflineBanner.tsx
+++ b/runtime/app/(platform)/_components/OfflineBanner.tsx
@@ -7,9 +7,12 @@ import styles from './OfflineBanner.module.css';
 type Status = 'online' | 'offline' | 'reconnected';
 
 export function OfflineBanner() {
-  const [status, setStatus] = useState<Status>(() =>
-    typeof navigator !== 'undefined' && !navigator.onLine ? 'offline' : 'online',
-  );
+  // Always initialise to 'online' so the server-rendered HTML matches the
+  // first client render. navigator.onLine is checked in useEffect (client-only)
+  // to pick up the case where the user loads the page while already offline
+  // (e.g. from the service-worker cache). The imperceptible one-frame delay
+  // before the banner appears is preferable to a hydration mismatch.
+  const [status, setStatus] = useState<Status>('online');
   const dismissTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
@@ -19,6 +22,11 @@ export function OfflineBanner() {
         dismissTimer.current = null;
       }
     };
+
+    // Sync with actual connectivity state after hydration.
+    if (!navigator.onLine) {
+      setStatus('offline');
+    }
 
     const handleOffline = () => {
       clearDismiss();

--- a/runtime/app/(platform)/_components/OfflineBanner.tsx
+++ b/runtime/app/(platform)/_components/OfflineBanner.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { Icon } from '@sovereignfs/ui';
+import styles from './OfflineBanner.module.css';
+
+type Status = 'online' | 'offline' | 'reconnected';
+
+export function OfflineBanner() {
+  const [status, setStatus] = useState<Status>(() =>
+    typeof navigator !== 'undefined' && !navigator.onLine ? 'offline' : 'online',
+  );
+  const dismissTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const clearDismiss = () => {
+      if (dismissTimer.current !== null) {
+        clearTimeout(dismissTimer.current);
+        dismissTimer.current = null;
+      }
+    };
+
+    const handleOffline = () => {
+      clearDismiss();
+      setStatus('offline');
+    };
+
+    const handleOnline = () => {
+      clearDismiss();
+      setStatus('reconnected');
+      dismissTimer.current = setTimeout(() => setStatus('online'), 3000);
+    };
+
+    window.addEventListener('offline', handleOffline);
+    window.addEventListener('online', handleOnline);
+
+    return () => {
+      window.removeEventListener('offline', handleOffline);
+      window.removeEventListener('online', handleOnline);
+      clearDismiss();
+    };
+  }, []);
+
+  if (status === 'online') return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={status === 'offline' ? styles.offline : styles.reconnected}
+    >
+      <Icon name="alert-triangle" size="sm" aria-hidden />
+      {status === 'offline' ? 'No internet connection' : 'Back online'}
+    </div>
+  );
+}

--- a/runtime/app/(platform)/layout.tsx
+++ b/runtime/app/(platform)/layout.tsx
@@ -7,6 +7,7 @@ import { CHROME_PLUGIN_IDS } from '@/src/launcher-plugins';
 import { AccountMenu } from './_components/AccountMenu';
 import { ActivePluginTitle } from './_components/ActivePluginTitle';
 import { MobileNav } from './_components/MobileNav';
+import { OfflineBanner } from './_components/OfflineBanner';
 import styles from './shell.module.css';
 
 function monogram(name: string): string {
@@ -65,6 +66,7 @@ export default async function PlatformLayout({ children }: { children: ReactNode
 
   return (
     <div className={styles.shell}>
+      <OfflineBanner />
       <aside className={styles.sidebar} aria-label="Primary navigation">
         <Link href="/" className={styles.brand} aria-label="Sovereign home">
           S


### PR DESCRIPTION
## Summary

- **`@sovereignfs/ui` → 0.7.0** — adds warning (amber) and success (green) semantic token groups: `--sv-color-warning-surface/text/border` and `--sv-color-success-surface/text/border`, backed by new `--sv-amber-*` / `--sv-green-*` primitive swatches. These are the first non-monochrome tokens in the design system; `docs/design-system.md` documents them under a new "Status colours" subsection.
- **`OfflineBanner` component** — thin fixed banner (32 px, `z-index: 200`) that detects connectivity via `navigator.onLine` and `window` `offline`/`online` events. Initialises from `navigator.onLine` so users loading from the service-worker cache while offline see the banner immediately. Amber state ("No internet connection") persists until reconnected; green flash ("Back online") auto-dismisses after 3 s, after which the PWA's `reloadOnOnline` SW reload fires naturally. Uses `alert-triangle` icon and the new status tokens exclusively — no hardcoded hex.
- Wired into both `(platform)/layout.tsx` (authenticated shell) and `(minimal)/layout.tsx` (chrome-free kiosk plugins). The `/offline` fallback page is excluded — it's the hard-offline landing, where connectivity status is already implicit.

## Test plan

- [ ] `pnpm typecheck` and `pnpm lint` pass
- [ ] DevTools → Network → Offline: amber banner slides down immediately
- [ ] DevTools → Network → Online: green "Back online" flash appears, then dismisses after ~3 s
- [ ] Load page from SW cache while offline (PWA installed): amber banner present on mount
- [ ] Mobile (< 768 px): banner appears above the sticky header (z-index 200 > 101)
- [ ] Dark mode (Account → Preferences → Dark): dark amber/green tokens render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)