### PR TITLE
feat(auth): enable login rate limiting in all environments

### DIFF
--- a/apps/auth/src/auth.ts
+++ b/apps/auth/src/auth.ts
@@ -45,6 +45,22 @@ function buildOptions(): BetterAuthOptions {
           text: `You requested a password reset.\n\nReset your password: ${resetUrl}\n\nThis link expires in 1 hour. If you did not request this, ignore this email.`,
         });
       },
+      // Minimum password length (better-auth default is 8, but being explicit
+      // here so it doesn't silently change with a library upgrade).
+      minPasswordLength: 8,
+    },
+    // Brute-force / credential-stuffing protection. better-auth applies
+    // per-path special rules on top of the global rate limit:
+    //   • /sign-in/* and /sign-up/*      → 3 requests per 10 s per IP
+    //   • /request-password-reset / etc  → 3 requests per 60 s per IP
+    // Returns 429 with an X-Retry-After header when exceeded.
+    // Enabled unconditionally so dev behaviour matches production; in dev
+    // better-auth resolves all requests to LOCALHOST_IP, so all browser
+    // sign-in attempts share the same bucket — a minor inconvenience worth the
+    // consistency.
+    rateLimit: {
+      enabled: process.env.NODE_ENV !== 'test',
+      storage: 'memory',
     },
     user: {
       additionalFields: {

--- a/docs/security.md
+++ b/docs/security.md
@@ -89,6 +89,13 @@ Task 1.0.01; zero-knowledge E2EE is charted but out of v1 scope.
   HMAC-verified offline and carries `Secure` in production (`__Secure-` prefix).
 - **Transport:** Postgres connects over TLS when the connection string sets
   `sslmode` (see below); the public edge must terminate TLS with HSTS.
+- **Login rate limiting** is active in all environments (dev + production): the
+  auth server enforces 3 sign-in attempts per 10 seconds per IP address and 3
+  password-reset requests per 60 seconds per IP (via better-auth's built-in
+  per-path rate limiter). Responses above the limit return `429 Too Many Requests`
+  with an `X-Retry-After` header. Rate limiting is stored in-memory per process
+  (sufficient for single-instance deployments); a shared secondary storage (e.g.
+  Redis) would be needed for multi-instance setups.
 
 ## Self-hoster hardening checklist
 


### PR DESCRIPTION
## Summary

- Adds explicit `rateLimit` config to better-auth so brute-force protection is active in dev **and** production (only `NODE_ENV=test` is excluded to prevent flaky tests)
- Sets `minPasswordLength: 8` explicitly so a library upgrade can't silently weaken the requirement
- Documents the rate limiting policy in `docs/security.md`

## How it works

better-auth ships built-in per-path rate limiting. With `rateLimit.enabled: true`, these rules apply on every request:

| Endpoint | Limit | Window |
|---|---|---|
| `/sign-in/*`, `/sign-up/*` | 3 requests | 10 s per IP |
| `/request-password-reset` and similar | 3 requests | 60 s per IP |

Exceeding the limit returns `429 Too Many Requests` with an `X-Retry-After` header. Rate limit state is stored in-memory per process (sufficient for single-instance deployments).

Previously `rateLimit` was absent from the config, causing better-auth to apply its default of `enabled: process.env.NODE_ENV === 'production'` — meaning dev instances had no protection and the behaviour differed from production.

## Test plan

- [ ] Log in with a wrong password 4 times in a row → 4th attempt returns 429 in dev and production
- [ ] `pnpm lint && pnpm typecheck` pass
- [ ] `pnpm test` passes (rate limiting disabled under `NODE_ENV=test`)
- [ ] `docs/security.md` hardening section mentions rate limiting

🤖 Generated with [Claude Code](https://claude.com/claude-code)