### PR TITLE
fix: avatar cursor, launcher sidebar order, session logout

### DIFF
--- a/plugins/account/app/_components/SessionList.tsx
+++ b/plugins/account/app/_components/SessionList.tsx
@@ -1,4 +1,5 @@
 import type { ActiveSession } from '@sovereignfs/sdk';
+import { logoutAction } from '../actions';
 import { deviceHint } from '../_lib/device-hint';
 import { RevokeSessionButton } from './RevokeSessionButton';
 import styles from '../account.module.css';
@@ -28,9 +29,9 @@ export function SessionList({ sessions }: { sessions: ActiveSession[] }) {
           </div>
           {session.current ? (
             // The current session can't be revoked via ACC-06; logging out ends
-            // it instead. Plain form POST to the runtime logout route so it
-            // works without JS (it clears the session-cache cookies + redirects).
-            <form action="/api/account/logout" method="post">
+            // it instead. Server action so the redirect + cookie-clearing works
+            // correctly from both hard-navigation and overlay contexts.
+            <form action={logoutAction}>
               <button type="submit" className={styles.revokeButton}>
                 Log out
               </button>

--- a/plugins/account/app/account.module.css
+++ b/plugins/account/app/account.module.css
@@ -234,6 +234,7 @@
   background-color: transparent;
   color: var(--sv-color-text-muted);
   font-size: var(--sv-font-size-sm);
+  white-space: nowrap;
   cursor: pointer;
 }
 

--- a/plugins/account/app/actions.ts
+++ b/plugins/account/app/actions.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
 import { cookies, headers } from 'next/headers';
 import QRCode from 'qrcode';
 import { sdk } from '@sovereignfs/sdk';
@@ -145,6 +146,21 @@ export async function changePasswordAction(
   }
   void sdk.activity.log({ action: 'account.password_changed', summary: 'Password changed' });
   return { ok: true };
+}
+
+/**
+ * Sign the current user out (ACC-11). Used by the Active sessions Log out
+ * button. Calls better-auth's sign-out, clears the runtime's session-cache
+ * cookies, then redirects to the auth server's login page.
+ */
+export async function logoutAction(): Promise<void> {
+  await sdk.auth.signOut();
+  await invalidateSessionCache();
+  const authPublicUrl =
+    process.env.SOVEREIGN_AUTH_PUBLIC_URL ??
+    process.env.SOVEREIGN_AUTH_URL ??
+    'http://localhost:3001';
+  redirect(`${authPublicUrl}/login?signedout=1`);
 }
 
 /** Revoke another session (ACC-06). The current session can't be revoked here. */

--- a/plugins/account/package.json
+++ b/plugins/account/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sovereignfs/plugin-account",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/runtime/app/(platform)/layout.tsx
+++ b/runtime/app/(platform)/layout.tsx
@@ -38,8 +38,11 @@ export default async function PlatformLayout({ children }: { children: ReactNode
   // Non-chrome plugins for the sidebar middle section and the mobile Drawer.
   const allPlugins = getInstalledPlugins();
   const plugins = allPlugins.filter((plugin) => !CHROME_PLUGIN_IDS.has(plugin.id));
+  // The Launcher is a chrome plugin (hidden from its own tiles) but should
+  // always appear as the first icon in the sidebar so users can return home.
+  const launcher = allPlugins.find((plugin) => plugin.id === 'fs.sovereign.launcher');
 
-  const pluginIcons = plugins.map((plugin) => (
+  const pluginIcons = [...(launcher ? [launcher] : []), ...plugins].map((plugin) => (
     <Link key={plugin.id} href={plugin.routePrefix} className={styles.icon} title={plugin.name}>
       {plugin.icon ? (
         <img

--- a/runtime/app/(platform)/shell.module.css
+++ b/runtime/app/(platform)/shell.module.css
@@ -103,6 +103,7 @@
   font-weight: var(--sv-font-weight-semibold);
   color: var(--sv-color-text-muted);
   text-decoration: none;
+  cursor: pointer;
 }
 
 .avatarImage {

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sovereignfs/runtime",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- **Avatar cursor**: Added `cursor: pointer` to `.avatar` in `shell.module.css`. The class is applied to a `<button>` element, but CSS resets suppress the default pointer cursor browsers give to buttons — this makes it explicit.
- **Launcher as first sidebar icon**: The Launcher plugin was in `CHROME_PLUGIN_IDS` (correct — it shouldn't appear in its own tile grid) but was therefore absent from the sidebar's plugin icon strip. The layout now finds the Launcher in `allPlugins` and prepends it to the icon list so it's always the first icon after the brand mark, giving users a clear home-screen shortcut.
- **Session logout**: Replaced the plain `<form action="/api/account/logout" method="post">` in `SessionList` with a `logoutAction` server action. The server action calls `sdk.auth.signOut()`, clears both `session_data` cookie variants, and `redirect()`s to the auth login page — consistent with how the middleware handles sign-out and robust in both hard-navigation and overlay (dialog) rendering contexts.

## Version bumps

- `runtime`: 0.29.0 → 0.29.1
- `@sovereignfs/plugin-account`: 0.9.0 → 0.9.1

## Test plan

- [ ] Hover the avatar in the sidebar — cursor should be a pointer
- [ ] Open the sidebar — Launcher icon appears first in the plugin section (before other installed plugins)
- [ ] Navigate to Account → Security → Active sessions → click "Log out" — should sign out and redirect to the auth login page

🤖 Generated with [Claude Code](https://claude.com/claude-code)