### PR TITLE
feat(console,account): inline form feedback via useActionState

### DIFF
--- a/plugins/account/app/account.module.css
+++ b/plugins/account/app/account.module.css
@@ -156,6 +156,26 @@
   color: var(--sv-color-accent);
 }
 
+.feedbackSuccess {
+  margin: 0;
+  font-size: var(--sv-font-size-sm);
+  padding: var(--sv-space-2) var(--sv-space-3);
+  border-radius: var(--sv-radius-md);
+  border: 1px solid var(--sv-color-success-border);
+  background-color: var(--sv-color-success-surface);
+  color: var(--sv-color-success-text);
+}
+
+.feedbackError {
+  margin: 0;
+  font-size: var(--sv-font-size-sm);
+  padding: var(--sv-space-2) var(--sv-space-3);
+  border-radius: var(--sv-radius-md);
+  border: 1px solid var(--sv-color-error-border);
+  background-color: var(--sv-color-error-surface);
+  color: var(--sv-color-error-text);
+}
+
 /* ── Sessions ───────────────────────────────────────────────────────────── */
 
 .sessionList {

--- a/plugins/account/app/actions.ts
+++ b/plugins/account/app/actions.ts
@@ -42,12 +42,18 @@ async function authPost(path: string, body: Record<string, unknown>): Promise<Re
   });
 }
 
+export type DisplayNameResult = { ok: true; message: string } | { ok: false; error: string };
+
 /** Change the display name (ACC-02). Delegates to better-auth's update-user. */
-export async function updateDisplayNameAction(formData: FormData): Promise<void> {
+export async function updateDisplayNameAction(
+  _prev: DisplayNameResult | null,
+  formData: FormData,
+): Promise<DisplayNameResult> {
   await sdk.auth.requireSession();
   const name = (formData.get('name') as string | null)?.trim() ?? '';
-  if (name.length === 0) throw new Error('Display name is required.');
-  if (name.length > 100) throw new Error('Display name must be 100 characters or fewer.');
+  if (name.length === 0) return { ok: false, error: 'Display name is required.' };
+  if (name.length > 100)
+    return { ok: false, error: 'Display name must be 100 characters or fewer.' };
 
   const res = await fetch(`${AUTH_URL}/api/auth/update-user`, {
     method: 'POST',
@@ -60,13 +66,14 @@ export async function updateDisplayNameAction(formData: FormData): Promise<void>
     },
     body: JSON.stringify({ name }),
   });
-  if (!res.ok) throw new Error(`Failed to update display name: ${res.status}`);
+  if (!res.ok) return { ok: false, error: `Failed to update display name: ${res.status}` };
   await invalidateSessionCache();
   void sdk.activity.log({
     action: 'account.display_name_changed',
     summary: 'Display name updated',
   });
   revalidatePath('/account/profile');
+  return { ok: true, message: 'Name saved.' };
 }
 
 /** Persist a preference change (ACC-07/08) via the runtime account-prefs route. */

--- a/plugins/account/app/profile/DisplayNameForm.tsx
+++ b/plugins/account/app/profile/DisplayNameForm.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useActionState } from 'react';
+import { type DisplayNameResult, updateDisplayNameAction } from '../actions';
+import styles from '../account.module.css';
+
+export function DisplayNameForm({ initialName }: { initialName: string }) {
+  const [state, action, pending] = useActionState<DisplayNameResult | null, FormData>(
+    updateDisplayNameAction,
+    null,
+  );
+
+  return (
+    <form action={action} className={styles.form}>
+      <div className={styles.field}>
+        <label className={styles.label} htmlFor="name">
+          Name
+        </label>
+        <input
+          id="name"
+          name="name"
+          type="text"
+          required
+          maxLength={100}
+          defaultValue={initialName}
+          className={styles.input}
+        />
+      </div>
+      {state && (
+        <p
+          className={state.ok ? styles.feedbackSuccess : styles.feedbackError}
+          role="status"
+          aria-live="polite"
+        >
+          {state.ok ? state.message : state.error}
+        </p>
+      )}
+      <button type="submit" className={styles.button} disabled={pending}>
+        {pending ? 'Saving…' : 'Save name'}
+      </button>
+    </form>
+  );
+}

--- a/plugins/account/app/profile/page.tsx
+++ b/plugins/account/app/profile/page.tsx
@@ -1,7 +1,7 @@
 import { headers } from 'next/headers';
 import { sdk } from '@sovereignfs/sdk';
-import { updateDisplayNameAction } from '../actions';
 import { AvatarUpload } from '../_components/AvatarUpload';
+import { DisplayNameForm } from './DisplayNameForm';
 import styles from '../account.module.css';
 
 export const dynamic = 'force-dynamic';
@@ -53,25 +53,7 @@ export default async function ProfilePage() {
 
       <section className={styles.section}>
         <h2 className={styles.sectionTitle}>Display name</h2>
-        <form action={updateDisplayNameAction} className={styles.form}>
-          <div className={styles.field}>
-            <label className={styles.label} htmlFor="name">
-              Name
-            </label>
-            <input
-              id="name"
-              name="name"
-              type="text"
-              required
-              maxLength={100}
-              defaultValue={name ?? ''}
-              className={styles.input}
-            />
-          </div>
-          <button type="submit" className={styles.button}>
-            Save name
-          </button>
-        </form>
+        <DisplayNameForm initialName={name ?? ''} />
       </section>
 
       <section className={styles.section}>

--- a/plugins/console/app/console.module.css
+++ b/plugins/console/app/console.module.css
@@ -397,6 +397,24 @@
   background-color: var(--sv-color-surface-sunken);
 }
 
+.feedbackSuccess {
+  font-size: var(--sv-font-size-sm);
+  padding: var(--sv-space-2) var(--sv-space-3);
+  border-radius: var(--sv-radius-md);
+  border: 1px solid var(--sv-color-success-border);
+  background-color: var(--sv-color-success-surface);
+  color: var(--sv-color-success-text);
+}
+
+.feedbackError {
+  font-size: var(--sv-font-size-sm);
+  padding: var(--sv-space-2) var(--sv-space-3);
+  border-radius: var(--sv-radius-md);
+  border: 1px solid var(--sv-color-error-border);
+  background-color: var(--sv-color-error-surface);
+  color: var(--sv-color-error-text);
+}
+
 /* ── Utility ────────────────────────────────────────────────────────────── */
 
 .textMuted {

--- a/plugins/console/app/settings/SettingsForms.tsx
+++ b/plugins/console/app/settings/SettingsForms.tsx
@@ -1,0 +1,304 @@
+'use client';
+
+import { useActionState } from 'react';
+import styles from '../console.module.css';
+import {
+  type ActionResult,
+  updateTenantNameAction,
+  updateInviteOnlyAction,
+  updateRootPluginAction,
+  updateBrandingAction,
+  uploadLogoAction,
+  uploadFaviconAction,
+} from './actions';
+
+function Feedback({ result }: { result: ActionResult | null }) {
+  if (!result) return null;
+  return (
+    <p
+      className={result.ok ? styles.feedbackSuccess : styles.feedbackError}
+      role="status"
+      aria-live="polite"
+    >
+      {result.ok ? result.message : result.error}
+    </p>
+  );
+}
+
+export function TenantForm({ initialName }: { initialName: string }) {
+  const [state, action, pending] = useActionState(updateTenantNameAction, null);
+  return (
+    <form action={action} className={styles.settingsForm}>
+      <div className={styles.fieldGroup}>
+        <label className={styles.label} htmlFor="tenantName">
+          Tenant name
+        </label>
+        <input
+          id="tenantName"
+          name="tenantName"
+          type="text"
+          required
+          defaultValue={initialName}
+          className={styles.input}
+        />
+      </div>
+      <Feedback result={state} />
+      <button type="submit" className={styles.actionButton} disabled={pending}>
+        {pending ? 'Saving…' : 'Save name'}
+      </button>
+    </form>
+  );
+}
+
+export function InviteOnlyForm({ initialValue }: { initialValue: boolean }) {
+  const [state, action, pending] = useActionState(updateInviteOnlyAction, null);
+  return (
+    <form action={action} className={styles.settingsForm}>
+      <label className={styles.checkboxRow}>
+        <input type="checkbox" name="inviteOnly" defaultChecked={initialValue} />
+        <span>
+          Invite-only registration
+          <span className={styles.helpText}>
+            When enabled, only invited email addresses can register. The first user is always
+            exempt.
+          </span>
+        </span>
+      </label>
+      <Feedback result={state} />
+      <button type="submit" className={styles.actionButton} disabled={pending}>
+        {pending ? 'Saving…' : 'Save registration policy'}
+      </button>
+    </form>
+  );
+}
+
+interface PluginOption {
+  id: string;
+  name: string;
+}
+
+export function RootPluginForm({
+  candidates,
+  currentId,
+  currentInstalled,
+}: {
+  candidates: PluginOption[];
+  currentId: string;
+  currentInstalled: boolean;
+}) {
+  const [state, action, pending] = useActionState(updateRootPluginAction, null);
+  return (
+    <form action={action} className={styles.settingsForm}>
+      <div className={styles.fieldGroup}>
+        <label className={styles.label} htmlFor="rootPluginId">
+          Plugin served at <code className={styles.codeInline}>/</code>
+        </label>
+        {candidates.length === 0 ? (
+          <p className={styles.helpText}>
+            No eligible plugins installed yet. The Launcher (the default root) arrives with the next
+            platform task; until then <code className={styles.codeInline}>/</code> shows a
+            placeholder.
+          </p>
+        ) : (
+          <select
+            id="rootPluginId"
+            name="rootPluginId"
+            defaultValue={currentInstalled ? currentId : undefined}
+            className={styles.roleSelect}
+          >
+            {!currentInstalled && (
+              <option value="" disabled>
+                {currentId} (not installed)
+              </option>
+            )}
+            {candidates.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.name} ({p.id})
+              </option>
+            ))}
+          </select>
+        )}
+      </div>
+      <Feedback result={state} />
+      {candidates.length > 0 && (
+        <button type="submit" className={styles.actionButton} disabled={pending}>
+          {pending ? 'Saving…' : 'Save root plugin'}
+        </button>
+      )}
+    </form>
+  );
+}
+
+export interface BrandingValues {
+  brandName: string;
+  brandLogo: string | null;
+  brandLogoDark: string | null;
+  brandFavicon: string | null;
+  brandPrimary: string | null;
+  emailFromName: string | null;
+  emailLogo: string | null;
+}
+
+export function BrandingForm({ initialValues }: { initialValues: BrandingValues }) {
+  const [state, action, pending] = useActionState(updateBrandingAction, null);
+  return (
+    <form action={action} className={styles.settingsForm}>
+      <div className={styles.fieldGroup}>
+        <label className={styles.label} htmlFor="brandName">
+          Brand name
+        </label>
+        <input
+          id="brandName"
+          name="brandName"
+          type="text"
+          placeholder="Sovereign"
+          defaultValue={initialValues.brandName !== 'Sovereign' ? initialValues.brandName : ''}
+          className={styles.input}
+        />
+        <span className={styles.helpText}>Displayed in the shell header and login page.</span>
+      </div>
+      <div className={styles.fieldGroup}>
+        <label className={styles.label} htmlFor="brandPrimary">
+          Primary colour
+        </label>
+        <input
+          id="brandPrimary"
+          name="brandPrimary"
+          type="text"
+          pattern="^#[0-9a-fA-F]{6}$"
+          placeholder="#3b82f6"
+          defaultValue={initialValues.brandPrimary ?? ''}
+          className={styles.input}
+        />
+        <span className={styles.helpText}>
+          6-digit hex (e.g. <code className={styles.codeInline}>#3b82f6</code>). Sets{' '}
+          <code className={styles.codeInline}>--sv-color-accent</code>. Leave blank to use the
+          default.
+        </span>
+      </div>
+      <div className={styles.fieldGroup}>
+        <label className={styles.label} htmlFor="brandLogo">
+          Logo URL (light theme)
+        </label>
+        <input
+          id="brandLogo"
+          name="brandLogo"
+          type="url"
+          placeholder="https://… or /api/brand/logo"
+          defaultValue={initialValues.brandLogo ?? ''}
+          className={styles.input}
+        />
+      </div>
+      <div className={styles.fieldGroup}>
+        <label className={styles.label} htmlFor="brandLogoDark">
+          Logo URL (dark theme)
+        </label>
+        <input
+          id="brandLogoDark"
+          name="brandLogoDark"
+          type="url"
+          placeholder="https://… or /api/brand/logo?dark=1"
+          defaultValue={initialValues.brandLogoDark ?? ''}
+          className={styles.input}
+        />
+      </div>
+      <div className={styles.fieldGroup}>
+        <label className={styles.label} htmlFor="brandFavicon">
+          Favicon URL
+        </label>
+        <input
+          id="brandFavicon"
+          name="brandFavicon"
+          type="url"
+          placeholder="https://… or /api/brand/favicon"
+          defaultValue={initialValues.brandFavicon ?? ''}
+          className={styles.input}
+        />
+      </div>
+      <div className={styles.fieldGroup}>
+        <label className={styles.label} htmlFor="emailFromName">
+          Email sender name
+        </label>
+        <input
+          id="emailFromName"
+          name="emailFromName"
+          type="text"
+          placeholder="Sovereign"
+          defaultValue={initialValues.emailFromName ?? ''}
+          className={styles.input}
+        />
+      </div>
+      <div className={styles.fieldGroup}>
+        <label className={styles.label} htmlFor="emailLogo">
+          Email logo URL
+        </label>
+        <input
+          id="emailLogo"
+          name="emailLogo"
+          type="url"
+          placeholder="https://…"
+          defaultValue={initialValues.emailLogo ?? ''}
+          className={styles.input}
+        />
+        <span className={styles.helpText}>
+          Used in outbound email HTML templates. Must be publicly reachable.
+        </span>
+      </div>
+      <Feedback result={state} />
+      <button type="submit" className={styles.actionButton} disabled={pending}>
+        {pending ? 'Saving…' : 'Save branding'}
+      </button>
+    </form>
+  );
+}
+
+export function LogoUploadForm({ dark }: { dark: boolean }) {
+  const [state, action, pending] = useActionState(uploadLogoAction, null);
+  return (
+    <form action={action} className={styles.settingsForm} style={{ marginTop: '8px' }}>
+      <input type="hidden" name="dark" value={dark ? '1' : '0'} />
+      <div className={styles.fieldGroup}>
+        <label className={styles.label} htmlFor={dark ? 'logoDarkFile' : 'logoFile'}>
+          {dark ? 'Upload logo (dark theme)' : 'Upload logo (light theme)'}
+        </label>
+        <input
+          id={dark ? 'logoDarkFile' : 'logoFile'}
+          name="file"
+          type="file"
+          accept="image/png,image/svg+xml,image/jpeg,image/webp"
+          className={styles.input}
+        />
+        {!dark && <span className={styles.helpText}>PNG, SVG, JPEG, or WebP · max 2 MB</span>}
+      </div>
+      <Feedback result={state} />
+      <button type="submit" className={styles.actionButton} disabled={pending}>
+        {pending ? 'Uploading…' : 'Upload'}
+      </button>
+    </form>
+  );
+}
+
+export function FaviconUploadForm() {
+  const [state, action, pending] = useActionState(uploadFaviconAction, null);
+  return (
+    <form action={action} className={styles.settingsForm} style={{ marginTop: '8px' }}>
+      <div className={styles.fieldGroup}>
+        <label className={styles.label} htmlFor="faviconFile">
+          Upload favicon
+        </label>
+        <input
+          id="faviconFile"
+          name="file"
+          type="file"
+          accept="image/png,image/svg+xml,image/x-icon,image/webp"
+          className={styles.input}
+        />
+        <span className={styles.helpText}>PNG, SVG, ICO, or WebP · max 2 MB</span>
+      </div>
+      <Feedback result={state} />
+      <button type="submit" className={styles.actionButton} disabled={pending}>
+        {pending ? 'Uploading…' : 'Upload'}
+      </button>
+    </form>
+  );
+}

--- a/plugins/console/app/settings/actions.ts
+++ b/plugins/console/app/settings/actions.ts
@@ -5,11 +5,11 @@ import { sdk } from '@sovereignfs/sdk';
 
 const HEX_COLOR_RE = /^#[0-9a-fA-F]{6}$/;
 
-// Self-fetch address for the runtime's own admin API — the server always
-// listens on :3000 (see plugins/actions.ts for the reverse-proxy rationale).
 const SELF_URL = `http://localhost:${process.env.PORT ?? '3000'}`;
 
-async function patchSettings(body: Record<string, unknown>): Promise<void> {
+export type ActionResult = { ok: true; message: string } | { ok: false; error: string };
+
+async function patchSettings(body: Record<string, unknown>): Promise<ActionResult> {
   await sdk.auth.requireSession();
   const adminKey = process.env.SOVEREIGN_ADMIN_KEY ?? '';
   const res = await fetch(`${SELF_URL}/api/admin/settings`, {
@@ -22,29 +22,42 @@ async function patchSettings(body: Record<string, unknown>): Promise<void> {
   });
   if (!res.ok) {
     const detail = ((await res.json().catch(() => null)) as { error?: string } | null)?.error;
-    throw new Error(detail ?? `Failed to update settings: ${res.status}`);
+    return { ok: false, error: detail ?? `Failed to update settings: ${res.status}` };
   }
   revalidatePath('/console/settings');
   revalidatePath('/');
+  return { ok: true, message: 'Saved.' };
 }
 
-export async function updateTenantNameAction(formData: FormData): Promise<void> {
+export async function updateTenantNameAction(
+  _prev: ActionResult | null,
+  formData: FormData,
+): Promise<ActionResult> {
   const tenantName = (formData.get('tenantName') as string | null)?.trim();
-  if (!tenantName) throw new Error('Tenant name is required.');
-  await patchSettings({ tenantName });
+  if (!tenantName) return { ok: false, error: 'Tenant name is required.' };
+  return patchSettings({ tenantName });
 }
 
-export async function updateInviteOnlyAction(formData: FormData): Promise<void> {
-  await patchSettings({ inviteOnly: formData.get('inviteOnly') === 'on' });
+export async function updateInviteOnlyAction(
+  _prev: ActionResult | null,
+  formData: FormData,
+): Promise<ActionResult> {
+  return patchSettings({ inviteOnly: formData.get('inviteOnly') === 'on' });
 }
 
-export async function updateRootPluginAction(formData: FormData): Promise<void> {
+export async function updateRootPluginAction(
+  _prev: ActionResult | null,
+  formData: FormData,
+): Promise<ActionResult> {
   const rootPluginId = formData.get('rootPluginId') as string | null;
-  if (!rootPluginId) throw new Error('Select a plugin.');
-  await patchSettings({ rootPluginId });
+  if (!rootPluginId) return { ok: false, error: 'Select a plugin.' };
+  return patchSettings({ rootPluginId });
 }
 
-export async function updateBrandingAction(formData: FormData): Promise<void> {
+export async function updateBrandingAction(
+  _prev: ActionResult | null,
+  formData: FormData,
+): Promise<ActionResult> {
   await sdk.auth.requireSession();
   const adminKey = process.env.SOVEREIGN_ADMIN_KEY ?? '';
 
@@ -57,7 +70,7 @@ export async function updateBrandingAction(formData: FormData): Promise<void> {
   const emailLogo = (formData.get('emailLogo') as string | null)?.trim() || null;
 
   if (brandPrimary && !HEX_COLOR_RE.test(brandPrimary)) {
-    throw new Error('Primary colour must be a 6-digit hex value, e.g. #3b82f6.');
+    return { ok: false, error: 'Primary colour must be a 6-digit hex value, e.g. #3b82f6.' };
   }
 
   const body = {
@@ -76,18 +89,22 @@ export async function updateBrandingAction(formData: FormData): Promise<void> {
   });
   if (!res.ok) {
     const detail = ((await res.json().catch(() => null)) as { error?: string } | null)?.error;
-    throw new Error(detail ?? `Failed to update branding: ${res.status}`);
+    return { ok: false, error: detail ?? `Failed to update branding: ${res.status}` };
   }
   revalidatePath('/console/settings');
   revalidatePath('/');
+  return { ok: true, message: 'Branding saved.' };
 }
 
-export async function uploadLogoAction(formData: FormData): Promise<void> {
+export async function uploadLogoAction(
+  _prev: ActionResult | null,
+  formData: FormData,
+): Promise<ActionResult> {
   await sdk.auth.requireSession();
   const adminKey = process.env.SOVEREIGN_ADMIN_KEY ?? '';
   const dark = formData.get('dark') === '1';
   const file = formData.get('file') as File | null;
-  if (!file) throw new Error('No file provided.');
+  if (!file || file.size === 0) return { ok: false, error: 'No file selected.' };
   const uploadForm = new FormData();
   uploadForm.set('file', file);
   const url = `${SELF_URL}/api/brand/logo${dark ? '?dark=1' : ''}`;
@@ -98,17 +115,21 @@ export async function uploadLogoAction(formData: FormData): Promise<void> {
   });
   if (!res.ok) {
     const detail = ((await res.json().catch(() => null)) as { error?: string } | null)?.error;
-    throw new Error(detail ?? `Failed to upload logo: ${res.status}`);
+    return { ok: false, error: detail ?? `Failed to upload logo: ${res.status}` };
   }
   revalidatePath('/console/settings');
   revalidatePath('/');
+  return { ok: true, message: `Logo (${dark ? 'dark' : 'light'}) uploaded.` };
 }
 
-export async function uploadFaviconAction(formData: FormData): Promise<void> {
+export async function uploadFaviconAction(
+  _prev: ActionResult | null,
+  formData: FormData,
+): Promise<ActionResult> {
   await sdk.auth.requireSession();
   const adminKey = process.env.SOVEREIGN_ADMIN_KEY ?? '';
   const file = formData.get('file') as File | null;
-  if (!file) throw new Error('No file provided.');
+  if (!file || file.size === 0) return { ok: false, error: 'No file selected.' };
   const uploadForm = new FormData();
   uploadForm.set('file', file);
   const res = await fetch(`${SELF_URL}/api/brand/favicon`, {
@@ -118,8 +139,9 @@ export async function uploadFaviconAction(formData: FormData): Promise<void> {
   });
   if (!res.ok) {
     const detail = ((await res.json().catch(() => null)) as { error?: string } | null)?.error;
-    throw new Error(detail ?? `Failed to upload favicon: ${res.status}`);
+    return { ok: false, error: detail ?? `Failed to upload favicon: ${res.status}` };
   }
   revalidatePath('/console/settings');
   revalidatePath('/');
+  return { ok: true, message: 'Favicon uploaded.' };
 }

--- a/plugins/console/app/settings/page.tsx
+++ b/plugins/console/app/settings/page.tsx
@@ -69,10 +69,6 @@ export default async function SettingsPage() {
   const plugins = settled(pluginsResult, [] as PluginRow[]);
   const branding = settled(brandingResult, DEFAULT_BRANDING);
 
-  const settings = settled(settingsResult, DEFAULT_SETTINGS);
-  const plugins = settled(pluginsResult, [] as PluginRow[]);
-  const branding = settled(brandingResult, DEFAULT_BRANDING);
-
   // Only installed, enabled, non-adminOnly, non-overlay plugins are eligible
   // roots (CON-11): `/` is served as a full page, which overlay plugins cannot.
   const rootCandidates = plugins.filter((p) => p.enabled && !p.adminOnly && p.shell !== 'overlay');

--- a/plugins/console/app/settings/page.tsx
+++ b/plugins/console/app/settings/page.tsx
@@ -1,12 +1,12 @@
-import {
-  updateInviteOnlyAction,
-  updateRootPluginAction,
-  updateTenantNameAction,
-  updateBrandingAction,
-  uploadLogoAction,
-  uploadFaviconAction,
-} from './actions';
 import styles from '../console.module.css';
+import {
+  TenantForm,
+  InviteOnlyForm,
+  RootPluginForm,
+  BrandingForm,
+  LogoUploadForm,
+  FaviconUploadForm,
+} from './SettingsForms';
 
 const SELF_URL = `http://localhost:${process.env.PORT ?? '3000'}`;
 
@@ -65,6 +65,9 @@ export default async function SettingsPage() {
     adminGet<PluginRow[]>('/api/admin/plugins'),
     adminGet<Branding>('/api/admin/tenant-branding'),
   ]);
+  const settings = settled(settingsResult, DEFAULT_SETTINGS);
+  const plugins = settled(pluginsResult, [] as PluginRow[]);
+  const branding = settled(brandingResult, DEFAULT_BRANDING);
 
   const settings = settled(settingsResult, DEFAULT_SETTINGS);
   const plugins = settled(pluginsResult, [] as PluginRow[]);
@@ -84,88 +87,26 @@ export default async function SettingsPage() {
       <div className={styles.settingsSections}>
         <section className={styles.settingsSection}>
           <h3 className={styles.sectionTitle}>Tenant</h3>
-          <form action={updateTenantNameAction} className={styles.settingsForm}>
-            <div className={styles.fieldGroup}>
-              <label className={styles.label} htmlFor="tenantName">
-                Tenant name
-              </label>
-              <input
-                id="tenantName"
-                name="tenantName"
-                type="text"
-                required
-                defaultValue={settings.tenantName}
-                className={styles.input}
-              />
-            </div>
-            <button type="submit" className={styles.actionButton}>
-              Save name
-            </button>
-          </form>
+          <TenantForm initialName={settings.tenantName} />
         </section>
 
         <section className={styles.settingsSection}>
           <h3 className={styles.sectionTitle}>Registration</h3>
-          <form action={updateInviteOnlyAction} className={styles.settingsForm}>
-            <label className={styles.checkboxRow}>
-              <input type="checkbox" name="inviteOnly" defaultChecked={settings.inviteOnly} />
-              <span>
-                Invite-only registration
-                <span className={styles.helpText}>
-                  When enabled, only invited email addresses can register. The first user is always
-                  exempt.
-                </span>
-              </span>
-            </label>
-            <button type="submit" className={styles.actionButton}>
-              Save registration policy
-            </button>
-          </form>
+          <InviteOnlyForm initialValue={settings.inviteOnly} />
         </section>
 
         <section className={styles.settingsSection}>
           <h3 className={styles.sectionTitle}>Root plugin</h3>
-          <form action={updateRootPluginAction} className={styles.settingsForm}>
-            <div className={styles.fieldGroup}>
-              <label className={styles.label} htmlFor="rootPluginId">
-                Plugin served at <code className={styles.codeInline}>/</code>
-              </label>
-              {rootCandidates.length === 0 ? (
-                <p className={styles.helpText}>
-                  No eligible plugins installed yet. The Launcher (the default root) arrives with
-                  the next platform task; until then <code className={styles.codeInline}>/</code>{' '}
-                  shows a placeholder.
-                </p>
-              ) : (
-                <select
-                  id="rootPluginId"
-                  name="rootPluginId"
-                  defaultValue={rootInstalled ? settings.rootPluginId : undefined}
-                  className={styles.roleSelect}
-                >
-                  {!rootInstalled && (
-                    <option value="" disabled>
-                      {settings.rootPluginId} (not installed)
-                    </option>
-                  )}
-                  {rootCandidates.map((p) => (
-                    <option key={p.id} value={p.id}>
-                      {p.name} ({p.id})
-                    </option>
-                  ))}
-                </select>
-              )}
-            </div>
-            {rootCandidates.length > 0 && (
-              <button type="submit" className={styles.actionButton}>
-                Save root plugin
-              </button>
-            )}
-          </form>
+          <RootPluginForm
+            candidates={rootCandidates.map((p) => ({ id: p.id, name: p.name }))}
+            currentId={settings.rootPluginId}
+            currentInstalled={rootInstalled}
+          />
           <p className={styles.helpText}>
             Current setting: <code className={styles.codeInline}>{settings.rootPluginId}</code>
           </p>
         </section>
+
         <section className={styles.settingsSection}>
           <h3 className={styles.sectionTitle}>Branding</h3>
           <p className={styles.helpText}>
@@ -173,186 +114,11 @@ export default async function SettingsPage() {
             stored in <code className={styles.codeInline}>data/brand/</code>.
           </p>
 
-          {/* Text / colour fields */}
-          <form action={updateBrandingAction} className={styles.settingsForm}>
-            <div className={styles.fieldGroup}>
-              <label className={styles.label} htmlFor="brandName">
-                Brand name
-              </label>
-              <input
-                id="brandName"
-                name="brandName"
-                type="text"
-                placeholder="Sovereign"
-                defaultValue={branding.brandName !== 'Sovereign' ? branding.brandName : ''}
-                className={styles.input}
-              />
-              <span className={styles.helpText}>Displayed in the shell header and login page.</span>
-            </div>
-            <div className={styles.fieldGroup}>
-              <label className={styles.label} htmlFor="brandPrimary">
-                Primary colour
-              </label>
-              <input
-                id="brandPrimary"
-                name="brandPrimary"
-                type="text"
-                pattern="^#[0-9a-fA-F]{6}$"
-                placeholder="#3b82f6"
-                defaultValue={branding.brandPrimary ?? ''}
-                className={styles.input}
-              />
-              <span className={styles.helpText}>
-                6-digit hex (e.g. <code className={styles.codeInline}>#3b82f6</code>). Sets{' '}
-                <code className={styles.codeInline}>--sv-color-accent</code>. Leave blank to use the
-                default.
-              </span>
-            </div>
-            <div className={styles.fieldGroup}>
-              <label className={styles.label} htmlFor="brandLogo">
-                Logo URL (light theme)
-              </label>
-              <input
-                id="brandLogo"
-                name="brandLogo"
-                type="url"
-                placeholder="https://… or /api/brand/logo"
-                defaultValue={branding.brandLogo ?? ''}
-                className={styles.input}
-              />
-            </div>
-            <div className={styles.fieldGroup}>
-              <label className={styles.label} htmlFor="brandLogoDark">
-                Logo URL (dark theme)
-              </label>
-              <input
-                id="brandLogoDark"
-                name="brandLogoDark"
-                type="url"
-                placeholder="https://… or /api/brand/logo?dark=1"
-                defaultValue={branding.brandLogoDark ?? ''}
-                className={styles.input}
-              />
-            </div>
-            <div className={styles.fieldGroup}>
-              <label className={styles.label} htmlFor="brandFavicon">
-                Favicon URL
-              </label>
-              <input
-                id="brandFavicon"
-                name="brandFavicon"
-                type="url"
-                placeholder="https://… or /api/brand/favicon"
-                defaultValue={branding.brandFavicon ?? ''}
-                className={styles.input}
-              />
-            </div>
-            <div className={styles.fieldGroup}>
-              <label className={styles.label} htmlFor="emailFromName">
-                Email sender name
-              </label>
-              <input
-                id="emailFromName"
-                name="emailFromName"
-                type="text"
-                placeholder="Sovereign"
-                defaultValue={branding.emailFromName ?? ''}
-                className={styles.input}
-              />
-            </div>
-            <div className={styles.fieldGroup}>
-              <label className={styles.label} htmlFor="emailLogo">
-                Email logo URL
-              </label>
-              <input
-                id="emailLogo"
-                name="emailLogo"
-                type="url"
-                placeholder="https://…"
-                defaultValue={branding.emailLogo ?? ''}
-                className={styles.input}
-              />
-              <span className={styles.helpText}>
-                Used in outbound email HTML templates. Must be publicly reachable.
-              </span>
-            </div>
-            <button type="submit" className={styles.actionButton}>
-              Save branding
-            </button>
-          </form>
+          <BrandingForm initialValues={branding} />
 
-          {/* Logo file upload (light) */}
-          <form
-            action={uploadLogoAction}
-            className={styles.settingsForm}
-            style={{ marginTop: '16px' }}
-          >
-            <input type="hidden" name="dark" value="0" />
-            <div className={styles.fieldGroup}>
-              <label className={styles.label} htmlFor="logoFile">
-                Upload logo (light theme)
-              </label>
-              <input
-                id="logoFile"
-                name="file"
-                type="file"
-                accept="image/png,image/svg+xml,image/jpeg,image/webp"
-                className={styles.input}
-              />
-              <span className={styles.helpText}>PNG, SVG, JPEG, or WebP · max 2 MB</span>
-            </div>
-            <button type="submit" className={styles.actionButton}>
-              Upload
-            </button>
-          </form>
-
-          {/* Logo file upload (dark) */}
-          <form
-            action={uploadLogoAction}
-            className={styles.settingsForm}
-            style={{ marginTop: '8px' }}
-          >
-            <input type="hidden" name="dark" value="1" />
-            <div className={styles.fieldGroup}>
-              <label className={styles.label} htmlFor="logoDarkFile">
-                Upload logo (dark theme)
-              </label>
-              <input
-                id="logoDarkFile"
-                name="file"
-                type="file"
-                accept="image/png,image/svg+xml,image/jpeg,image/webp"
-                className={styles.input}
-              />
-            </div>
-            <button type="submit" className={styles.actionButton}>
-              Upload
-            </button>
-          </form>
-
-          {/* Favicon file upload */}
-          <form
-            action={uploadFaviconAction}
-            className={styles.settingsForm}
-            style={{ marginTop: '8px' }}
-          >
-            <div className={styles.fieldGroup}>
-              <label className={styles.label} htmlFor="faviconFile">
-                Upload favicon
-              </label>
-              <input
-                id="faviconFile"
-                name="file"
-                type="file"
-                accept="image/png,image/svg+xml,image/x-icon,image/webp"
-                className={styles.input}
-              />
-              <span className={styles.helpText}>PNG, SVG, ICO, or WebP · max 2 MB</span>
-            </div>
-            <button type="submit" className={styles.actionButton}>
-              Upload
-            </button>
-          </form>
+          <LogoUploadForm dark={false} />
+          <LogoUploadForm dark={true} />
+          <FaviconUploadForm />
         </section>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- Console Settings forms (tenant name, invite-only, root plugin, branding, logo/favicon upload) now show inline success (green) or error (red) messages after submit — no more silent saves or unhandled throws
- Account display name form shows the same inline feedback
- Buttons show "Saving…" while the action is in-flight
- Server actions updated to return `ActionResult = { ok: true; message } | { ok: false; error }` and accept the `useActionState` `prevState` param instead of throwing
- Server component pages remain server components for data fetching; client form components receive initial values as props and own the action state
- Console Settings also switches to `PORT`-aware `SELF_URL` and `Promise.allSettled` for data fetches (fault-tolerant if one admin API call fails)
- New `feedbackSuccess` / `feedbackError` CSS classes added to both console and account CSS modules using `--sv-color-success-*` and `--sv-color-error-*` semantic tokens

## Test plan

- [ ] Open Console → Settings, save tenant name — see "Saved." banner
- [ ] Open Console → Settings, save with empty tenant name — see error banner
- [ ] Save branding with invalid hex colour — see validation error inline
- [ ] Upload a logo file — see "Logo (light) uploaded." banner
- [ ] Open Account → Profile, save display name — see "Name saved." banner
- [ ] Account → Profile, submit empty name — see validation error
- [ ] `pnpm lint && pnpm format:check && pnpm typecheck` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)