### PR TITLE
feat(runtime): dynamic page title from brand name

### DIFF
--- a/runtime/app/layout.tsx
+++ b/runtime/app/layout.tsx
@@ -2,20 +2,34 @@ import '@sovereignfs/ui/tokens.css';
 import './globals.css';
 import type { ReactNode } from 'react';
 import type { Metadata, Viewport } from 'next';
+import { DEFAULT_TENANT_ID, getPlatformDb, getTenantBranding } from '@sovereignfs/db';
 import { themeScript } from '@/src/theme-script';
 
-export const metadata: Metadata = {
-  title: 'Sovereign',
-  description: 'Your self-hosted workspace.',
-  // Installable PWA (SRS §3.11, PLT-09). The web manifest + icons live in
-  // public/; the service worker is generated there at build by next-pwa.
-  manifest: '/manifest.json',
-  appleWebApp: { capable: true, title: 'Sovereign', statusBarStyle: 'black-translucent' },
-  icons: {
-    icon: '/icons/icon-192.png',
-    apple: '/icons/apple-touch-icon.png',
-  },
-};
+// Resolved at request time so the page <title> reflects the operator's brand
+// name whether it was set via DB (Console Settings) or BRAND_NAME env. Falls
+// back to 'Sovereign' when the DB is unavailable (e.g. during build).
+export async function generateMetadata(): Promise<Metadata> {
+  let name = process.env.BRAND_NAME ?? 'Sovereign';
+  try {
+    const pdb = await getPlatformDb();
+    const branding = await getTenantBranding(pdb, DEFAULT_TENANT_ID);
+    name = branding.brandName;
+  } catch {
+    // Metadata is cosmetic — never crash on a failed DB read.
+  }
+  return {
+    title: name,
+    description: 'Your self-hosted workspace.',
+    // Installable PWA (SRS §3.11, PLT-09). The web manifest + icons live in
+    // public/; the service worker is generated there at build by next-pwa.
+    manifest: '/manifest.json',
+    appleWebApp: { capable: true, title: name, statusBarStyle: 'black-translucent' },
+    icons: {
+      icon: '/icons/icon-192.png',
+      apple: '/icons/apple-touch-icon.png',
+    },
+  };
+}
 
 export const viewport: Viewport = {
   themeColor: '#09090b',


### PR DESCRIPTION
## Summary

Replaces the static `metadata = { title: 'Sovereign' }` export in `runtime/app/layout.tsx` with an async `generateMetadata()` that reads the brand name from the platform DB — the same source as `BrandProvider`, which already drives the sidebar logo and shell chrome.

Fallback chain: DB `tenant_branding.brand_name` → `BRAND_NAME` env → `'Sovereign'`. The `appleWebApp.title` (PWA install name) also uses the resolved name.

**Effect:** The browser tab title, PWA install dialog, and Apple home screen shortcut title all reflect whatever the operator set in Console → Settings → Branding, without requiring a restart or rebuild.

**No breaking change:** instances without a configured brand name continue to show "Sovereign".

## Test plan

- [ ] Without BRAND_NAME or DB brand: `<title>Sovereign</title>`
- [ ] With `BRAND_NAME=My Workspace` env: `<title>My Workspace</title>`
- [ ] After setting brand name in Console → Settings → Branding → saving: next page load shows `<title>Acme Corp</title>` (or whatever was set)
- [ ] PWA install dialog shows correct name
- [ ] `pnpm format:check && pnpm lint && pnpm typecheck` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)