### PR TITLE
feat(runtime): dynamic PWA manifest with tenant brand name

### DIFF
--- a/runtime/app/api/manifest/route.ts
+++ b/runtime/app/api/manifest/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from 'next/server';
+import { getPlatformDb } from '@sovereignfs/db';
+import { DEFAULT_TENANT_ID, getTenantBranding } from '@sovereignfs/db';
+
+/**
+ * Dynamic web app manifest — returns the PWA manifest with the tenant's brand
+ * name instead of the hardcoded "Sovereign" default. Excluded from the
+ * middleware session gate (browsers fetch the manifest before the user logs in).
+ * The static public/manifest.json is kept for @ducanh2912/next-pwa build-time
+ * tooling; this route is the authoritative one for browsers.
+ */
+export async function GET(): Promise<Response> {
+  let brandName = process.env.BRAND_NAME ?? 'Sovereign';
+  let description = 'Your self-hosted workspace.';
+
+  try {
+    const pdb = await getPlatformDb();
+    const branding = await getTenantBranding(pdb, DEFAULT_TENANT_ID);
+    if (branding.brandName) {
+      brandName = branding.brandName;
+      description = `${brandName} — your self-hosted workspace.`;
+    }
+  } catch {
+    // Branding is cosmetic — serve a working manifest even on DB failure.
+  }
+
+  const manifest = {
+    name: brandName,
+    short_name: brandName,
+    description,
+    start_url: '/',
+    scope: '/',
+    display: 'standalone',
+    display_override: ['standalone', 'minimal-ui'],
+    background_color: '#09090b',
+    theme_color: '#09090b',
+    orientation: 'any',
+    categories: ['productivity'],
+    icons: [
+      { src: '/icons/icon-192.png', sizes: '192x192', type: 'image/png', purpose: 'any' },
+      { src: '/icons/icon-512.png', sizes: '512x512', type: 'image/png', purpose: 'any' },
+      {
+        src: '/icons/icon-maskable-512.png',
+        sizes: '512x512',
+        type: 'image/png',
+        purpose: 'maskable',
+      },
+    ],
+    shortcuts: [
+      {
+        name: 'Launcher',
+        short_name: 'Apps',
+        description: 'Open the app launcher',
+        url: '/launcher',
+      },
+      {
+        name: 'Account',
+        short_name: 'Account',
+        description: 'Manage your profile and preferences',
+        url: '/account',
+      },
+    ],
+  };
+
+  return NextResponse.json(manifest, {
+    headers: {
+      'Content-Type': 'application/manifest+json',
+      'Cache-Control': 'public, max-age=300, stale-while-revalidate=3600',
+    },
+  });
+}

--- a/runtime/app/layout.tsx
+++ b/runtime/app/layout.tsx
@@ -7,9 +7,10 @@ import { themeScript } from '@/src/theme-script';
 export const metadata: Metadata = {
   title: 'Sovereign',
   description: 'Your self-hosted workspace.',
-  // Installable PWA (SRS §3.11, PLT-09). The web manifest + icons live in
-  // public/; the service worker is generated there at build by next-pwa.
-  manifest: '/manifest.json',
+  // Installable PWA (SRS §3.11, PLT-09). The dynamic manifest route returns
+  // the correct brand name from the DB; the static public/manifest.json is
+  // kept for @ducanh2912/next-pwa build-time tooling only.
+  manifest: '/api/manifest',
   appleWebApp: { capable: true, title: 'Sovereign', statusBarStyle: 'black-translucent' },
   icons: {
     icon: '/icons/icon-192.png',

--- a/runtime/middleware.ts
+++ b/runtime/middleware.ts
@@ -345,8 +345,9 @@ export const config = {
   // bundles, icons — must load without a session), and Next static assets.
   matcher: [
     // Exclude: auth pages, admin API (self-authenticated), public liveness probe,
-    // brand assets (must load on the login page pre-session), offline fallback,
-    // PWA assets, and Next.js static assets.
-    '/((?!login|register|offline|api/admin|api/health|api/brand|manifest.json|sw.js|workbox-|fallback-|icons/|_next/static|_next/image|favicon.ico).*)',
+    // brand assets (must load on the login page pre-session), dynamic manifest
+    // (browsers fetch it before login for PWA install), offline fallback, PWA
+    // assets, and Next.js static assets.
+    '/((?!login|register|offline|api/admin|api/health|api/brand|api/manifest|manifest.json|sw.js|workbox-|fallback-|icons/|_next/static|_next/image|favicon.ico).*)',
   ],
 };

--- a/runtime/src/api-namespace.ts
+++ b/runtime/src/api-namespace.ts
@@ -24,6 +24,7 @@ export const RESERVED_API_SEGMENTS: ReadonlySet<string> = new Set([
   'auth',
   'brand',
   'health',
+  'manifest',
   'plugins',
 ]);
 


### PR DESCRIPTION
## Summary

- Replaces the static `public/manifest.json` link with a dynamic `GET /api/manifest` route
- The route reads the tenant's brand name from `tenant_branding` (set via Console → Settings → Branding) and returns it in the PWA manifest
- Browsers installing as a PWA now show the tenant's brand name rather than the hardcoded "Sovereign"
- Falls back gracefully: `BRAND_NAME` env var → `"Sovereign"` if the DB is unavailable

## Details

- `runtime/app/api/manifest/route.ts` — new dynamic route, Node runtime only, fully public (no session required)
- Excluded from the middleware session gate (browser fetches the manifest before authentication)
- `'manifest'` added to `RESERVED_API_SEGMENTS` — parity test still passes
- `public/manifest.json` kept unchanged for `@ducanh2912/next-pwa` build-time tooling
- Short `Cache-Control: max-age=300, stale-while-revalidate=3600` so the brand name propagates within minutes of a change

## Test plan

- [ ] Set a brand name in Console → Settings → Branding
- [ ] Open DevTools → Application → Manifest and confirm the `name` field matches the brand name
- [ ] `pnpm test` passes (RESERVED_API_SEGMENTS parity test included)
- [ ] `pnpm lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)