### PR TITLE
feat: error boundaries and not-found pages

### DIFF
--- a/apps/auth/app/error.tsx
+++ b/apps/auth/app/error.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useEffect } from 'react';
+import styles from './auth.module.css';
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <main className={styles.page}>
+      <div className={styles.card}>
+        <h1 className={styles.title}>Something went wrong</h1>
+        <p className={styles.error}>An unexpected error occurred. Please try again.</p>
+        <button
+          onClick={reset}
+          style={{
+            marginTop: 'var(--sv-space-4)',
+            background: 'none',
+            border: 'none',
+            color: 'var(--sv-color-accent)',
+            fontWeight: 'var(--sv-font-weight-medium)',
+            cursor: 'pointer',
+            fontSize: 'var(--sv-font-size-sm)',
+            fontFamily: 'inherit',
+            padding: 0,
+          }}
+        >
+          Try again
+        </button>
+      </div>
+    </main>
+  );
+}

--- a/apps/auth/app/global-error.tsx
+++ b/apps/auth/app/global-error.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useEffect } from 'react';
+
+// global-error replaces the root layout; must include <html> and <body>.
+// Inline styles required — CSS modules depend on the root layout's token import.
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body
+        style={{
+          margin: 0,
+          minHeight: '100vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontFamily: 'system-ui, sans-serif',
+          background: '#fafafa',
+          color: '#09090b',
+        }}
+      >
+        <div style={{ textAlign: 'center', padding: '2rem' }}>
+          <h1 style={{ fontSize: '1.5rem', fontWeight: 600, margin: '0 0 0.5rem' }}>
+            Something went wrong
+          </h1>
+          <p style={{ margin: '0 0 1.5rem', color: '#71717a', fontSize: '0.875rem' }}>
+            An unexpected error occurred. Please try again.
+          </p>
+          <button
+            onClick={reset}
+            style={{
+              padding: '0.5rem 1.25rem',
+              border: '1px solid #d4d4d8',
+              borderRadius: '6px',
+              background: '#09090b',
+              color: '#fafafa',
+              cursor: 'pointer',
+              fontSize: '0.875rem',
+            }}
+          >
+            Try again
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/apps/auth/app/not-found.tsx
+++ b/apps/auth/app/not-found.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link';
+import styles from './auth.module.css';
+
+export default function NotFound() {
+  return (
+    <main className={styles.page}>
+      <div className={styles.card}>
+        <h1 className={styles.title}>Page not found</h1>
+        <p style={{ marginBottom: 'var(--sv-space-6)', color: 'var(--sv-color-text-muted)' }}>
+          The page you&rsquo;re looking for doesn&rsquo;t exist.
+        </p>
+        <Link className={styles.link} href="/login">
+          Back to sign in
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/runtime/app/_error.module.css
+++ b/runtime/app/_error.module.css
@@ -1,0 +1,44 @@
+.page {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--sv-space-4);
+}
+
+.card {
+  text-align: center;
+  padding: var(--sv-space-8);
+}
+
+.code {
+  margin: 0 0 var(--sv-space-2);
+  font-size: 4rem;
+  font-weight: var(--sv-font-weight-bold);
+  line-height: 1;
+  color: var(--sv-color-text-primary);
+}
+
+.message {
+  margin: 0 0 var(--sv-space-6);
+  color: var(--sv-color-text-muted);
+  font-size: var(--sv-font-size-base);
+}
+
+.link {
+  display: inline-block;
+  padding: var(--sv-space-2) var(--sv-space-5);
+  background-color: var(--sv-color-accent);
+  color: var(--sv-color-text-on-accent);
+  border: none;
+  border-radius: var(--sv-radius-md);
+  font-size: var(--sv-font-size-sm);
+  font-weight: var(--sv-font-weight-medium);
+  text-decoration: none;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.link:hover {
+  background-color: var(--sv-color-accent-hover);
+}

--- a/runtime/app/error.tsx
+++ b/runtime/app/error.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { useEffect } from 'react';
+import styles from './_error.module.css';
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className={styles.page}>
+      <div className={styles.card}>
+        <h1 className={styles.code}>500</h1>
+        <p className={styles.message}>Something went wrong.</p>
+        <button className={styles.link} onClick={reset}>
+          Try again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/runtime/app/global-error.tsx
+++ b/runtime/app/global-error.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useEffect } from 'react';
+
+// global-error replaces the root layout; must include <html> and <body>.
+// Inline styles are required here — CSS modules depend on the root layout's
+// token import, which is unavailable when the root layout itself errors.
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body
+        style={{
+          margin: 0,
+          minHeight: '100vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontFamily: 'system-ui, sans-serif',
+          background: '#fafafa',
+          color: '#09090b',
+        }}
+      >
+        <div style={{ textAlign: 'center', padding: '2rem' }}>
+          <h1 style={{ fontSize: '4rem', fontWeight: 700, margin: '0 0 0.5rem' }}>500</h1>
+          <p style={{ margin: '0 0 1.5rem', color: '#71717a' }}>Something went wrong.</p>
+          <button
+            onClick={reset}
+            style={{
+              padding: '0.5rem 1.25rem',
+              border: '1px solid #d4d4d8',
+              borderRadius: '6px',
+              background: '#09090b',
+              color: '#fafafa',
+              cursor: 'pointer',
+              fontSize: '0.875rem',
+            }}
+          >
+            Try again
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/runtime/app/not-found.tsx
+++ b/runtime/app/not-found.tsx
@@ -1,0 +1,16 @@
+import Link from 'next/link';
+import styles from './_error.module.css';
+
+export default function NotFound() {
+  return (
+    <div className={styles.page}>
+      <div className={styles.card}>
+        <h1 className={styles.code}>404</h1>
+        <p className={styles.message}>This page could not be found.</p>
+        <Link href="/" className={styles.link}>
+          Go home
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `error.tsx`, `global-error.tsx`, and `not-found.tsx` to both `runtime/` and `apps/auth/`.
- `global-error.tsx` uses inline styles in both apps since it replaces the root layout (CSS modules and token imports are unavailable at that point).
- Runtime error/not-found pages use a shared `_error.module.css` with `--sv-*` design-system tokens.
- Auth error/not-found pages reuse the existing `auth.module.css` card style for visual consistency with the login/register pages.

These files are stock Next.js App Router error handling — the platform was missing all three, meaning crashes or 404s produced Next's default fallback page (no branding, no navigation).

## Test plan

- [ ] Navigate to a non-existent runtime route → not-found page with "Go home" link
- [ ] Navigate to a non-existent auth route → not-found page with "Back to sign in" link
- [ ] Trigger a render error in a route component → error.tsx displays with "Try again" button; clicking reset re-renders the segment
- [ ] `pnpm format:check && pnpm lint && pnpm typecheck` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)