### PR TITLE
fix(console): resolve invite link URL at runtime for any deployment

### DIFF
--- a/plugins/console/app/users/actions.ts
+++ b/plugins/console/app/users/actions.ts
@@ -123,7 +123,10 @@ export async function sendInviteAction(
 
   const { token } = (await res.json()) as { token: string; email: string };
 
-  const runtimeUrl = `http://localhost:${process.env.PORT ?? '3000'}`;
+  // Read via a computed key so Next.js does not inline the value at build time
+  // (the Docker image builds without .env, freezing a literal to localhost:3000).
+  const runtimeUrlKey = 'NEXT_PUBLIC_RUNTIME_URL';
+  const runtimeUrl = process.env[runtimeUrlKey] ?? `http://localhost:${process.env.PORT ?? '3000'}`;
   const registerUrl = `${runtimeUrl}/register`;
   await sdk.mailer.send({
     to: email,


### PR DESCRIPTION
## Summary

- Invite emails sent via Console now include the correct public runtime URL regardless of deployment type
- Reads `NEXT_PUBLIC_RUNTIME_URL` via a computed property key (not a literal) to avoid Next.js build-time inlining — the Docker image builds without `.env`, so a literal access would freeze to the localhost fallback and ignore the value injected at container start
- Falls back to `http://localhost:${PORT ?? '3000'}` for local/PM2 deployments where `NEXT_PUBLIC_RUNTIME_URL` is unset

## Test plan

- [ ] Invite a user from Console with `NEXT_PUBLIC_RUNTIME_URL` unset — link uses `http://localhost:3000`
- [ ] Invite with `NEXT_PUBLIC_RUNTIME_URL=https://myserver.com` in `.env` — link uses `https://myserver.com/register`
- [ ] Invite with `PORT=4000` and no `NEXT_PUBLIC_RUNTIME_URL` — link uses `http://localhost:4000/register`
- [ ] `pnpm lint && pnpm format:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)