### PR TITLE
feat(auth): use BRAND_NAME on login page and page title

### DIFF
--- a/apps/auth/app/layout.tsx
+++ b/apps/auth/app/layout.tsx
@@ -1,11 +1,15 @@
 import '@sovereignfs/ui/tokens.css';
 import './globals.css';
 import type { ReactNode } from 'react';
+import { brandName } from '@/src/brand-name';
 
-export const metadata = {
-  title: 'Sovereign',
-  description: 'Sign in to your Sovereign workspace.',
-};
+export function generateMetadata() {
+  const name = brandName();
+  return {
+    title: name,
+    description: `Sign in to your ${name} workspace.`,
+  };
+}
 
 // Render per-request so the middleware's CSP nonce is injected into Next's
 // inline scripts (a statically-prerendered page can't carry a per-request

--- a/apps/auth/app/login/login-form.tsx
+++ b/apps/auth/app/login/login-form.tsx
@@ -11,8 +11,9 @@ import styles from '../auth.module.css';
  * `runtimeUrl` is resolved server-side (see runtimePublicUrl) and passed in so
  * the post-login redirect targets the deployment's real runtime origin at
  * request time — not a value frozen into the client bundle at build time.
+ * `brandName` is resolved from BRAND_NAME env at request time for the same reason.
  */
-export function LoginForm({ runtimeUrl }: { runtimeUrl: string }) {
+export function LoginForm({ runtimeUrl, brandName }: { runtimeUrl: string; brandName: string }) {
   const signedOut = useSearchParams().get('signedout') === '1';
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -53,7 +54,7 @@ export function LoginForm({ runtimeUrl }: { runtimeUrl: string }) {
   return (
     <main className={styles.page}>
       <div className={styles.card}>
-        <h1 className={styles.title}>Sign in to Sovereign</h1>
+        <h1 className={styles.title}>Sign in to {brandName}</h1>
         {signedOut ? (
           <p className={styles.notice} role="status">
             You&rsquo;ve been signed out.

--- a/apps/auth/app/login/page.tsx
+++ b/apps/auth/app/login/page.tsx
@@ -1,15 +1,14 @@
 import { Suspense } from 'react';
+import { brandName } from '@/src/brand-name';
 import { runtimePublicUrl } from '@/src/runtime-url';
 import { LoginForm } from './login-form';
 
-// Server component: resolves the runtime URL at request time and hands it to the
-// client form. useSearchParams (in LoginForm) must sit under a Suspense boundary
-// (Next 15).
+// Server component: resolves the runtime URL and brand name at request time.
+// useSearchParams (in LoginForm) must sit under a Suspense boundary (Next 15).
 export default function LoginPage() {
-  const runtimeUrl = runtimePublicUrl();
   return (
     <Suspense>
-      <LoginForm runtimeUrl={runtimeUrl} />
+      <LoginForm runtimeUrl={runtimePublicUrl()} brandName={brandName()} />
     </Suspense>
   );
 }

--- a/apps/auth/src/brand-name.ts
+++ b/apps/auth/src/brand-name.ts
@@ -1,0 +1,4 @@
+/** The brand name for this deployment. Falls back to 'Sovereign' when not set. */
+export function brandName(): string {
+  return process.env.BRAND_NAME || 'Sovereign';
+}

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -132,13 +132,67 @@ to get started — every variable is documented there.
 | `SOVEREIGN_DEV_MODE_ENABLED` | no       | —                                                   | Set to `true` to enable production dev-mode (RFC 0020). When unset the feature does not exist and the dev-mode secret header is ignored entirely.                                                                                                                                                                                                                                                               |
 | `SOVEREIGN_DEV_MODE_SECRET`  | no       | `SOVEREIGN_ADMIN_KEY`                               | Secret callers supply in `X-Sovereign-Dev-Mode-Secret` to activate dev-mode on a request. Defaults to `SOVEREIGN_ADMIN_KEY` when unset. Set explicitly in production.                                                                                                                                                                                                                                           |
 | `SOVEREIGN_DEV_DATABASE_URL` | no       | —                                                   | URL of the mock database populated by `sv seed`. Dev-mode requests resolve all platform DB reads/writes to this database. Must be a separate file/schema from `DATABASE_URL`. Example: `file:./data/sovereign-dev.db`.                                                                                                                                                                                          |
-| `BRAND_NAME`                 | no       | `Sovereign`                                         | Display name of the instance shown in the shell, login page, and email. Overridable per tenant in Console → Settings → Branding.                                                                                                                                                                                                                                                                                |
+| `BRAND_NAME`                 | no       | `Sovereign`                                         | Display name of the instance. Appears in the runtime shell header, the auth server login page title and heading, and outbound email. Read server-side at request time (not baked at build). Overridable per tenant in Console → Settings → Branding.                                                                                                                                                            |
 | `BRAND_PRIMARY_COLOR`        | no       | —                                                   | 6-digit hex accent colour (e.g. `#3b82f6`) injected as `--sv-color-accent`. Leave unset to use the default monochrome palette.                                                                                                                                                                                                                                                                                  |
 | `BRAND_LOGO`                 | no       | —                                                   | URL of the light-theme brand logo. Use an absolute URL for an external logo, or `/api/brand/logo` after uploading via Console → Branding.                                                                                                                                                                                                                                                                       |
 | `BRAND_LOGO_DARK`            | no       | `BRAND_LOGO`                                        | URL of the dark-theme brand logo. Falls back to `BRAND_LOGO` when unset.                                                                                                                                                                                                                                                                                                                                        |
 | `BRAND_FAVICON`              | no       | —                                                   | URL of the branded favicon. Falls back to the built-in `favicon.ico` when unset.                                                                                                                                                                                                                                                                                                                                |
 | `BRAND_EMAIL_FROM_NAME`      | no       | —                                                   | Sender display name used in outbound email (invite, password reset). Falls back to `BRAND_NAME` when unset.                                                                                                                                                                                                                                                                                                     |
 | `BRAND_EMAIL_LOGO`           | no       | —                                                   | Publicly reachable URL for the logo included in HTML email bodies. Must be reachable by email client rendering engines — not a path-relative URL.                                                                                                                                                                                                                                                               |
+
+---
+
+## Branding and white-labeling
+
+Sovereign supports full white-labeling via env vars (instance-wide defaults) and
+the Console Branding UI (per-tenant overrides stored in the database). The two
+layers stack: Console settings take precedence over env vars; env vars take
+precedence over built-in defaults.
+
+### What `BRAND_NAME` affects
+
+`BRAND_NAME` is read server-side at request time by both apps, so changing it in
+your deployment env takes effect on the next request without a rebuild.
+
+| Surface          | App         | Detail                                                      |
+| ---------------- | ----------- | ----------------------------------------------------------- |
+| Shell header     | Runtime     | Shown as the instance name when no logo is configured       |
+| Page `<title>`   | Auth server | `<BRAND_NAME>` — used for the browser tab and bookmark name |
+| Login heading    | Auth server | "Sign in to `<BRAND_NAME>`"                                 |
+| Page description | Auth server | "Sign in to your `<BRAND_NAME>` workspace."                 |
+| Outbound email   | Both        | Subject lines and body copy use the brand name              |
+| PWA manifest     | Runtime     | `name` and `short_name` in the web app manifest             |
+
+### Env-var branding (instance-wide)
+
+Set any of the `BRAND_*` vars in `.env` before starting the containers. All are
+optional — unset vars fall back to the Sovereign defaults.
+
+```env
+BRAND_NAME=Acme Workspace
+BRAND_PRIMARY_COLOR=#3b82f6      # hex accent colour
+BRAND_LOGO=https://cdn.example.com/logo.png
+BRAND_LOGO_DARK=https://cdn.example.com/logo-dark.png
+BRAND_FAVICON=https://cdn.example.com/favicon.ico
+BRAND_EMAIL_FROM_NAME=Acme      # email sender display name
+BRAND_EMAIL_LOGO=https://cdn.example.com/logo-email.png
+```
+
+> **Logo and favicon URLs** must be publicly reachable absolute URLs. The auth
+> server login page loads before any session exists, so relative or
+> session-gated paths won't work. Use a CDN, object storage, or upload via the
+> Console (which exposes `/api/brand/logo` and `/api/brand/favicon` as
+> unauthenticated endpoints).
+
+### Console branding (per-tenant override)
+
+**Console → Settings → Branding** provides a live UI for the same fields. Values
+saved there are stored in the `tenant_branding` table and take precedence over
+env vars for every request — no restart needed. This is the recommended path for
+operators who want to update branding without touching deployment config.
+
+To reset a Console-set value back to the env-var default, clear the field in
+Console and save.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `apps/auth/src/brand-name.ts` — reads `BRAND_NAME` env var, falls back to `'Sovereign'`. Same pattern as the runtime's `BrandProvider`.
- `apps/auth/app/layout.tsx`: replaces static `metadata` with `generateMetadata()` so both the page title and description reference the brand name.
- `apps/auth/app/login/page.tsx`: passes `brandName()` result to `LoginForm` as a prop (same server-resolved-prop pattern as `runtimeUrl`).
- `apps/auth/app/login/login-form.tsx`: renders `Sign in to {brandName}` instead of the hardcoded `Sign in to Sovereign`.

No env var changes — `BRAND_NAME` was already documented in `.env.example` by Task 1.0.03. Operators who set it in their `.env` (or Docker Compose) will now see it reflected on the auth login page.

## Test plan

- [ ] Without `BRAND_NAME` set → login page shows "Sign in to Sovereign" and `<title>Sovereign</title>`
- [ ] With `BRAND_NAME=Acme Corp` → login page shows "Sign in to Acme Corp" and `<title>Acme Corp</title>`
- [ ] `pnpm format:check && pnpm lint && pnpm typecheck` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)