### PR TITLE
fix(runtime): return 503 not 500 when SOVEREIGN_ADMIN_KEY is unset

### DIFF
--- a/runtime/src/__tests__/admin-guard.test.ts
+++ b/runtime/src/__tests__/admin-guard.test.ts
@@ -31,8 +31,8 @@ describe('checkAdminKey (runtime)', () => {
     expect(checkAdminKey(requestWithAuth())?.status).toBe(403);
   });
 
-  it('returns 500 when SOVEREIGN_ADMIN_KEY is not configured', () => {
+  it('returns 503 when SOVEREIGN_ADMIN_KEY is not configured', () => {
     delete process.env.SOVEREIGN_ADMIN_KEY;
-    expect(checkAdminKey(requestWithAuth('Bearer anything'))?.status).toBe(500);
+    expect(checkAdminKey(requestWithAuth('Bearer anything'))?.status).toBe(503);
   });
 });

--- a/runtime/src/admin-guard.ts
+++ b/runtime/src/admin-guard.ts
@@ -8,7 +8,9 @@ import { NextResponse } from 'next/server';
 export function checkAdminKey(request: Request): NextResponse | null {
   const adminKey = process.env.SOVEREIGN_ADMIN_KEY;
   if (!adminKey) {
-    return NextResponse.json({ error: 'SOVEREIGN_ADMIN_KEY is not configured' }, { status: 500 });
+    // 503 Service Unavailable: the server is running but misconfigured.
+    // 500 would imply a bug; the operator simply hasn't set the required key.
+    return NextResponse.json({ error: 'SOVEREIGN_ADMIN_KEY is not configured' }, { status: 503 });
   }
   const auth = request.headers.get('authorization') ?? '';
   if (auth !== `Bearer ${adminKey}`) {


### PR DESCRIPTION
## Summary

`checkAdminKey()` in `runtime/src/admin-guard.ts` returned HTTP 500 when `SOVEREIGN_ADMIN_KEY` was not set. This was semantically wrong:

- **500 Internal Server Error** — implies a code bug or unhandled exception.
- **503 Service Unavailable** — the server is running but currently unable to handle the request, typically due to misconfiguration or a dependent service being down.

An operator forgetting to set the admin key is a configuration issue, not a code defect. Returning 503 gives a clearer signal to:
- Operators reading logs ("why is my admin API broken?")
- Monitoring tools that treat 5xx differently (503 is often non-alerting in uptime checks; 500 triggers "bug" pages)
- The admin health endpoint, which callers may observe

One-line change to the status code; comment added explaining the rationale.

## Test plan

- [ ] `SOVEREIGN_ADMIN_KEY` unset → `GET /api/admin/health` returns 503
- [ ] `SOVEREIGN_ADMIN_KEY` set but wrong value → still 403
- [ ] `SOVEREIGN_ADMIN_KEY` set correctly → 200
- [ ] `pnpm format:check && pnpm lint && pnpm typecheck` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)