### PR TITLE
fix(console): use Promise.allSettled in settings page

### DIFF
--- a/plugins/console/app/settings/page.tsx
+++ b/plugins/console/app/settings/page.tsx
@@ -44,12 +44,31 @@ async function adminGet<T>(path: string): Promise<T> {
   return res.json() as Promise<T>;
 }
 
+const DEFAULT_SETTINGS: Settings = { tenantName: 'Sovereign', inviteOnly: false, rootPluginId: '' };
+const DEFAULT_BRANDING: Branding = {
+  brandName: 'Sovereign',
+  brandLogo: null,
+  brandLogoDark: null,
+  brandFavicon: null,
+  brandPrimary: null,
+  emailFromName: null,
+  emailLogo: null,
+};
+
+function settled<T>(result: PromiseSettledResult<T>, fallback: T): T {
+  return result.status === 'fulfilled' ? result.value : fallback;
+}
+
 export default async function SettingsPage() {
-  const [settings, plugins, branding] = await Promise.all([
+  const [settingsResult, pluginsResult, brandingResult] = await Promise.allSettled([
     adminGet<Settings>('/api/admin/settings'),
     adminGet<PluginRow[]>('/api/admin/plugins'),
     adminGet<Branding>('/api/admin/tenant-branding'),
   ]);
+
+  const settings = settled(settingsResult, DEFAULT_SETTINGS);
+  const plugins = settled(pluginsResult, [] as PluginRow[]);
+  const branding = settled(brandingResult, DEFAULT_BRANDING);
 
   // Only installed, enabled, non-adminOnly, non-overlay plugins are eligible
   // roots (CON-11): `/` is served as a full page, which overlay plugins cannot.


### PR DESCRIPTION
## Summary

The Console Settings page fetches three endpoints in parallel (`/api/admin/settings`, `/api/admin/plugins`, `/api/admin/tenant-branding`) with `Promise.all`. A failure in any one of them (e.g. a transient DB error, or the migration timing bug that was previously present on `tenant_branding`) threw an uncaught error and crashed the entire page.

Switched to `Promise.allSettled` with per-result fallback defaults:
- `settings` → `{ tenantName: 'Sovereign', inviteOnly: false, rootPluginId: '' }`
- `plugins` → `[]`
- `branding` → safe empty-values object

Sections backed by a failed fetch render with defaults and remain interactive; the operator can still change the settings that did load.

## Test plan

- [ ] All three fetches succeed → page renders normally as before
- [ ] Simulate one fetch failing (e.g. wrong admin key temporarily) → other sections still render; failed section shows defaults
- [ ] `pnpm format:check && pnpm lint && pnpm typecheck` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)